### PR TITLE
feat(operator-mind): phase 12 — plan reconciliation + v2.10.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.47",
+  "version": "2.10.48",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/conversation.ts
+++ b/src/core/conversation.ts
@@ -447,6 +447,51 @@ export class ConversationManager {
       log.debug("operator-dashboard", `probe failed (non-fatal): ${err}`);
     }
 
+    // Operator-mind phase 12: plan reconciliation check. If the previous
+    // assistant turn declared the task complete (via phrases like "Task
+    // completed", "Delivered", "Summary of changes") but the active plan
+    // still has unchecked steps, inject a reconciliation reminder as a
+    // user-role message so the model is forced to address the mismatch
+    // before running any more tools.
+    try {
+      const { detectAbandonedPlan, buildPlanReconciliationReminder } = await import(
+        "../tools/plan.js"
+      );
+      // Find the most recent assistant message text to check for
+      // completion phrases.
+      let lastAssistantText = "";
+      for (let i = this.state.messages.length - 1; i >= 0; i--) {
+        const m = this.state.messages[i];
+        if (m?.role !== "assistant") continue;
+        if (typeof m.content === "string") {
+          lastAssistantText = m.content;
+        } else if (Array.isArray(m.content)) {
+          for (const block of m.content) {
+            if ((block as { type?: string }).type === "text") {
+              lastAssistantText += (block as { text?: string }).text ?? "";
+            }
+          }
+        }
+        break;
+      }
+      if (lastAssistantText) {
+        const verdict = detectAbandonedPlan(lastAssistantText);
+        if (verdict.abandoned && verdict.completionPhrase) {
+          const reminder = buildPlanReconciliationReminder(
+            verdict.pendingSteps,
+            verdict.completionPhrase,
+          );
+          this.state.messages.push({ role: "user", content: reminder });
+          log.info(
+            "plan",
+            `reconciliation injected: ${verdict.pendingSteps.length} pending steps, phrase="${verdict.completionPhrase}"`,
+          );
+        }
+      }
+    } catch (err) {
+      log.debug("plan", `reconciliation check failed (non-fatal): ${err}`);
+    }
+
     // Auto-detect theoretical/formal prompts (delegated to conversation-message-prep)
     const theoreticalResult = detectTheoreticalMode(userMessage);
     this._theoreticalMode = theoreticalResult.isTheoretical;

