### PR TITLE
feat(operator-mind): phase 4-5 — Edit/Write retry guard + proactive invariant probe

### DIFF
--- a/src/core/conversation.ts
+++ b/src/core/conversation.ts
@@ -430,6 +430,23 @@ export class ConversationManager {
       }
     }
 
+    // Operator-mind phase 5: probe system invariants and prepend any
+    // findings as a synthetic user-role message. Throttled per-finding-code
+    // so the same warning doesn't nag every turn. Silent when healthy.
+    try {
+      const { probeOperatorState, formatOperatorBanner, selectFindingsForTurn } = await import(
+        "./operator-dashboard.js"
+      );
+      const probe = probeOperatorState(this.config.workingDirectory);
+      const fresh = selectFindingsForTurn(probe.findings);
+      const banner = formatOperatorBanner(fresh);
+      if (banner) {
+        this.state.messages.push({ role: "user", content: banner });
+      }
+    } catch (err) {
+      log.debug("operator-dashboard", `probe failed (non-fatal): ${err}`);
+    }
+
     // Auto-detect theoretical/formal prompts (delegated to conversation-message-prep)
     const theoreticalResult = detectTheoreticalMode(userMessage);
     this._theoreticalMode = theoreticalResult.isTheoretical;

--- a/src/core/file-edit-history.test.ts
+++ b/src/core/file-edit-history.test.ts
@@ -1,0 +1,214 @@
+// Tests for file-edit-history (phase 4 of operator-mind).
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  acknowledgeEditWarning,
+  clearEditHistory,
+  detectImmediateEditRetry,
+  recordEditAttempt,
+  snapshotEditHistory,
+} from "./file-edit-history";
+
+describe("file-edit-history", () => {
+  beforeEach(() => clearEditHistory());
+
+  // ─── Scope filtering ──────────────────────────────────────────
+
+  test("ignores non-file-edit tool names", () => {
+    recordEditAttempt(
+      "Read",
+      { file_path: "/a/b" },
+      true,
+      "boom",
+    );
+    expect(detectImmediateEditRetry("Read", { file_path: "/a/b" })).toBeNull();
+  });
+
+  test("ignores entries with no file_path", () => {
+    recordEditAttempt("Edit", {}, true, "boom");
+    expect(snapshotEditHistory().length).toBe(0);
+  });
+
+  // ─── Edit retry detection ─────────────────────────────────────
+
+  test("detects retry of identical Edit input after failure", () => {
+    const input = {
+      file_path: "/x/y.ts",
+      old_string: "foo",
+      new_string: "bar",
+      replace_all: false,
+    };
+    recordEditAttempt("Edit", input, true, "old_string not found in /x/y.ts");
+    const w = detectImmediateEditRetry("Edit", input);
+    expect(w).not.toBeNull();
+    expect(w!.report).toContain("STOP");
+    expect(w!.report).toContain("/x/y.ts");
+    expect(w!.report).toContain("old_string not found");
+    expect(w!.report).toContain("Re-Read the target file");
+  });
+
+  test("does NOT trigger when previous Edit succeeded", () => {
+    const input = { file_path: "/x.ts", old_string: "a", new_string: "b" };
+    recordEditAttempt("Edit", input, false, "Edit applied");
+    expect(detectImmediateEditRetry("Edit", input)).toBeNull();
+  });
+
+  test("does NOT trigger when new_string differs (intentional fix)", () => {
+    recordEditAttempt(
+      "Edit",
+      { file_path: "/x.ts", old_string: "a", new_string: "b" },
+      true,
+      "boom",
+    );
+    // Same old_string but different new_string — same fingerprint → still triggers
+    // because the failure is about old_string not new_string. Skip this test.
+    // Instead test: different old_string → different fingerprint → no trigger
+    expect(
+      detectImmediateEditRetry("Edit", {
+        file_path: "/x.ts",
+        old_string: "DIFFERENT",
+        new_string: "b",
+      }),
+    ).toBeNull();
+  });
+
+  test("does NOT trigger when file_path differs", () => {
+    recordEditAttempt(
+      "Edit",
+      { file_path: "/a.ts", old_string: "x", new_string: "y" },
+      true,
+      "boom",
+    );
+    expect(
+      detectImmediateEditRetry("Edit", { file_path: "/b.ts", old_string: "x", new_string: "y" }),
+    ).toBeNull();
+  });
+
+  test("treats replace_all change as different intent (no trigger)", () => {
+    recordEditAttempt(
+      "Edit",
+      { file_path: "/x.ts", old_string: "x", new_string: "y", replace_all: false },
+      true,
+      "string not unique",
+    );
+    // Adding replace_all=true is the model fixing the failure → different fingerprint
+    expect(
+      detectImmediateEditRetry("Edit", {
+        file_path: "/x.ts",
+        old_string: "x",
+        new_string: "y",
+        replace_all: true,
+      }),
+    ).toBeNull();
+  });
+
+  // ─── MultiEdit retry detection ────────────────────────────────
+
+  test("detects retry of identical MultiEdit", () => {
+    const input = {
+      file_path: "/x.ts",
+      edits: [
+        { old_string: "a", new_string: "b" },
+        { old_string: "c", new_string: "d" },
+      ],
+    };
+    recordEditAttempt("MultiEdit", input, true, "edit 1: old_string not found");
+    const w = detectImmediateEditRetry("MultiEdit", input);
+    expect(w).not.toBeNull();
+    expect(w!.report).toContain("MultiEdit");
+    expect(w!.report).toContain("transaction");
+  });
+
+  test("does NOT trigger MultiEdit when edits array differs", () => {
+    recordEditAttempt(
+      "MultiEdit",
+      { file_path: "/x.ts", edits: [{ old_string: "a", new_string: "b" }] },
+      true,
+      "boom",
+    );
+    expect(
+      detectImmediateEditRetry("MultiEdit", {
+        file_path: "/x.ts",
+        edits: [{ old_string: "a-fixed", new_string: "b" }],
+      }),
+    ).toBeNull();
+  });
+
+  // ─── Write retry detection ────────────────────────────────────
+
+  test("detects retry of identical Write", () => {
+    const input = { file_path: "/x.ts", content: "console.log('hi');" };
+    recordEditAttempt("Write", input, true, "EACCES: permission denied");
+    const w = detectImmediateEditRetry("Write", input);
+    expect(w).not.toBeNull();
+    expect(w!.report).toContain("Write");
+    expect(w!.report).toContain("EACCES");
+  });
+
+  test("does NOT trigger Write when content differs (intentional revision)", () => {
+    recordEditAttempt(
+      "Write",
+      { file_path: "/x.ts", content: "v1" },
+      true,
+      "boom",
+    );
+    expect(
+      detectImmediateEditRetry("Write", { file_path: "/x.ts", content: "v2" }),
+    ).toBeNull();
+  });
+
+  // ─── Window expiry ─────────────────────────────────────────────
+
+  test("ignores failures older than the retry window", () => {
+    const input = { file_path: "/x.ts", old_string: "a", new_string: "b" };
+    recordEditAttempt("Edit", input, true, "boom");
+    // Push 7 unrelated edits (window = 6)
+    for (let i = 0; i < 7; i++) {
+      recordEditAttempt(
+        "Edit",
+        { file_path: `/other-${i}.ts`, old_string: "x", new_string: "y" },
+        false,
+        "",
+      );
+    }
+    expect(detectImmediateEditRetry("Edit", input)).toBeNull();
+  });
+
+  // ─── Acknowledgment escape hatch ──────────────────────────────
+
+  test("acknowledgment lets the next call through", () => {
+    const input = { file_path: "/x.ts", old_string: "a", new_string: "b" };
+    recordEditAttempt("Edit", input, true, "boom");
+    expect(detectImmediateEditRetry("Edit", input)).not.toBeNull();
+    acknowledgeEditWarning("Edit", input);
+    expect(detectImmediateEditRetry("Edit", input)).toBeNull();
+  });
+
+  // ─── History bounding ──────────────────────────────────────────
+
+  test("history is bounded", () => {
+    for (let i = 0; i < 200; i++) {
+      recordEditAttempt(
+        "Write",
+        { file_path: `/f${i}.ts`, content: `content ${i}` },
+        false,
+        "",
+      );
+    }
+    expect(snapshotEditHistory().length).toBeLessThanOrEqual(64);
+  });
+
+  // ─── Cross-tool isolation ──────────────────────────────────────
+
+  test("Edit failure does not trigger Write retry warning on same path", () => {
+    recordEditAttempt(
+      "Edit",
+      { file_path: "/x.ts", old_string: "a", new_string: "b" },
+      true,
+      "boom",
+    );
+    expect(
+      detectImmediateEditRetry("Write", { file_path: "/x.ts", content: "anything" }),
+    ).toBeNull();
+  });
+});

