### PR TITLE
feat(operator-mind): phase 10 — smart port-collision resolution + v2.10.45

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.44",
+  "version": "2.10.45",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/bash-spawn-preflight.test.ts
+++ b/src/core/bash-spawn-preflight.test.ts
@@ -83,7 +83,14 @@ describe("runSpawnPreflight", () => {
 
   test("port refusal includes AUTHORIZED RECOVERY block (phase 6)", () => {
     server = Bun.serve({ port: 0, fetch: () => new Response("hi") });
-    const r = runSpawnPreflight(`next dev --port ${server.port}`, process.cwd());
+    // Phase 10: pass a fake cwd that does NOT match the test process's
+    // real cwd, so the smart resolver picks the different-project
+    // branch (which is the one with the "WITHOUT asking the user"
+    // language and the ALTERNATIVE clause).
+    const r = runSpawnPreflight(
+      `next dev --port ${server.port}`,
+      "/tmp/some-other-project-9f3e2",
+    );
     expect(r!.report).toContain("AUTHORIZED RECOVERY");
     expect(r!.report).toContain("WITHOUT asking the user");
     expect(r!.report).toMatch(/Step 1[\s\S]*kill/);

--- a/src/core/bash-spawn-preflight.ts
+++ b/src/core/bash-spawn-preflight.ts
@@ -17,9 +17,39 @@
 // `ls` are unaffected).
 
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, readlinkSync } from "node:fs";
 import { detectServerSpawn, extractDeclaredPort } from "./bash-spawn-verifier.js";
 import { log } from "./logger.js";
+
+// ─── Phase 10: process cwd lookup for smart port-collision resolution
+
+/**
+ * Look up a process's working directory via /proc/<pid>/cwd.
+ * Returns null on permission denied / dead process / non-Linux.
+ */
+export function getProcessCwd(pid: number): string | null {
+  if (pid <= 0) return null;
+  try {
+    return readlinkSync(`/proc/${pid}/cwd`);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decide whether two cwds belong to the "same project" — i.e. one is
+ * a subdirectory of the other or they are identical. Conservative:
+ * returns false if either path is empty or the relationship can't be
+ * determined.
+ */
+export function cwdsAreSameProject(a: string | null, b: string | null): boolean {
+  if (!a || !b) return false;
+  if (a === b) return true;
+  // Normalize trailing slash
+  const na = a.endsWith("/") ? a : a + "/";
+  const nb = b.endsWith("/") ? b : b + "/";
+  return na.startsWith(nb) || nb.startsWith(na);
+}
 
 // ─── Phase 8: stale-watcher self-heal ─────────────────────────────
 
@@ -273,17 +303,60 @@ export function runSpawnPreflight(
     const occupant = findListeningPid(port);
     if (occupant !== null) {
       const occupantName = occupant > 0 ? processNameFor(occupant) : null;
+      // Phase 10: look up the occupant's working directory so we can
+      // tell the model whether the colliding server is the SAME project
+      // (same cwd subtree → file edits will hot-reload through it,
+      // task can proceed without spawning) or a DIFFERENT project
+      // (must kill or pick a different port).
+      const occupantCwd = occupant > 0 ? getProcessCwd(occupant) : null;
+      const sameProject = cwdsAreSameProject(cwd, occupantCwd);
+
       lines.push(`✗ Port ${port} is already in use.`);
       if (occupant > 0) {
         lines.push(`  occupant: PID ${occupant}${occupantName ? ` (${occupantName})` : ""}`);
+        if (occupantCwd) {
+          lines.push(`  occupant cwd: ${occupantCwd}`);
+        }
       } else {
         lines.push(`  occupant: detected by ss but PID hidden (insufficient privileges)`);
       }
       lines.push(`  Spawning ${detection.framework} on this port would race and fail.`);
       lines.push(``);
-      lines.push(`  AUTHORIZED RECOVERY (you may run these as your next tool calls`);
-      lines.push(`  WITHOUT asking the user — they are reversible system maintenance):`);
-      if (occupant > 0) {
+
+      if (sameProject) {
+        // Same project — the occupant is almost certainly a dev server
+        // started by an earlier session for THIS project. Hot-reload
+        // will pick up the file edits we just made. The model should
+        // treat the task as already-served, not as a failure.
+        lines.push(`  ✓ The occupant's cwd is inside YOUR current working directory.`);
+        lines.push(`  This is almost always a dev server from an earlier session for the`);
+        lines.push(`  same project. Watch-mode frameworks (Next.js, Vite, etc.) hot-reload`);
+        lines.push(`  on file changes, so the edits you just made are already being served`);
+        lines.push(`  by PID ${occupant}.`);
+        lines.push(``);
+        lines.push(`  RECOMMENDED: Treat this as a success, not a failure.`);
+        lines.push(`    1. Verify by curling http://localhost:${port}/ — you should see your`);
+        lines.push(`       new content already.`);
+        lines.push(`    2. Tell the user the project is live at http://localhost:${port}.`);
+        lines.push(`    3. Do NOT spawn another server. Do NOT kill PID ${occupant} unless`);
+        lines.push(`       there is a config-level change Next.js cannot hot-reload`);
+        lines.push(`       (next.config.js / package.json / tailwind.config — edits to`);
+        lines.push(`       components/pages always hot-reload fine).`);
+        lines.push(``);
+        lines.push(`  AUTHORIZED RECOVERY (only if hot-reload truly is not enough,`);
+        lines.push(`  e.g. you changed next.config.js or installed new dependencies):`);
+        lines.push(`    Step 1 — kill the occupant:  kill ${occupant}`);
+        lines.push(`    Step 2 — wait for release:   sleep 1`);
+        lines.push(`    Step 3 — retry the original command.`);
+      } else if (occupant > 0) {
+        // Different project — model should kill or pick a different port
+        if (occupantCwd) {
+          lines.push(`  ⚠ The occupant's cwd (${occupantCwd}) is OUTSIDE your current`);
+          lines.push(`  working directory (${cwd}). It belongs to a different project.`);
+          lines.push(``);
+        }
+        lines.push(`  AUTHORIZED RECOVERY (you may run these as your next tool calls`);
+        lines.push(`  WITHOUT asking the user — they are reversible system maintenance):`);
         lines.push(`    Step 1 — kill the occupant:`);
         lines.push(`        kill ${occupant}`);
         lines.push(`    Step 2 — wait for the port to release:`);
@@ -293,6 +366,9 @@ export function runSpawnPreflight(
         lines.push(`  ALTERNATIVE: pick a different port (PORT=N or --port N) if you suspect`);
         lines.push(`  the occupant is a dev server the user is actively using elsewhere.`);
       } else {
+        // PID hidden by ss
+        lines.push(`  AUTHORIZED RECOVERY (you may run these as your next tool calls`);
+        lines.push(`  WITHOUT asking the user — they are reversible system maintenance):`);
         lines.push(`    Step 1 — pick a different port: change PORT=N or --port N in the command.`);
         lines.push(`    Step 2 — retry the spawn with the new port.`);
       }

--- a/src/core/operator-port-collision.test.ts
+++ b/src/core/operator-port-collision.test.ts
@@ -1,0 +1,120 @@
+// Tests for phase 10 — smart port-collision resolution that distinguishes
+// "occupant is your same project (hot-reload will pick up the edits)"
+// from "occupant is a different project (kill or pick another port)".
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  cwdsAreSameProject,
+  getProcessCwd,
+  runSpawnPreflight,
+} from "./bash-spawn-preflight";
+
+describe("getProcessCwd", () => {
+  test("returns the cwd of the current process", () => {
+    const cwd = getProcessCwd(process.pid);
+    expect(cwd).not.toBeNull();
+    expect(typeof cwd).toBe("string");
+    expect(cwd!.length).toBeGreaterThan(0);
+  });
+
+  test("returns null for a garbage PID", () => {
+    expect(getProcessCwd(9999998)).toBeNull();
+  });
+
+  test("returns null for non-positive PIDs", () => {
+    expect(getProcessCwd(0)).toBeNull();
+    expect(getProcessCwd(-1)).toBeNull();
+  });
+});
+
+describe("cwdsAreSameProject", () => {
+  test("identical paths match", () => {
+    expect(cwdsAreSameProject("/home/curly/projects/my-site", "/home/curly/projects/my-site")).toBe(
+      true,
+    );
+  });
+
+  test("subdirectory matches parent", () => {
+    expect(
+      cwdsAreSameProject("/home/curly/projects/my-site", "/home/curly/projects/my-site/src"),
+    ).toBe(true);
+  });
+
+  test("parent matches subdirectory", () => {
+    expect(
+      cwdsAreSameProject("/home/curly/projects/my-site/src", "/home/curly/projects/my-site"),
+    ).toBe(true);
+  });
+
+  test("siblings do NOT match", () => {
+    expect(cwdsAreSameProject("/home/curly/projects/site-a", "/home/curly/projects/site-b")).toBe(
+      false,
+    );
+  });
+
+  test("unrelated paths do NOT match", () => {
+    expect(cwdsAreSameProject("/home/curly/projects", "/tmp")).toBe(false);
+  });
+
+  test("null inputs return false", () => {
+    expect(cwdsAreSameProject(null, "/x")).toBe(false);
+    expect(cwdsAreSameProject("/x", null)).toBe(false);
+    expect(cwdsAreSameProject(null, null)).toBe(false);
+  });
+
+  test("trailing-slash differences do not break the match", () => {
+    expect(cwdsAreSameProject("/x/y/", "/x/y")).toBe(true);
+    expect(cwdsAreSameProject("/x/y", "/x/y/z/")).toBe(true);
+  });
+
+  test("prefix-but-not-subdirectory does NOT match", () => {
+    // /x/yz starts with "/x/y" textually but isn't a subdirectory.
+    // The trailing-slash normalization in the implementation prevents this.
+    expect(cwdsAreSameProject("/x/y", "/x/yz")).toBe(false);
+  });
+});
+
+describe("runSpawnPreflight — port collision smart resolution (phase 10)", () => {
+  let server: ReturnType<typeof Bun.serve> | null = null;
+
+  afterEach(() => {
+    server?.stop(true);
+    server = null;
+  });
+
+  test("same-project occupant: refusal recommends treating as success", () => {
+    server = Bun.serve({ port: 0, fetch: () => new Response("hi") });
+    // The bun process running this test has a cwd that should match
+    // process.cwd() — so getProcessCwd(server.pid) === process.cwd().
+    const r = runSpawnPreflight(`PORT=${server.port} npm run dev`, process.cwd());
+    expect(r).not.toBeNull();
+    expect(r!.refused).toBe(true);
+    // Same-project banner
+    expect(r!.report).toContain("inside YOUR current working directory");
+    expect(r!.report).toContain("hot-reload");
+    // Recommends success-path
+    expect(r!.report).toContain("Treat this as a success");
+    expect(r!.report).toContain("curling http://localhost:");
+    // Still includes the AUTHORIZED RECOVERY for edge cases
+    expect(r!.report).toContain("AUTHORIZED RECOVERY");
+    expect(r!.report).toMatch(/only if hot-reload truly is not enough/i);
+  });
+
+  test("different-project occupant: refusal uses the kill-or-switch path", () => {
+    server = Bun.serve({ port: 0, fetch: () => new Response("hi") });
+    // Pretend the spawn is happening from /tmp, which is NOT the cwd of
+    // the test process (which lives in /home/curly/KCode). The occupant's
+    // real cwd is the test process cwd, so cwds differ.
+    const fakeCwd = "/tmp/some-other-project-9f3e2";
+    const r = runSpawnPreflight(`PORT=${server.port} npm run dev`, fakeCwd);
+    expect(r).not.toBeNull();
+    expect(r!.refused).toBe(true);
+    // Different-project warning
+    expect(r!.report).toMatch(/OUTSIDE your current[\s\S]*working directory/);
+    // Standard recovery block
+    expect(r!.report).toContain("AUTHORIZED RECOVERY");
+    expect(r!.report).toContain("WITHOUT asking the user");
+    expect(r!.report).toMatch(/Step 1[\s\S]*kill/);
+    expect(r!.report).toContain("ALTERNATIVE");
+  });
+});


### PR DESCRIPTION
## The ambiguity phase 6 left behind

This morning's Artemis session ended in an unverified guess. Phase 2 detected a port collision on 25632:

\`\`\`
⚡ Bash: cd /home/curly/projects/my-site && npm run dev -- --port 25632
✗ Bash failed (703ms)
    ✗ Port 25632 is already in use.
  occupant: PID 4124801 (next-server (v1)
  Spawning node-dev on this port would race and fail.
  AUT…
\`\`\`

The model read the AUTHORIZED RECOVERY block, saw "kill PID X" + "ALTERNATIVE: pick a different port if you suspect the occupant is a dev server the user is actively using elsewhere", and **declared the task complete**: "you can now visit http://localhost:25632".

It happened to be right — \`curl 25632\` later showed 32 mentions of "Artemis" in the served HTML, meaning Next.js had hot-reloaded the new files into the existing server. But **that was a guess**. The model didn't know whether the occupant was the same project or a different one. If it had been a different project's dev server the user had stale-running, the user would have seen the wrong content.

## What phase 10 changes

The port-collision branch of \`runSpawnPreflight\` now reads \`/proc/<occupant>/cwd\` and tells the model concretely whether the occupant is in the same project subtree as the current cwd.

### Same project (occupant cwd matches current cwd subtree)

\`\`\`
✗ Port 25632 is already in use.
  occupant: PID 4124801 (next-server (v1)
  occupant cwd: /home/curly/projects/my-site
  Spawning node-dev on this port would race and fail.

  ✓ The occupant's cwd is inside YOUR current working directory.
  This is almost always a dev server from an earlier session for the
  same project. Watch-mode frameworks (Next.js, Vite, etc.) hot-reload
  on file changes, so the edits you just made are already being served
  by PID 4124801.

  RECOMMENDED: Treat this as a success, not a failure.
    1. Verify by curling http://localhost:25632/ — you should see your
       new content already.
    2. Tell the user the project is live at http://localhost:25632.
    3. Do NOT spawn another server. Do NOT kill PID 4124801 unless
       there is a config-level change Next.js cannot hot-reload
       (next.config.js / package.json / tailwind.config — edits to
       components/pages always hot-reload fine).

  AUTHORIZED RECOVERY (only if hot-reload truly is not enough,
  e.g. you changed next.config.js or installed new dependencies):
    Step 1 — kill the occupant:  kill 4124801
    Step 2 — wait for release:   sleep 1
    Step 3 — retry the original command.
\`\`\`

The model now has step-by-step instructions: **curl, declare live, do NOT spawn**. The kill-and-respawn path is still there but explicitly gated on "config-level change Next.js cannot hot-reload".

### Different project (occupant cwd outside current cwd subtree)

\`\`\`
✗ Port 25632 is already in use.
  occupant: PID 4124801 (next-server)
  occupant cwd: /home/curly/projects/some-other-thing
  ⚠ The occupant's cwd (/home/curly/projects/some-other-thing) is OUTSIDE your current
  working directory (/home/curly/projects/my-site). It belongs to a different project.

  AUTHORIZED RECOVERY (you may run these as your next tool calls
  WITHOUT asking the user — they are reversible system maintenance):
    Step 1 — kill the occupant:  kill 4124801
    Step 2 — wait for the port to release:  sleep 1
    Step 3 — retry the original command.

  ALTERNATIVE: pick a different port (PORT=N or --port N) if you suspect
  the occupant is a dev server the user is actively using elsewhere.
\`\`\`

Same as before phase 10 — model gets the unchanged kill-or-switch playbook.

### Unknown occupant (PID hidden by \`ss\` insufficient privs)

Just "pick a different port" — the only safe option.

## New helpers

\`\`\`ts
export function getProcessCwd(pid: number): string | null
export function cwdsAreSameProject(a: string | null, b: string | null): boolean
\`\`\`

\`cwdsAreSameProject\` handles:
- Identical paths
- Subdirectory matches parent (and vice versa)
- Trailing slash differences
- The \`/x/y\` vs \`/x/yz\` prefix trap (avoided by appending \`/\` before the prefix check)

## Tests

13 new cases in \`operator-port-collision.test.ts\`:
- \`getProcessCwd\` against the running test process / garbage PID / non-positive PID
- \`cwdsAreSameProject\` for every relationship: identical / sub / parent / sibling / null / trailing slashes / prefix-but-not-subdirectory
- End-to-end: same-project refusal contains the "Treat as success" recommendation
- End-to-end: different-project refusal contains the "OUTSIDE your current working directory" warning + the standard AUTHORIZED RECOVERY block

Plus an update to the existing phase-6 test (\`bash-spawn-preflight.test.ts\`) to pass a fake cwd so it lands on the different-project branch where the original "WITHOUT asking the user" + "ALTERNATIVE" wording lives.

## Test plan

- [x] \`bun test src/core/operator-port-collision.test.ts\` — **13 / 0**
- [x] \`bun test src/core/bash-spawn-preflight.test.ts\` — **9 / 0** (updated phase-6 test)
- [x] \`bun test\` (full) — **6155 pass / 11 skip / 2 fail** (the 2 fails are pre-existing \`file-sync\` \`EMFILE\` flakies, unrelated)
- [x] \`bun run build\` — production binary deployed to all 3 paths, reports v2.10.45
- [x] **End-to-end against your live state**: with the actual next-server PID 4124801 sitting on port 25632 in /home/curly/projects/my-site, the refusal correctly identifies it as same-project and recommends "Treat as success"
- [ ] **Manual smoke**: re-run the Artemis scenario with the same occupant present, verify the model now curls 25632 and declares the page live with confidence (not as a guess)

## Bumps version to 2.10.45

🤖 Generated with [Claude Code](https://claude.com/claude-code)