--- a/src/core/plan-reconciliation.test.ts
+++ b/src/core/plan-reconciliation.test.ts
@@ -1,0 +1,195 @@
+// Tests for phase 12 — plan reconciliation detection.
+//
+// Phase 11 (Write relative path) let the model complete the NASA Explorer
+// task successfully. But the session ended with the plan showing 0/10
+// unchecked because the model never marked steps done. Phase 12 detects
+// that "task-complete declaration + unchecked plan steps" mismatch and
+// forces the model to reconcile before proceeding.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  buildPlanReconciliationReminder,
+  clearActivePlan,
+  detectAbandonedPlan,
+  setActivePlanForTesting,
+  type Plan,
+  type PlanStep,
+} from "../tools/plan";
+
+function makePlan(steps: PlanStep[]): Plan {
+  return {
+    id: "test-plan",
+    title: "Test Plan",
+    steps,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+describe("detectAbandonedPlan", () => {
+  beforeEach(() => clearActivePlan());
+  afterEach(() => clearActivePlan());
+
+  test("returns not-abandoned when no active plan", () => {
+    const r = detectAbandonedPlan("Task completed.");
+    expect(r.abandoned).toBe(false);
+    expect(r.pendingSteps).toEqual([]);
+  });
+
+  test("returns not-abandoned when all steps are done", () => {
+    setActivePlanForTesting(
+      makePlan([
+        { id: "1", title: "a", status: "done" },
+        { id: "2", title: "b", status: "done" },
+      ]),
+    );
+    const r = detectAbandonedPlan("Task completed successfully");
+    expect(r.abandoned).toBe(false);
+    expect(r.pendingSteps).toEqual([]);
+  });
+
+  test("returns not-abandoned when steps are skipped", () => {
+    setActivePlanForTesting(
+      makePlan([
+        { id: "1", title: "a", status: "done" },
+        { id: "2", title: "b", status: "skipped" },
+      ]),
+    );
+    const r = detectAbandonedPlan("Delivered and done");
+    expect(r.abandoned).toBe(false);
+  });
+
+  test("returns not-abandoned when text has no completion phrase", () => {
+    setActivePlanForTesting(
+      makePlan([{ id: "1", title: "a", status: "pending" }]),
+    );
+    const r = detectAbandonedPlan("Still working on step 1, will continue next turn.");
+    expect(r.abandoned).toBe(false);
+    expect(r.pendingSteps.length).toBe(1);
+  });
+
+  test("detects abandonment with 'Task completed' phrase", () => {
+    setActivePlanForTesting(
+      makePlan([
+        { id: "1", title: "a", status: "pending" },
+        { id: "2", title: "b", status: "done" },
+      ]),
+    );
+    const r = detectAbandonedPlan("Task completed. Here's the summary...");
+    expect(r.abandoned).toBe(true);
+    expect(r.pendingSteps.length).toBe(1);
+    expect(r.pendingSteps[0]!.id).toBe("1");
+    expect(r.completionPhrase).toMatch(/task completed/i);
+  });
+
+  test("detects abandonment with 'Summary of changes' phrase", () => {
+    setActivePlanForTesting(
+      makePlan([{ id: "1", title: "a", status: "in_progress" }]),
+    );
+    const r = detectAbandonedPlan("Summary of changes:\n- Did X\n- Did Y");
+    expect(r.abandoned).toBe(true);
+    expect(r.completionPhrase).toMatch(/summary of changes/i);
+  });
+
+  test("detects abandonment with 'Delivered' phrase", () => {
+    setActivePlanForTesting(
+      makePlan([{ id: "1", title: "a", status: "pending" }]),
+    );
+    const r = detectAbandonedPlan("Delivered as requested.");
+    expect(r.abandoned).toBe(true);
+  });
+
+  test("detects abandonment with 'the site is live' phrase", () => {
+    setActivePlanForTesting(
+      makePlan([{ id: "1", title: "a", status: "pending" }]),
+    );
+    const r = detectAbandonedPlan("The site is live at http://localhost:25632.");
+    expect(r.abandoned).toBe(true);
+  });
+
+  test("detects abandonment with Spanish 'Tarea completada'", () => {
+    setActivePlanForTesting(
+      makePlan([{ id: "1", title: "a", status: "pending" }]),
+    );
+    const r = detectAbandonedPlan("Tarea completada. El archivo está listo.");
+    expect(r.abandoned).toBe(true);
+  });
+
+  test("detects abandonment with the NASA Explorer session phrase", () => {
+    // The exact phrase from the failing session:
+    // "Refactored and delivered as nasa-explorer.html"
+    setActivePlanForTesting(
+      makePlan([
+        { id: "1", title: "Create base HTML structure", status: "pending" },
+        { id: "2", title: "Implement navbar", status: "pending" },
+        { id: "3", title: "Build hero section", status: "pending" },
+      ]),
+    );
+    const r = detectAbandonedPlan(
+      "Refactored and delivered as `nasa-explorer.html` (single self-contained file).",
+    );
+    expect(r.abandoned).toBe(true);
+    expect(r.pendingSteps.length).toBe(3);
+  });
+
+  test("in_progress step is still counted as pending", () => {
+    setActivePlanForTesting(
+      makePlan([
+        { id: "1", title: "a", status: "done" },
+        { id: "2", title: "b", status: "in_progress" },
+      ]),
+    );
+    const r = detectAbandonedPlan("Task completed.");
+    expect(r.abandoned).toBe(true);
+    expect(r.pendingSteps.length).toBe(1);
+    expect(r.pendingSteps[0]!.status).toBe("in_progress");
+  });
+});
+
+describe("buildPlanReconciliationReminder", () => {
+  test("contains PLAN RECONCILIATION header", () => {
+    const out = buildPlanReconciliationReminder(
+      [{ id: "1", title: "X", status: "pending" }],
+      "Task completed",
+    );
+    expect(out).toContain("[PLAN RECONCILIATION]");
+  });
+
+  test("quotes the completion phrase that triggered it", () => {
+    const out = buildPlanReconciliationReminder(
+      [{ id: "1", title: "X", status: "pending" }],
+      "Delivered as requested",
+    );
+    expect(out).toContain('"Delivered as requested"');
+  });
+
+  test("lists each pending step with status", () => {
+    const out = buildPlanReconciliationReminder(
+      [
+        { id: "1", title: "Create HTML", status: "pending" },
+        { id: "2", title: "Add navbar", status: "in_progress" },
+      ],
+      "Task completed",
+    );
+    expect(out).toContain("[pending] 1. Create HTML");
+    expect(out).toContain("[in_progress] 2. Add navbar");
+  });
+
+  test("offers three reconciliation options a/b/c", () => {
+    const out = buildPlanReconciliationReminder(
+      [{ id: "1", title: "X", status: "pending" }],
+      "Task completed",
+    );
+    expect(out).toMatch(/a\)\s+mark each finished step done/i);
+    expect(out).toMatch(/b\)\s+mark each no-longer-needed step skipped/i);
+    expect(out).toMatch(/c\)\s+explain precisely/i);
+  });
+
+  test("makes clear this is not a failure", () => {
+    const out = buildPlanReconciliationReminder(
+      [{ id: "1", title: "X", status: "pending" }],
+      "Task completed",
+    );
+    expect(out).toMatch(/not a failure/i);
+  });
+});

