### PR TITLE
fix(write): resolve relative paths against cwd + drop STOP directive + v2.10.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.45",
+  "version": "2.10.46",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/permissions.test.ts
+++ b/src/core/permissions.test.ts
@@ -354,10 +354,12 @@ describe("validateFileWritePath", () => {
     expect(result.allowed).toBe(true);
   });
 
-  test("blocks relative path", () => {
+  test("resolves relative path against the working directory", () => {
+    // Previously relative paths were hard-rejected. They now resolve
+    // against the passed workingDirectory and run through the normal
+    // bounds / sensitive-dir / symlink checks.
     const result = validateFileWritePath("relative/path.txt", "/home/user/project");
-    expect(result.allowed).toBe(false);
-    expect(result.reason).toContain("must be absolute");
+    expect(result.allowed).toBe(true);
   });
 
   test("blocks write outside working directory", () => {
@@ -473,12 +475,16 @@ describe("PermissionManager", () => {
       expect(result.allowed).toBe(true);
     });
 
-    test("blocks file write to relative path", async () => {
+    test("resolves relative file write against the working directory", async () => {
+      // Previously relative paths were hard-rejected. They now resolve
+      // against the passed workingDirectory (/tmp/test) and run through
+      // the normal bounds check. /tmp/test/relative.txt is inside
+      // /tmp/test, so the write is allowed.
       const pm = new PermissionManager("auto", "/tmp/test");
       const result = await pm.checkPermission(
-        makeToolUse("Write", { file_path: "relative.txt", content: "bad" }),
+        makeToolUse("Write", { file_path: "relative.txt", content: "hello" }),
       );
-      expect(result.allowed).toBe(false);
+      expect(result.allowed).toBe(true);
     });
   });
 
@@ -523,15 +529,17 @@ describe("PermissionManager", () => {
       expect(result.reason).toContain("No permission prompt function");
     });
 
-    test("still blocks relative file paths even in ask mode", async () => {
+    test("resolves relative file paths in ask mode (bounds still apply after resolve)", async () => {
+      // Previously this asserted that ask-mode hard-rejected relative paths.
+      // The new behavior resolves /tmp/test/relative.txt against the cwd
+      // and prompts normally; the prompt fn grants, so the result is allowed.
       const pm = new PermissionManager("ask", "/tmp/test");
       pm.setPromptFn(async () => ({ granted: true }));
 
       const result = await pm.checkPermission(
         makeToolUse("Edit", { file_path: "relative.txt", old_string: "a", new_string: "b" }),
       );
-      expect(result.allowed).toBe(false);
-      expect(result.reason).toContain("must be absolute");
+      expect(result.allowed).toBe(true);
     });
   });
 

--- a/src/core/safety-analysis.test.ts
+++ b/src/core/safety-analysis.test.ts
@@ -482,9 +482,36 @@ describe("validateFileWritePath", () => {
     expect(result.allowed).toBe(true);
   });
 
-  test("denies relative path", () => {
+  test("resolves relative path against the working directory", () => {
+    // Previously this rejected all relative paths with a refusal that
+    // broke the most common usage pattern. The resolver now combines
+    // the relative path with cwd and lets the normal downstream checks
+    // (working-directory bounds, sensitive dirs, etc.) run against
+    // the resolved absolute path.
     const result = validateFileWritePath("relative/path.txt", cwd);
+    expect(result.allowed).toBe(true);
+  });
+
+  test("resolves bare filename against the working directory", () => {
+    const result = validateFileWritePath("nasa-explorer.html", cwd);
+    expect(result.allowed).toBe(true);
+  });
+
+  test("resolves relative path that escapes with ../", () => {
+    // "/home/user/project" + "../../etc/passwd" resolves to "/etc/passwd",
+    // which is a protected system directory → still denied (but via the
+    // protected-dir check, not the absolute-path check).
+    const result = validateFileWritePath("../../etc/passwd", cwd);
     expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/protected|outside/i);
+  });
+
+  test("relative path outside the working directory is denied", () => {
+    // "../other-project/file.txt" from /home/user/project resolves to
+    // /home/user/other-project/file.txt — outside the cwd subtree.
+    const result = validateFileWritePath("../other-project/file.txt", cwd);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/outside working directory/i);
   });
 
   test("denies outside working directory", () => {

--- a/src/core/safety-analysis.ts
+++ b/src/core/safety-analysis.ts
@@ -450,14 +450,16 @@ export function validateFileWritePath(
   workingDirectory: string,
   additionalDirs?: string[],
 ): PermissionResult {
-  if (!isAbsolute(filePath)) {
-    return {
-      allowed: false,
-      reason: `File path must be absolute, got: ${filePath}`,
-    };
-  }
-
-  let resolved = resolve(filePath);
+  // Auto-resolve relative paths against the working directory. Previously
+  // this rejected relative paths outright with a "path must be absolute"
+  // refusal, which was too strict — the LLM routinely passes bare filenames
+  // like `nasa-explorer.html` and the intent is always "in the current cwd".
+  // All downstream checks (sensitive dirs, symlink traversal, working
+  // directory bounds) still apply after resolution, so the relaxation
+  // does not weaken security — it just makes the tool accept the common case.
+  let resolved = isAbsolute(filePath)
+    ? resolve(filePath)
+    : resolve(workingDirectory, filePath);
 
   // Resolve symlinks to prevent directory traversal via symlink chains
   try {

--- a/src/core/tool-executor.ts
+++ b/src/core/tool-executor.ts
@@ -370,25 +370,34 @@ export async function* executeToolsSequential(
       turnHadDenial = true;
       // Smart routing: if a Bash command was denied but it was trying to
       // create a file via shell redirection, suggest the Write tool instead
-      // of telling the model to give up entirely. This prevents the failure
-      // mode where the model stops trying to create a file after Bash safety
+      // of telling the model to give up. This prevents the failure mode
+      // where the model stops trying to create a file after Bash safety
       // blocks a heredoc, instead of routing to the proper tool.
-      let suggestion = "STOP: Do not retry this tool or any other tools. Respond to the user with text only.";
+      //
+      // For all OTHER denials we stay silent about retry strategy — the
+      // denial reason itself is enough for the model to decide whether
+      // to recover. Previously this branch used an aggressive
+      // "STOP: Do not retry... respond with text only" suffix that
+      // prevented the model from trying legitimate recovery paths
+      // (e.g. passing an absolute path instead of a relative one), and
+      // induced it to hallucinate success in user-facing text. We
+      // never want that on recoverable denials.
+      let suggestion = "";
       if (call.name === "Bash" && typeof call.input?.command === "string") {
         try {
           const { extractRedirectionTargets } = await import("./audit-guards.js");
           const targets = extractRedirectionTargets(call.input.command as string);
           if (targets.length > 0) {
             suggestion =
-              `STOP using Bash for this. To CREATE a file, call the Write tool: ` +
+              ` STOP using Bash for this. To CREATE a file, call the Write tool: ` +
               `Write(file_path="${targets[0]}", content="..."). ` +
               `Do NOT retry the Bash command.`;
           }
         } catch {
-          /* fallback to default message */
+          /* fallback: no suggestion */
         }
       }
-      const deniedContent = `Permission denied: ${permResult.reason ?? "blocked by permission system"}. ${suggestion}`;
+      const deniedContent = `Permission denied: ${permResult.reason ?? "blocked by permission system"}.${suggestion}`;
       yield {
         type: "tool_result",
         name: call.name,


### PR DESCRIPTION
## Two linked bugs exposed by a real session

User asked for a NASA Explorer HTML dashboard. The model called \`Write({file_path: "nasa-explorer.html", content: "..."})\`. KCode refused with:

\`\`\`
Permission denied: File path must be absolute, got: nasa-explorer.html.
STOP: Do not retry this tool or any other tools. Respond to the user with text only.
\`\`\`

Two problems in one message:

### Bug 1: relative paths hard-rejected

\`safety-analysis.validateFileWritePath\` at line 453 rejected any path not starting with \`/\`. The LLM routinely passes bare filenames when the intent is "in the current working directory" — \`nasa-explorer.html\`, \`package.json\`, \`README.md\`. Every relative-path call failed.

### Bug 2: aggressive STOP directive on recoverable denials

\`tool-executor.ts:376\` had:

\`\`\`ts
let suggestion = "STOP: Do not retry this tool or any other tools. Respond to the user with text only.";
\`\`\`

This was intended as the default for Bash-heredoc → Write routing. It got applied to **every** denial. For recoverable cases like "use an absolute path" the directive actively harmed recovery: it prevented the model from retrying with the fix AND induced it to hallucinate success.

The session transcript shows the model after the STOP directive:
- Claimed "I created a complete, production-ready, self-contained nasa-explorer.html"
- Dumped a code block in the chat with **CSS literally mangled** (\`background-size: ;\`, \`animation: twinkle infinite alternate;\`, \`padding: \`)
- Told the user "save the full file (available via the tool write that was attempted) as nasa-explorer.html"

The model KNEW the write had failed ("that was attempted") but still claimed success, because the system directive had told it to "respond with text only."

## The fix

### 1. \`validateFileWritePath\` auto-resolves relative paths

\`\`\`diff
-  if (!isAbsolute(filePath)) {
-    return {
-      allowed: false,
-      reason: \`File path must be absolute, got: \${filePath}\`,
-    };
-  }
-
-  let resolved = resolve(filePath);
+  let resolved = isAbsolute(filePath)
+    ? resolve(filePath)
+    : resolve(workingDirectory, filePath);
\`\`\`

All the downstream checks (protected system dirs, symlink traversal, working-directory bounds, \`.env\`/\`.ssh\`/etc.) still run against the resolved absolute path. Security is preserved — only the ergonomic hard-reject is removed.

### 2. \`tool-executor\` default denial suffix is now empty

\`\`\`diff
-  let suggestion = "STOP: Do not retry this tool or any other tools. Respond to the user with text only.";
+  let suggestion = "";
   if (call.name === "Bash" && typeof call.input?.command === "string") {
     try {
       const { extractRedirectionTargets } = await import("./audit-guards.js");
       const targets = extractRedirectionTargets(call.input.command as string);
       if (targets.length > 0) {
         suggestion =
           \` STOP using Bash for this. To CREATE a file, call the Write tool: ...\`;
       }
     } catch { /* fallback: no suggestion */ }
   }
\`\`\`

The Bash-heredoc routing suggestion is **unchanged**. Every other denial gets just the reason — enough for the model to reason about whether to recover, without a blocking directive that induces hallucination.

## End-to-end verification

\`\`\`bash
$ bun -e 'import { executeWrite } from "./src/tools/write.ts"; ...'
=== Write with bare filename (NASA Explorer case) ===
is_error: false
content: Created nasa-explorer.html (1 lines)
  +    1 | <!DOCTYPE html><html><body>NASA Explorer</body></html>

=== file actually exists? ===
path: /tmp/nasa-cTWbwm/nasa-explorer.html
exists: true
size: 54
\`\`\`

The exact call pattern from the failing session now succeeds.

## Test plan

- [x] \`bun test src/core/safety-analysis.test.ts\` — **111 / 0** (was 107; added 4 new cases for bare filename, bounds after resolve, ../-escape to protected dir, ../-escape outside cwd)
- [x] \`bun test src/core/permissions.test.ts\` — **135 / 0** (updated 3 tests that codified the old hard-reject behavior)
- [x] \`bun test\` (full) — **6158 pass / 11 skip / 2 fail** (2 fails are pre-existing \`file-sync\` \`EMFILE\` flakies, unrelated)
- [x] \`bun run build\` — production binary deployed to all 3 paths, reports v2.10.46
- [x] **End-to-end**: \`executeWrite({file_path: "nasa-explorer.html", content: "..."})\` in a tmpdir → file written, is_error=false
- [ ] **Manual smoke**: re-run the exact Nasa Explorer session, verify Write succeeds and the model doesn't hallucinate a code block in the chat

## Not touched by this PR

The deeper issue — the model hallucinating success after a tool failure — is a model-behavior problem that a simple language change can't fully fix. Phase 6 tried to address it for operator-mind refusals; the fix here removes the specific directive that made the hallucination worse, but a determined model can still fabricate completion text for any reason. A future phase could add a post-turn guard: if the last assistant turn claims "I created X" and no Write/Edit for X succeeded in this turn, flag it. That's deferred.

## Bumps version to 2.10.46

🤖 Generated with [Claude Code](https://claude.com/claude-code)