### PR TITLE
fix(oauth): KCODE_OAUTH_NO_BROWSER env gate + v2.10.47

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.46",
+  "version": "2.10.47",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/enterprise/oauth/flow.test.ts
+++ b/src/enterprise/oauth/flow.test.ts
@@ -28,8 +28,13 @@ describe("oauth/flow", () => {
     tempDir = await mkdtemp(join(tmpdir(), "kcode-oauth-flow-test-"));
     origEnv = {
       KCODE_HOME: process.env.KCODE_HOME,
+      KCODE_OAUTH_NO_BROWSER: process.env.KCODE_OAUTH_NO_BROWSER,
     };
     process.env.KCODE_HOME = tempDir;
+    // Block the integration test from spawning xdg-open and flashing
+    // a real browser tab on the developer's desktop every time the
+    // suite runs. flow.ts respects this env var.
+    process.env.KCODE_OAUTH_NO_BROWSER = "1";
     await clearTokens();
   });
 

--- a/src/enterprise/oauth/flow.ts
+++ b/src/enterprise/oauth/flow.ts
@@ -112,14 +112,22 @@ export async function startOAuthFlow(config: OAuthConfig): Promise<OAuthTokens |
   });
   const authUrl = `${config.authUrl}?${authParams.toString()}`;
 
-  // Open browser
-  try {
-    const openCmd =
-      process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
-    Bun.spawn([openCmd, authUrl], { stdout: "ignore", stderr: "ignore" });
-  } catch (err) {
-    log.warn("config", `Failed to open browser for OAuth: ${err}`);
-    console.error(`Please open this URL in your browser:\n${authUrl}`);
+  // Open browser — unless KCODE_OAUTH_NO_BROWSER=1 is set, which tests
+  // (and headless CI) use to prevent this function from spawning xdg-open
+  // and flashing a real browser window on the user's desktop. The
+  // fallback path below prints the URL to stderr, so manual flows still
+  // work in that mode.
+  if (process.env.KCODE_OAUTH_NO_BROWSER === "1") {
+    log.info("oauth", `KCODE_OAUTH_NO_BROWSER=1 — not opening browser. URL:\n${authUrl}`);
+  } else {
+    try {
+      const openCmd =
+        process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+      Bun.spawn([openCmd, authUrl], { stdout: "ignore", stderr: "ignore" });
+    } catch (err) {
+      log.warn("config", `Failed to open browser for OAuth: ${err}`);
+      console.error(`Please open this URL in your browser:\n${authUrl}`);
+    }
   }
 
   // Wait for callback


### PR DESCRIPTION
## The bug

\`src/enterprise/oauth/flow.test.ts:167\` calls \`startOAuthFlow(testConfig)\` for real. \`startOAuthFlow\` in \`flow.ts:119\` unconditionally executes:

\`\`\`ts
Bun.spawn(["xdg-open", authUrl], { stdout: "ignore", stderr: "ignore" });
\`\`\`

So every \`bun test\` run spawns \`xdg-open\` and flashes a real browser tab on the developer's desktop with the URL:

\`\`\`
http://127.0.0.1:19520/authorize?response_type=code
  &client_id=test-client-id
  &redirect_uri=http%3A%2F%2F127.0.0.1%3A19000%2Fcallback
  &scope=kcode%3Aread+kcode%3Awrite&state=jE1Eg093gJ9DxSwSat-GP6nCcKm-3YufkU6y_dAGze8
  &code_challenge=bSGdxc2FuXNqyv5bBGZ6bSDhipbwxosPLGm8MQfv_C0
  &code_challenge_method=S256
\`\`\`

Repeated \`bun test\` runs during long dev sessions (e.g. iterating on the operator-mind phases this week) opened that tab dozens of times.

## The fix

Gate the browser-open with a \`KCODE_OAUTH_NO_BROWSER\` env var:

\`\`\`ts
if (process.env.KCODE_OAUTH_NO_BROWSER === "1") {
  log.info("oauth", \`KCODE_OAUTH_NO_BROWSER=1 — not opening browser. URL:\\n\${authUrl}\`);
} else {
  try {
    const openCmd = process.platform === "darwin" ? "open" : ...;
    Bun.spawn([openCmd, authUrl], ...);
  } catch (err) {
    // existing fallback unchanged
  }
}
\`\`\`

\`flow.test.ts:beforeEach\` sets \`KCODE_OAUTH_NO_BROWSER=1\` alongside \`KCODE_HOME\`, and \`afterEach\` restores the original value. The fix only applies during the test — production OAuth flows are completely unchanged.

## Verification

\`\`\`bash
$ pgrep -af xdg-open  # before
(no matching processes)
$ bun test src/enterprise/oauth/flow.test.ts
 11 pass / 0 fail
$ pgrep -af xdg-open  # after
(no matching processes)
\`\`\`

Zero \`xdg-open\` spawned. Test still passes 11/11.

## Test plan

- [x] \`bun test src/enterprise/oauth/flow.test.ts\` — 11 / 0
- [x] \`bun test\` (full) — 6158 pass / 11 skip / 2 fail (pre-existing file-sync EMFILE flakies, unrelated)
- [x] \`bun run build\` — production binary deployed to all 3 paths, reports v2.10.47
- [x] \`pgrep xdg-open\` before and after the test — 0 processes
- [ ] Manual: verify a real OAuth flow (without the env var set) still opens the browser as expected

## Bumps version to 2.10.47