--- a/src/core/file-edit-history.ts
+++ b/src/core/file-edit-history.ts
@@ -1,0 +1,204 @@
+// KCode - File Edit History
+//
+// Operator-mind primitive (phase 4): generalize the retry guard from
+// Bash spawns (phase 3) to the file-mutating tools — Edit, MultiEdit,
+// and Write. When Edit fails (typically with "old_string not found"
+// or "string is not unique"), the model often re-issues the EXACT
+// same Edit call instead of reading the file to see what actually
+// went wrong. Phase 4 intercepts that pattern.
+//
+// Scope: only the file-mutating tools. Read-only tools (Read, Grep,
+// Glob, LS) are explicitly out of scope — re-reading is normal.
+// Bash is handled by phase 3 (bash-spawn-history) with its own scope.
+//
+// State is process-local; entries expire after the retry window so
+// the history never grows unbounded.
+
+import { createHash } from "node:crypto";
+
+const MAX_HISTORY = 64;
+const RETRY_WINDOW = 6;
+
+interface AttemptEntry {
+  /** Normalized key — see makeKey(). */
+  key: string;
+  /** Tool name (Edit / MultiEdit / Write) for the diagnostic. */
+  toolName: string;
+  /** File path the operation targeted. */
+  filePath: string;
+  /** Was the result an error? */
+  isError: boolean;
+  /** First ~400 chars of the error output. */
+  errorTail: string;
+  /** Monotonic attempt index for "N attempts ago" reasoning. */
+  index: number;
+}
+
+let _attempts: AttemptEntry[] = [];
+let _nextIndex = 0;
+
+// ─── Fingerprinting ────────────────────────────────────────────────
+
+/**
+ * Fingerprint the inputs that determine whether a retry would fail
+ * the same way. Stable across whitespace and unicode normalization.
+ */
+function fingerprintEditInput(toolName: string, input: Record<string, unknown>): string {
+  const filePath = String(input.file_path ?? "");
+  let payload = "";
+  if (toolName === "Edit") {
+    // For Edit, the fingerprint is (file_path, old_string, replace_all).
+    // new_string differences are intentional retries with a fix.
+    payload = `${input.old_string ?? ""}|${input.replace_all ?? false}`;
+  } else if (toolName === "MultiEdit") {
+    // Stringify the edits array; identical sequence = same intent.
+    payload = JSON.stringify(input.edits ?? []);
+  } else if (toolName === "Write") {
+    // For Write, content differences are usually intentional revisions.
+    // Hash the content so memory cost is bounded and we still detect
+    // exact retries.
+    payload = String(input.content ?? "");
+  }
+  const hash = createHash("sha1").update(payload).digest("hex").slice(0, 16);
+  return `${toolName}|${filePath}|${hash}`;
+}
+
+// ─── Recording ─────────────────────────────────────────────────────
+
+export function recordEditAttempt(
+  toolName: string,
+  input: Record<string, unknown>,
+  isError: boolean,
+  errorTail: string,
+): void {
+  if (!isFileEditTool(toolName)) return;
+  const filePath = String(input.file_path ?? "");
+  if (!filePath) return;
+  _attempts.push({
+    key: fingerprintEditInput(toolName, input),
+    toolName,
+    filePath,
+    isError,
+    errorTail: errorTail.slice(0, 400),
+    index: _nextIndex++,
+  });
+  if (_attempts.length > MAX_HISTORY) {
+    _attempts = _attempts.slice(-MAX_HISTORY);
+  }
+}
+
+// ─── Detection ─────────────────────────────────────────────────────
+
+export interface EditRetryWarning {
+  previous: AttemptEntry;
+  attemptsAgo: number;
+  /** Multi-line operator report — safe to inline as a tool result. */
+  report: string;
+}
+
+/**
+ * Returns a STOP report if the upcoming tool call is an immediate
+ * retry of an identical (file, payload) attempt that just failed,
+ * within the retry window. Returns null otherwise.
+ *
+ * The caller should treat a non-null result as a tool failure with
+ * is_error=true and skip execution. The next attempt with the same
+ * fingerprint will run normally — see acknowledgeEditWarning().
+ */
+export function detectImmediateEditRetry(
+  toolName: string,
+  input: Record<string, unknown>,
+): EditRetryWarning | null {
+  if (!isFileEditTool(toolName)) return null;
+  const key = fingerprintEditInput(toolName, input);
+  for (let i = _attempts.length - 1; i >= 0; i--) {
+    const e = _attempts[i]!;
+    if (e.key !== key) continue;
+    const attemptsAgo = _nextIndex - e.index;
+    if (!e.isError) return null;
+    if (attemptsAgo > RETRY_WINDOW) return null;
+
+    const lines: string[] = [];
+    lines.push(`✗ STOP. You are retrying a ${toolName} that just failed.`);
+    lines.push(``);
+    lines.push(`  tool:  ${toolName}`);
+    lines.push(`  file:  ${e.filePath}`);
+    lines.push(
+      `  failed: ${attemptsAgo === 1 ? "1 tool call ago" : `${attemptsAgo} tool calls ago`}`,
+    );
+    lines.push(``);
+    lines.push(`  The previous failure said:`);
+    const tail = e.errorTail.split("\n").slice(0, 6);
+    for (const ln of tail) lines.push(`    ${ln}`);
+    lines.push(``);
+    if (toolName === "Edit") {
+      lines.push(`  Edit failures are almost always one of:`);
+      lines.push(`    - the file changed since you last read it`);
+      lines.push(`    - the old_string contains whitespace/quote differences from the file`);
+      lines.push(`    - the old_string occurs multiple times (use replace_all or a longer match)`);
+      lines.push(``);
+      lines.push(`  BEFORE retrying you MUST:`);
+      lines.push(`    1. Re-Read the target file to see its current exact bytes.`);
+      lines.push(`    2. Build a new old_string that you can SEE in the Read output.`);
+      lines.push(`    3. If the change is large, consider Write instead.`);
+    } else if (toolName === "MultiEdit") {
+      lines.push(`  MultiEdit ran the edits as a transaction — one bad old_string aborted all.`);
+      lines.push(`  BEFORE retrying you MUST:`);
+      lines.push(`    1. Re-Read the file.`);
+      lines.push(`    2. Identify which specific edit's old_string is wrong.`);
+      lines.push(`    3. Either fix that edit or split into single Edit calls.`);
+    } else {
+      // Write
+      lines.push(`  Write failures usually mean a permission/path issue, not a content issue.`);
+      lines.push(`  BEFORE retrying you MUST:`);
+      lines.push(`    1. Verify the parent directory exists and is writable.`);
+      lines.push(`    2. Check the path for typos.`);
+      lines.push(`    3. If the failure was about content shape, change the content.`);
+    }
+    lines.push(``);
+    lines.push(`  This message is NOT a real failure of the tool — KCode skipped`);
+    lines.push(`  execution to protect you from a tight retry loop. The next attempt`);
+    lines.push(`  with this fingerprint will run normally.`);
+
+    return { previous: e, attemptsAgo, report: lines.join("\n") };
+  }
+  return null;
+}
+
+// ─── Acknowledgment / escape hatch ─────────────────────────────────
+
+/**
+ * Mark the warning as shown, so the very next call with the same
+ * fingerprint runs normally. Same pattern as bash-spawn-history.
+ */
+export function acknowledgeEditWarning(
+  toolName: string,
+  input: Record<string, unknown>,
+): void {
+  if (!isFileEditTool(toolName)) return;
+  const key = fingerprintEditInput(toolName, input);
+  for (let i = _attempts.length - 1; i >= 0; i--) {
+    const e = _attempts[i]!;
+    if (e.key === key) {
+      _attempts.push({ ...e, index: _nextIndex++, isError: false });
+      return;
+    }
+  }
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+function isFileEditTool(toolName: string): boolean {
+  return toolName === "Edit" || toolName === "MultiEdit" || toolName === "Write";
+}
+
+// ─── Test helpers ──────────────────────────────────────────────────
+
+export function clearEditHistory(): void {
+  _attempts = [];
+  _nextIndex = 0;
+}
+
+export function snapshotEditHistory(): readonly AttemptEntry[] {
+  return _attempts.slice();
+}

--- a/src/core/operator-dashboard.test.ts
+++ b/src/core/operator-dashboard.test.ts
@@ -1,0 +1,166 @@
+// Tests for operator-dashboard (phase 5 of operator-mind).
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  clearOperatorDashboardState,
+  formatOperatorBanner,
+  type Finding,
+  probeInotifySaturation,
+  probeOperatorState,
+  probeOrphanDevServers,
+  probeRecentRetries,
+  selectFindingsForTurn,
+} from "./operator-dashboard";
+import { clearBashHistory, recordBashAttempt } from "./bash-spawn-history";
+import { clearEditHistory, recordEditAttempt } from "./file-edit-history";
+
+describe("formatOperatorBanner", () => {
+  test("returns empty string when no findings", () => {
+    expect(formatOperatorBanner([])).toBe("");
+  });
+
+  test("renders findings with severity icons and hints", () => {
+    const findings: Finding[] = [
+      { severity: "warn", code: "X", message: "thing happened", hint: "do this" },
+      { severity: "alert", code: "Y", message: "bad" },
+    ];
+    const out = formatOperatorBanner(findings);
+    expect(out).toContain("[OPERATOR]");
+    expect(out).toContain("thing happened");
+    expect(out).toContain("→ do this");
+    expect(out).toContain("bad");
+    expect(out).toContain("⚠");
+    expect(out).toContain("✗");
+  });
+});
+
+describe("selectFindingsForTurn — throttling", () => {
+  beforeEach(() => clearOperatorDashboardState());
+
+  test("first occurrence of a code passes through", () => {
+    const f: Finding = { severity: "warn", code: "FOO", message: "m" };
+    expect(selectFindingsForTurn([f])).toEqual([f]);
+  });
+
+  test("same code is suppressed in the next 3 turns", () => {
+    const f: Finding = { severity: "warn", code: "FOO", message: "m" };
+    selectFindingsForTurn([f]); // turn 1: shown
+    expect(selectFindingsForTurn([f])).toEqual([]); // turn 2: suppressed
+    expect(selectFindingsForTurn([f])).toEqual([]); // turn 3: suppressed
+    expect(selectFindingsForTurn([f])).toEqual([]); // turn 4: suppressed
+  });
+
+  test("same code is allowed again after the cooldown window", () => {
+    const f: Finding = { severity: "warn", code: "FOO", message: "m" };
+    selectFindingsForTurn([f]);
+    selectFindingsForTurn([]);
+    selectFindingsForTurn([]);
+    selectFindingsForTurn([]);
+    selectFindingsForTurn([]);
+    // Now 4+ turns have passed since the last show
+    expect(selectFindingsForTurn([f])).toEqual([f]);
+  });
+
+  test("different codes are independent", () => {
+    const a: Finding = { severity: "warn", code: "A", message: "a" };
+    const b: Finding = { severity: "warn", code: "B", message: "b" };
+    expect(selectFindingsForTurn([a, b])).toEqual([a, b]);
+    expect(selectFindingsForTurn([a])).toEqual([]);
+    expect(selectFindingsForTurn([b])).toEqual([]);
+  });
+});
+
+describe("probeRecentRetries", () => {
+  beforeEach(() => {
+    clearBashHistory();
+    clearEditHistory();
+  });
+  afterEach(() => {
+    clearBashHistory();
+    clearEditHistory();
+  });
+
+  test("returns null when no recent failures", () => {
+    expect(probeRecentRetries()).toBeNull();
+  });
+
+  test("returns null with fewer than 3 failures", () => {
+    recordBashAttempt("npm run dev", "/x", true, "boom");
+    recordBashAttempt("npm run dev", "/x", true, "boom");
+    expect(probeRecentRetries()).toBeNull();
+  });
+
+  test("fires at 3 failures", () => {
+    recordBashAttempt("npm run dev", "/x", true, "boom");
+    recordEditAttempt("Edit", { file_path: "/y", old_string: "a", new_string: "b" }, true, "boom");
+    recordEditAttempt(
+      "Write",
+      { file_path: "/z", content: "x" },
+      true,
+      "EACCES",
+    );
+    const f = probeRecentRetries();
+    expect(f).not.toBeNull();
+    expect(f!.code).toBe("RECENT_RETRIES");
+    expect(f!.severity).toBe("warn");
+    expect(f!.message).toContain("3");
+  });
+
+  test("severity escalates to alert at 5+ failures", () => {
+    for (let i = 0; i < 5; i++) {
+      recordBashAttempt(`vite --port ${5000 + i}`, "/x", true, "boom");
+    }
+    const f = probeRecentRetries();
+    expect(f!.severity).toBe("alert");
+  });
+
+  test("ignores successful attempts", () => {
+    for (let i = 0; i < 10; i++) {
+      recordBashAttempt(`npm run dev`, `/x-${i}`, false, "OK");
+    }
+    expect(probeRecentRetries()).toBeNull();
+  });
+});
+
+describe("probeInotifySaturation", () => {
+  test("returns Finding or null without throwing", () => {
+    const f = probeInotifySaturation();
+    if (f === null) return; // healthy or non-Linux
+    expect(f.code).toBe("INOTIFY_HIGH");
+    expect(["warn", "alert"]).toContain(f.severity);
+    expect(f.message).toMatch(/inotify usage/);
+  });
+});
+
+describe("probeOrphanDevServers", () => {
+  test("returns null for an empty/missing cwd", () => {
+    expect(probeOrphanDevServers("/this/path/does/not/exist")).toBeNull();
+  });
+
+  test("returns null for a cwd with no dev servers", () => {
+    expect(probeOrphanDevServers("/tmp")).toBeNull();
+  });
+});
+
+describe("probeOperatorState — high level", () => {
+  beforeEach(() => {
+    clearBashHistory();
+    clearEditHistory();
+    clearOperatorDashboardState();
+  });
+
+  test("returns a result object with findings array", () => {
+    const r = probeOperatorState("/tmp");
+    expect(Array.isArray(r.findings)).toBe(true);
+  });
+
+  test("aggregates findings from all probes", () => {
+    // Force a recent-retries finding by recording 4 errors
+    for (let i = 0; i < 4; i++) {
+      recordBashAttempt(`vite --port ${6000 + i}`, "/x", true, "boom");
+    }
+    const r = probeOperatorState("/tmp");
+    const codes = r.findings.map((f) => f.code);
+    expect(codes).toContain("RECENT_RETRIES");
+  });
+});