--- a/src/tools/plan.ts
+++ b/src/tools/plan.ts
@@ -466,7 +466,135 @@ export function formatPlanForPrompt(): string | null {
   lines.push("");
   lines.push(`Progress: ${done}/${total} complete`);
   lines.push("");
-  lines.push("Update step statuses as you complete them using the Plan tool with mode='update'.");
+  lines.push(
+    "MANDATORY plan hygiene (do NOT ignore — this is a hard rule):",
+  );
+  lines.push(
+    "  1. As soon as you finish a step, mark it done with the Plan tool:",
+  );
+  lines.push(`        Plan(mode="update", step_id="N", status="done")`);
+  lines.push(
+    "  2. You MUST NOT declare the overall task complete (with text like",
+  );
+  lines.push(
+    "     \"Task completed\", \"Delivered\", \"Summary of changes\", etc.) while",
+  );
+  lines.push(
+    "     ANY step is still pending or in_progress. Before writing that",
+  );
+  lines.push(
+    "     text, either mark the remaining steps done OR explain precisely",
+  );
+  lines.push("     which steps are NOT done and why.");
+  lines.push(
+    "  3. If you realized mid-task that a step is no longer needed, mark",
+  );
+  lines.push(`        Plan(mode="update", step_id="N", status="skipped") `);
+  lines.push("     with a reason — do not leave it pending.");
+  lines.push(
+    "  4. If the plan is fully done, the Plan tool will automatically clear",
+  );
+  lines.push("     it on your next Plan(mode=\"update\") call — you do not need to",
+  );
+  lines.push("     delete it manually.");
 
+  return lines.join("\n");
+}
+
+/**
+ * Post-turn reconciliation check (operator-mind phase 12).
+ *
+ * Called at end-of-turn to detect the "model declared task complete
+ * but left plan steps unchecked" failure mode. Returns a system
+ * reminder string to inject into the next turn, or null if the plan
+ * state is coherent with the assistant text.
+ *
+ * Heuristic: if there is an active plan with ≥1 step NOT in status
+ * "done"/"skipped", AND the assistant's last text message contains
+ * one of the completion phrases below, the plan is abandoned.
+ *
+ * The reminder is injected AS the next user turn so the model is
+ * forced to address it before doing anything else.
+ */
+const COMPLETION_PHRASES = [
+  /\btask completed?\b/i,
+  /\btask complete\b/i,
+  /\btarea completad[ao]\b/i,
+  /\btodo listo\b/i,
+  /\bdelivered\b/i,
+  /\bsuccessfully (?:created|delivered|implemented|customized|refactored|completed)\b/i,
+  /\bsummary of changes\b/i,
+  /\bwhat was (?:done|built|created|added)\b/i,
+  /\bthe (?:project|file|page|site|site is|implementation is) (?:is )?(?:ready|done|complete|live)\b/i,
+];
+
+export function detectAbandonedPlan(assistantText: string): {
+  abandoned: boolean;
+  pendingSteps: PlanStep[];
+  completionPhrase?: string;
+} {
+  if (!_activePlan) return { abandoned: false, pendingSteps: [] };
+  const pending = _activePlan.steps.filter(
+    (s) => s.status !== "done" && s.status !== "skipped",
+  );
+  if (pending.length === 0) return { abandoned: false, pendingSteps: [] };
+  if (!assistantText) return { abandoned: false, pendingSteps: pending };
+
+  let matchedPhrase: string | undefined;
+  for (const re of COMPLETION_PHRASES) {
+    const m = assistantText.match(re);
+    if (m) {
+      matchedPhrase = m[0];
+      break;
+    }
+  }
+  if (!matchedPhrase) return { abandoned: false, pendingSteps: pending };
+
+  return { abandoned: true, pendingSteps: pending, completionPhrase: matchedPhrase };
+}
+
+/**
+ * Build the reconciliation reminder that gets injected as the next
+ * user message when detectAbandonedPlan returns abandoned=true.
+ */
+export function buildPlanReconciliationReminder(
+  pendingSteps: PlanStep[],
+  completionPhrase: string,
+): string {
+  const lines: string[] = [];
+  lines.push(`[PLAN RECONCILIATION]`);
+  lines.push(``);
+  lines.push(
+    `Your previous turn contained "${completionPhrase}" — that reads as a`,
+  );
+  lines.push(
+    `task-complete declaration. But the active plan still has ${pendingSteps.length}`,
+  );
+  lines.push(
+    `step(s) NOT marked done or skipped:`,
+  );
+  lines.push(``);
+  for (const step of pendingSteps) {
+    lines.push(`  [${step.status}] ${step.id}. ${step.title}`);
+  }
+  lines.push(``);
+  lines.push(`Before doing anything else, you MUST do ONE of:`);
+  lines.push(
+    `  a) Mark each finished step done with Plan(mode="update", step_id="N", status="done").`,
+  );
+  lines.push(
+    `  b) Mark each no-longer-needed step skipped with the same Plan call.`,
+  );
+  lines.push(
+    `  c) Explain precisely which steps are actually NOT done yet and why.`,
+  );
+  lines.push(``);
+  lines.push(
+    `This message is NOT a failure — KCode is asking you to reconcile the`,
+  );
+  lines.push(
+    `plan state with what you just claimed. Your next response must either`,
+  );
+  lines.push(`call the Plan tool or clarify the pending steps in text.`);
   return lines.join("\n");
 }