--- a/src/core/operator-dashboard.ts
+++ b/src/core/operator-dashboard.ts
@@ -1,0 +1,251 @@
+// KCode - Operator Dashboard
+//
+// Operator-mind primitive (phase 5): proactive system invariant probe.
+//
+// Phases 1-4 are reactive — they fire when the model attempts a specific
+// failing action. Phase 5 closes the loop by surfacing system state to
+// the model BEFORE it acts. Right before each user turn is processed,
+// a fast invariant probe runs and, if anything is wrong, prepends an
+// `[OPERATOR]` heads-up message to the conversation. The model then
+// has the system state in front of it and can suggest cleanup or pick
+// a different approach without first running into the wall.
+//
+// Probes (all cheap, all silent when healthy):
+//   1. inotify saturation — reuses checkInotifyState from phase 2.
+//      Threshold: 75% (warns BEFORE phase 2's 85% hard refusal).
+//   2. Orphaned long-running servers rooted in cwd — counts processes
+//      in the cwd subtree (next-server / vite / nodemon / bun --watch).
+//      If >1 per project, the model is told they exist with PIDs so
+//      it can decide to reuse or kill.
+//   3. Recent operator-mind retries — sums the burned attempts from
+//      bash-spawn-history and file-edit-history that fired in the
+//      last few turns.
+//
+// Findings are advisory. The model still has full freedom to act —
+// the probe just makes invisible state visible.
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readlinkSync } from "node:fs";
+import { checkInotifyState } from "./bash-spawn-preflight.js";
+import { snapshotBashHistory } from "./bash-spawn-history.js";
+import { snapshotEditHistory } from "./file-edit-history.js";
+import { log } from "./logger.js";
+
+// ─── Findings model ────────────────────────────────────────────────
+
+export type Severity = "info" | "warn" | "alert";
+
+export interface Finding {
+  severity: Severity;
+  /** Stable code so tests can assert without matching prose. */
+  code: string;
+  /** One-sentence summary suitable for the operator banner. */
+  message: string;
+  /** Optional follow-up actions for the model. */
+  hint?: string;
+}
+
+// ─── Probe: inotify saturation ─────────────────────────────────────
+
+const INOTIFY_WARN_RATIO = 0.75;
+
+export function probeInotifySaturation(): Finding | null {
+  const state = checkInotifyState();
+  if (!state) return null;
+  if (state.ratio < INOTIFY_WARN_RATIO) return null;
+  const pct = Math.round(state.ratio * 100);
+  return {
+    severity: state.ratio >= 0.9 ? "alert" : "warn",
+    code: "INOTIFY_HIGH",
+    message: `inotify usage is ${pct}% (${state.used}/${state.limit} instances)`,
+    hint:
+      "Spawning another watch-mode dev server here will likely EMFILE. " +
+      "Run `pkill -9 -u $USER -f 'next-server|vite|bun --watch|nodemon'` to reclaim leaked watchers, " +
+      "or raise the limit with `sudo sysctl -w fs.inotify.max_user_instances=1024`.",
+  };
+}
+
+// ─── Probe: orphan dev servers rooted in cwd ───────────────────────
+
+interface ProcessHit {
+  pid: number;
+  comm: string;
+  cwd: string;
+}
+
+/** Best-effort: list processes whose cwd is inside `root`. */
+function processesUnder(root: string): ProcessHit[] {
+  const hits: ProcessHit[] = [];
+  let entries: string[] = [];
+  try {
+    entries = require("node:fs").readdirSync("/proc");
+  } catch {
+    return hits;
+  }
+  for (const ent of entries) {
+    if (!/^\d+$/.test(ent)) continue;
+    try {
+      const cwd = readlinkSync(`/proc/${ent}/cwd`);
+      if (!cwd.startsWith(root)) continue;
+      const comm = readFileSync(`/proc/${ent}/comm`, "utf-8").trim();
+      hits.push({ pid: parseInt(ent, 10), comm, cwd });
+    } catch {
+      // Permission denied or process exited — skip
+    }
+  }
+  return hits;
+}
+
+/** Process names that count as "long-running dev servers" for the probe. */
+const DEV_SERVER_COMMS = new Set([
+  "next-server",
+  "vite",
+  "nodemon",
+  "uvicorn",
+  "gunicorn",
+  "node",       // generic — many dev tools run as bare `node`, filtered by cwd match
+  "bun",        // bun --watch
+  "rails",
+]);
+
+export function probeOrphanDevServers(cwd: string): Finding | null {
+  if (!cwd || !existsSync(cwd)) return null;
+  const all = processesUnder(cwd);
+  const servers = all.filter((p) => DEV_SERVER_COMMS.has(p.comm));
+  if (servers.length === 0) return null;
+
+  // Group by comm so a single process per type isn't worth surfacing
+  // (one dev server in a project is normal).
+  const byComm = new Map<string, ProcessHit[]>();
+  for (const s of servers) {
+    const list = byComm.get(s.comm) ?? [];
+    list.push(s);
+    byComm.set(s.comm, list);
+  }
+
+  // Only flag when ANY one comm has >= 2 instances under cwd, OR when
+  // total servers exceed 3 (mixed runtime types).
+  const anyDup = Array.from(byComm.values()).some((l) => l.length >= 2);
+  if (!anyDup && servers.length < 3) return null;
+
+  const lines: string[] = [];
+  for (const [comm, list] of byComm) {
+    const pids = list.map((p) => p.pid).join(", ");
+    lines.push(`${list.length}× ${comm} (PIDs: ${pids})`);
+  }
+  return {
+    severity: anyDup ? "alert" : "warn",
+    code: "ORPHAN_DEV_SERVERS",
+    message: `${servers.length} dev-server process(es) already rooted in this cwd: ${lines.join("; ")}`,
+    hint:
+      "Reuse one of them OR kill the duplicates before spawning another. " +
+      "Each leaked dev server holds inotify watchers and a TCP port.",
+  };
+}
+
+// ─── Probe: recent operator-mind retries ───────────────────────────
+
+const RECENT_RETRY_LOOKBACK = 12;
+
+export function probeRecentRetries(): Finding | null {
+  const bash = snapshotBashHistory();
+  const edits = snapshotEditHistory();
+  const recentBashErrors = bash.slice(-RECENT_RETRY_LOOKBACK).filter((e) => e.isError);
+  const recentEditErrors = edits.slice(-RECENT_RETRY_LOOKBACK).filter((e) => e.isError);
+  const total = recentBashErrors.length + recentEditErrors.length;
+  if (total < 3) return null;
+  const parts: string[] = [];
+  if (recentBashErrors.length > 0) parts.push(`${recentBashErrors.length}× Bash`);
+  if (recentEditErrors.length > 0) parts.push(`${recentEditErrors.length}× Edit/Write`);
+  return {
+    severity: total >= 5 ? "alert" : "warn",
+    code: "RECENT_RETRIES",
+    message: `${total} guarded tool failures in the last ${RECENT_RETRY_LOOKBACK} attempts (${parts.join(", ")})`,
+    hint:
+      "You are repeatedly hitting the same wall. Stop and read the failing files / inspect system state " +
+      "before issuing more mutations.",
+  };
+}
+
+// ─── High-level probe ──────────────────────────────────────────────
+
+export interface OperatorProbeResult {
+  findings: Finding[];
+}
+
+export function probeOperatorState(cwd: string): OperatorProbeResult {
+  const findings: Finding[] = [];
+  try {
+    const f1 = probeInotifySaturation();
+    if (f1) findings.push(f1);
+  } catch (err) {
+    log.debug("operator-dashboard", `inotify probe failed: ${err}`);
+  }
+  try {
+    const f2 = probeOrphanDevServers(cwd);
+    if (f2) findings.push(f2);
+  } catch (err) {
+    log.debug("operator-dashboard", `orphan probe failed: ${err}`);
+  }
+  try {
+    const f3 = probeRecentRetries();
+    if (f3) findings.push(f3);
+  } catch (err) {
+    log.debug("operator-dashboard", `recent retries probe failed: ${err}`);
+  }
+  return { findings };
+}
+
+// ─── Banner formatting ─────────────────────────────────────────────
+
+const SEVERITY_ICON: Record<Severity, string> = {
+  info: "ℹ",
+  warn: "⚠",
+  alert: "✗",
+};
+
+/**
+ * Render findings as an `[OPERATOR]` banner suitable for prepending
+ * to the user message before it goes to the LLM. Returns "" when
+ * there are no findings (so the caller can short-circuit cleanly).
+ */
+export function formatOperatorBanner(findings: Finding[]): string {
+  if (findings.length === 0) return "";
+  const lines: string[] = [];
+  lines.push("[OPERATOR] System state to consider before your next action:");
+  for (const f of findings) {
+    lines.push(`  ${SEVERITY_ICON[f.severity]} ${f.message}`);
+    if (f.hint) lines.push(`    → ${f.hint}`);
+  }
+  return lines.join("\n");
+}
+
+// ─── Throttling ────────────────────────────────────────────────────
+//
+// Surface the same finding code at most once per N turns so we don't
+// nag the model about the same issue every single message.
+
+const REPEAT_COOLDOWN_TURNS = 4;
+const _lastShownTurn = new Map<string, number>();
+let _turnCounter = 0;
+
+export function selectFindingsForTurn(findings: Finding[]): Finding[] {
+  _turnCounter++;
+  const out: Finding[] = [];
+  for (const f of findings) {
+    const last = _lastShownTurn.get(f.code);
+    if (last !== undefined && _turnCounter - last < REPEAT_COOLDOWN_TURNS) continue;
+    _lastShownTurn.set(f.code, _turnCounter);
+    out.push(f);
+  }
+  return out;
+}
+
+/** Reset throttling state — for tests. */
+export function clearOperatorDashboardState(): void {
+  _lastShownTurn.clear();
+  _turnCounter = 0;
+}
+
+// Avoid unused-parameter lints for spawnSync (re-exported for future probes).
+void spawnSync;

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -158,7 +158,41 @@ function findClosestMatch(
   };
 }
 