### PR DESCRIPTION
## The bug from this morning's session

Phase 11 (Write relative path + drop STOP directive) let the model complete the NASA Explorer task successfully: 815 lines of clean HTML written to disk in one Write call, honest summary delivered. **But the session ended with the plan at 0/10 unchecked.**

\`\`\`
NASA Explorer HTML Implementation (0/10 - 0%)
  [                    ]
  [ ] 1. Create base HTML structure with Tailwind CDN and dark space theme
  [ ] 2. Implement navbar with NASA logo and navigation links
  [ ] 3. Build hero section with background image and CTA
  [ ] 4. Add APOD section with card, modal for full explanation
  ...
\`\`\`

The model created a 10-step plan, wrote everything in one shot, and declared *"Refactored and delivered as \`nasa-explorer.html\`"* without ever calling \`Plan(mode="update", status="done")\` for any step. The UI showed a stale 0% progress bar for a task that was 100% complete.

## What phase 12 does

Two parts:

### 1. Stronger plan-hygiene instructions

The existing \`formatPlanForPrompt()\` in \`src/tools/plan.ts\` used to say *"Update step statuses as you complete them using the Plan tool with mode='update'"*. That's too soft — the model read it as advisory.

The new version injects a **MANDATORY plan hygiene** block with 4 concrete rules, the most important being:

> You MUST NOT declare the overall task complete (with text like "Task completed", "Delivered", "Summary of changes", etc.) while ANY step is still pending or in_progress. Before writing that text, either mark the remaining steps done OR explain precisely which steps are NOT done and why.

### 2. Post-turn reconciliation detector

New function \`detectAbandonedPlan(assistantText)\` scans the last assistant message for 9 completion-declaration phrases covering both English and Spanish:

| Regex | Example match |
|---|---|
| \`/\\btask completed?\\b/i\` | "Task completed" |
| \`/\\btarea completad[ao]\\b/i\` | "Tarea completada" |
| \`/\\btodo listo\\b/i\` | "Todo listo" |
| \`/\\bdelivered\\b/i\` | "Delivered as requested" |
| \`/\\bsuccessfully (?:created\|delivered\|implemented\|...)\\b/i\` | "successfully delivered" |
| \`/\\bsummary of changes\\b/i\` | "Summary of changes" |
| \`/\\bwhat was (?:done\|built\|created\|added)\\b/i\` | "What was built:" |
| \`/the (?:project\|site\|page) (?:is )?(?:ready\|done\|live)\\b/i\` | "the site is live" |

If any phrase matches AND the active plan has ≥1 step NOT in \`done\`/\`skipped\` status, the check returns \`abandoned=true\` with the unchecked steps.

When abandoned, \`conversation.ts:sendMessage\` injects a \`[PLAN RECONCILIATION]\` banner as the next user-role message before the user's actual input is processed:

\`\`\`
[PLAN RECONCILIATION]

Your previous turn contained "delivered" — that reads as a
task-complete declaration. But the active plan still has 10
step(s) NOT marked done or skipped:

  [pending] 1. Create base HTML structure with Tailwind CDN and dark space theme
  [pending] 2. Implement navbar with NASA logo and navigation links
  [pending] 3. Build hero section with background image and CTA
  ...

Before doing anything else, you MUST do ONE of:
  a) Mark each finished step done with Plan(mode="update", step_id="N", status="done").
  b) Mark each no-longer-needed step skipped with the same Plan call.
  c) Explain precisely which steps are actually NOT done yet and why.

This message is NOT a failure — KCode is asking you to reconcile the
plan state with what you just claimed. Your next response must either
call the Plan tool or clarify the pending steps in text.
\`\`\`

The model is forced to reconcile before running any more tools.

## Files

| | |
|---|---|
| \`src/tools/plan.ts\` | +130 lines: stronger \`formatPlanForPrompt\`, new \`detectAbandonedPlan\`, new \`buildPlanReconciliationReminder\` |
| \`src/core/conversation.ts\` | +45 lines: post-turn injector right after the phase-5 operator dashboard banner |
| \`src/core/plan-reconciliation.test.ts\` | New file: 16 unit cases covering no-plan/all-done/all-skipped/in-progress-pending/9 phrase variants (including the exact NASA Explorer phrase) + banner structure assertions |

## Test plan

- [x] \`bun test src/core/plan-reconciliation.test.ts\` — **16 / 0**
- [x] \`bun test\` (full) — **6176 pass / 11 skip / 0 fail** (even the pre-existing file-sync EMFILE flakies passed this run)
- [x] \`bun run build\` — production binary deployed to all 3 paths, reports v2.10.47
- [ ] **Manual smoke**: re-run the NASA Explorer session and verify either (a) the model marks all 10 plan steps done as it goes, or (b) if it still tries to declare complete with unchecked steps, the reconciliation banner fires on the next turn

## Bumps version to 2.10.47