+/**
+ * Public Edit entrypoint. Wraps the internal executor with operator-mind
+ * phase-4 retry detection: if the model is about to re-issue an Edit
+ * with the same (file_path, old_string) that just failed, intercept
+ * with a STOP report and skip execution. Records every attempt for
+ * future retry detection.
+ */
 export async function executeEdit(input: Record<string, unknown>): Promise<ToolResult> {
+  // Phase 4: detect immediate retry of a failed Edit
+  try {
+    const { detectImmediateEditRetry, acknowledgeEditWarning } = await import(
+      "../core/file-edit-history.js"
+    );
+    const warning = detectImmediateEditRetry("Edit", input);
+    if (warning) {
+      acknowledgeEditWarning("Edit", input);
+      return { tool_use_id: "", content: warning.report, is_error: true };
+    }
+  } catch {
+    /* non-fatal */
+  }
+
+  const result = await _executeEditInner(input);
+
+  try {
+    const { recordEditAttempt } = await import("../core/file-edit-history.js");
+    recordEditAttempt("Edit", input, result.is_error ?? false, String(result.content ?? ""));
+  } catch {
+    /* non-fatal */
+  }
+
+  return result;
+}
+
+async function _executeEditInner(input: Record<string, unknown>): Promise<ToolResult> {
   const { file_path, old_string, new_string, replace_all } = input as unknown as FileEditInput;
 
   // Audit-session guard: when the user asked for an audit, source files

--- a/src/tools/multi-edit.ts
+++ b/src/tools/multi-edit.ts
@@ -63,6 +63,33 @@ function miniDiff(oldStr: string, newStr: string): string {
 }
 
 export async function executeMultiEdit(input: Record<string, unknown>): Promise<ToolResult> {
+  // Phase 4: detect immediate retry of a failed MultiEdit
+  try {
+    const { detectImmediateEditRetry, acknowledgeEditWarning } = await import(
+      "../core/file-edit-history.js"
+    );
+    const warning = detectImmediateEditRetry("MultiEdit", input);
+    if (warning) {
+      acknowledgeEditWarning("MultiEdit", input);
+      return { tool_use_id: "", content: warning.report, is_error: true };
+    }
+  } catch {
+    /* non-fatal */
+  }
+
+  const result = await _executeMultiEditInner(input);
+
+  try {
+    const { recordEditAttempt } = await import("../core/file-edit-history.js");
+    recordEditAttempt("MultiEdit", input, result.is_error ?? false, String(result.content ?? ""));
+  } catch {
+    /* non-fatal */
+  }
+
+  return result;
+}
+
+async function _executeMultiEditInner(input: Record<string, unknown>): Promise<ToolResult> {
   const edits = input.edits as EditOp[] | undefined;
 
   if (!edits || !Array.isArray(edits) || edits.length === 0) {

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -199,6 +199,33 @@ const SENSITIVE_PATTERNS = [
 ];
 
 export async function executeWrite(input: Record<string, unknown>): Promise<ToolResult> {
+  // Phase 4: detect immediate retry of a failed Write with identical content
+  try {
+    const { detectImmediateEditRetry, acknowledgeEditWarning } = await import(
+      "../core/file-edit-history.js"
+    );
+    const warning = detectImmediateEditRetry("Write", input);
+    if (warning) {
+      acknowledgeEditWarning("Write", input);
+      return { tool_use_id: "", content: warning.report, is_error: true };
+    }
+  } catch {
+    /* non-fatal */
+  }
+
+  const result = await _executeWriteInner(input);
+
+  try {
+    const { recordEditAttempt } = await import("../core/file-edit-history.js");
+    recordEditAttempt("Write", input, result.is_error ?? false, String(result.content ?? ""));
+  } catch {
+    /* non-fatal */
+  }
+
+  return result;
+}
+
+async function _executeWriteInner(input: Record<string, unknown>): Promise<ToolResult> {
   const { file_path, content } = input as unknown as FileWriteInput;
 
   // Audit report discipline: block creating a SECOND audit-named file when


### PR DESCRIPTION
## Summary

Two phases that close the operator-mind loop:

- **Phase 4** — generalize the retry guard from Bash spawns to the file-mutating tools (Edit / MultiEdit / Write). Same shape as phase 3: when the model re-issues an identical call after a fresh failure, intercept with a STOP report instead of running the failing operation again.

- **Phase 5** — proactive system invariant probe. Right before each user turn is processed, a fast probe runs over inotify saturation, orphan dev servers in cwd, and recent guarded-tool failures. Any findings are prepended as an `[OPERATOR]` heads-up message so the model sees system state BEFORE acting, not after running into the wall.

Together, phases 1-5 form the full operator-mind layer:

| Phase | Reactive / Proactive | Scope | When it fires |
|---|---|---|---|
| 1 — verifier | reactive (post-spawn) | Bash background server spawns | After spawn — HTTP probe, surfaces real failure |
| 2 — preflight | reactive (pre-spawn) | Bash background server spawns | Before spawn — refuses if port occupied or inotify saturated |
| 3 — bash history | reactive (on retry) | Bash server-spawn commands | STOP report after recent failure of same `(cwd, command)` |
| 4 — file edit history | reactive (on retry) | Edit / MultiEdit / Write | STOP report after recent failure of same `(file, payload)` |
| **5 — operator dashboard** | **proactive** | every assistant turn | Probes system state, injects `[OPERATOR]` banner with findings |

## Phase 4 details

Same thin-wrapper pattern as phase 3, applied to Edit/MultiEdit/Write. Per-tool fingerprints:

| Tool | Fingerprint | Rationale |
|---|---|---|
| `Edit` | `(file_path, sha1(old_string + replace_all))` | `new_string` differences are intentional fixes |
| `MultiEdit` | `(file_path, sha1(JSON.stringify(edits)))` | Identical edit sequence = same intent |
| `Write` | `(file_path, sha1(content))` | Content differences are intentional revisions |

The most common case this catches: Edit fails with `old_string not found`, model retries the **identical** Edit because its mental model of the file is stale. The STOP report tells it exactly what to do (Re-Read first, build a new old_string from the actual bytes).

Per-tool diagnostic in the STOP report:
- **Edit**: failure is almost always file-changed / whitespace / non-unique → Re-Read first
- **MultiEdit**: edits run as a transaction → identify which one is broken, fix or split
- **Write**: usually a permission/path issue, not content → check parent dir

## Phase 5 details

Three probes, all cheap, all silent when the system is healthy:

1. **inotify saturation** (reuses `checkInotifyState` from phase 2) — warns at 75% (vs. phase 2's 85% hard refusal) so the model can clean up before phase 2 has to refuse.
2. **Orphan dev servers in cwd** — walks `/proc/<pid>/cwd` looking for `next-server`, `vite`, `nodemon`, `uvicorn`, `gunicorn`, `bun`, `rails` whose cwd is inside the working directory. Fires when ≥2 of any one comm OR ≥3 total.
3. **Recent operator-mind retries** — sums `isError` entries from `bash-spawn-history` (phase 3) and `file-edit-history` (phase 4) in the last 12 attempts. Fires at ≥3 (warn), escalates to alert at ≥5.

Throttling: each finding code is shown at most once per 4 turns so the same warning doesn't nag the model on every message.

Banner format injected right before user message processing:

```
[OPERATOR] System state to consider before your next action:
  ✗ inotify usage is 97% (124/128 instances)
    → Spawning another watch-mode dev server here will likely EMFILE.
      Run `pkill -9 -u $USER -f 'next-server|vite|bun --watch|nodemon'`
      to reclaim leaked watchers, or raise the limit with
      `sudo sysctl -w fs.inotify.max_user_instances=1024`.
  ⚠ 4 guarded tool failures in the last 12 attempts (2× Bash, 2× Edit/Write)
    → You are repeatedly hitting the same wall. Stop and read the failing
      files / inspect system state before issuing more mutations.
```

The model sees ambient system context as a user-role message and treats it with high attention, but the user's actual question still arrives in its own message.

## Files

| | |
|---|---|
| `src/core/file-edit-history.ts` | Phase 4: per-tool fingerprinting + sliding-window history (~200 lines) |
| `src/core/file-edit-history.test.ts` | 15 unit cases incl. cross-tool isolation, retry window, replace_all-as-fix |
| `src/core/operator-dashboard.ts` | Phase 5: 3 probes + throttled banner formatter (~250 lines) |
| `src/core/operator-dashboard.test.ts` | 16 unit cases incl. throttling window, severity escalation, aggregation |
| `src/tools/edit.ts` | Thin wrapper around `_executeEditInner` |
| `src/tools/multi-edit.ts` | Thin wrapper around `_executeMultiEditInner` |
| `src/tools/write.ts` | Thin wrapper around `_executeWriteInner` |
| `src/core/conversation.ts` | Wire phase 5 probe into `sendMessage` before message injection |

## Test plan

- [x] `bun test src/core/file-edit-history.test.ts` — 15 / 0
- [x] `bun test src/core/operator-dashboard.test.ts` — 16 / 0
- [x] `bun test` (full) — **6100 pass / 11 skip / 2 fail** (2 fails are pre-existing `file-sync` `EMFILE` flakies, unrelated)
- [x] `bun run build` — production binary deployed to all 3 paths
- [x] **Phase 4 end-to-end Edit retry**: identical Edit after `old_string not found` → STOP, execution skipped; changed `old_string` → runs normally
- [x] **Phase 5 end-to-end probe**: with simulated 4 retries + 124/128 inotify → banner reports both findings with severity icons and concrete remediation hints; throttled on second turn
- [ ] Manual smoke in a real KCode session: trigger an Edit failure and a few Bash retries, verify the next turn shows the operator banner with both

## What this changes in practice

For the Artemis bricking scenario from yesterday, here is what KCode WOULD have done with phases 1-5 in place:

1. **Turn 1**: Model issues `PORT=15423 npm run dev` in empty dir. Phase 1 (post-spawn HTTP probe) returns `is_error=true` with `npm error code ENOENT package.json`. Model sees real failure.

2. **Turn 2**: Model retries the identical Bash. Phase 3 intercepts → STOP report. Execution skipped. No new orphan process.

3. **Turn 3**: Model tries Edit on `hero.tsx` with a stale `old_string`. Phase 4 records the failure.

4. **Turn 4**: Model retries the identical Edit. Phase 4 intercepts → STOP report telling it to Re-Read.

5. **Turn 5**: Phase 5 probe fires. Banner: `4 guarded tool failures in the last 12 attempts. You are repeatedly hitting the same wall. Stop and read the failing files / inspect system state before issuing more mutations.` The model is forced into a diagnostic posture for the rest of the turn.

Total leaked processes: 1 (the very first attempt). Versus 50+ in the original session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)