### PR TITLE
feat(platform): phase 14 — Bash cross-platform command translation + v2.10.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.49",
+  "version": "2.10.50",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/bash-platform-translate.test.ts
+++ b/src/core/bash-platform-translate.test.ts
@@ -1,0 +1,156 @@
+// Tests for phase 14 — platform-aware Bash command translation.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  clearCommandExistsCache,
+  extractFirstExecutable,
+  TRANSLATIONS,
+  translateBashCommand,
+} from "./bash-platform-translate";
+
+describe("extractFirstExecutable", () => {
+  test.each([
+    ["ls -la", "ls"],
+    ["ls", "ls"],
+    ["PORT=3000 npm run dev", "npm"],
+    ["NODE_ENV=prod node server.js", "node"],
+    ["sudo ls /root", "ls"],
+    ["nohup bash script.sh", "bash"],
+    ["exec python3 -m http.server", "python3"],
+    ["time make build", "make"],
+    // Note: we don't try to parse `sudo -u <user>` flag chains here —
+    // extractFirstExecutable stops at the first non-wrapper token.
+    // That covers ~all real model output; the few edge cases with
+    // flag-args to sudo don't need platform translation anyway.
+    ["cd /tmp && open file.html", "open"],
+    ["cd /tmp && cat x", "cat"],
+    ["cd /a && cd /b && npm run dev", "npm"],
+    ["echo 'hi' | grep hi", "grep"],
+    ["/usr/bin/open file.pdf", "open"],
+    ["/usr/local/bin/xdg-open x", "xdg-open"],
+    ["   cat foo   ", "cat"],
+  ])("extracts %p → %p", (cmd, expected) => {
+    const result = extractFirstExecutable(cmd);
+    expect(result.executable).toBe(expected);
+  });
+
+  test("returns null for empty", () => {
+    const r = extractFirstExecutable("");
+    expect(r.executable).toBeNull();
+  });
+
+  test("returns start/length that point at the executable in the command", () => {
+    const r = extractFirstExecutable("cd /tmp && open file.html");
+    expect(r.executable).toBe("open");
+    const extracted = "cd /tmp && open file.html".slice(r.start, r.start + r.length);
+    expect(extracted).toBe("open");
+  });
+
+  test("start/length point at the basename even for absolute paths", () => {
+    // Note: we return the basename as the executable, but start/length
+    // point at the full path in the original command so the rewriter
+    // replaces the whole thing.
+    const cmd = "/usr/bin/open file.pdf";
+    const r = extractFirstExecutable(cmd);
+    expect(r.executable).toBe("open");
+    const extracted = cmd.slice(r.start, r.start + r.length);
+    expect(extracted).toBe("/usr/bin/open");
+  });
+});
+
+describe("TRANSLATIONS table", () => {
+  test("includes open → xdg-open for Linux", () => {
+    const t = TRANSLATIONS.find((x) => x.from === "open" && x.to === "xdg-open");
+    expect(t).toBeDefined();
+    expect(t!.missingOn).toContain("linux");
+  });
+
+  test("includes xdg-open → open for macOS", () => {
+    const t = TRANSLATIONS.find((x) => x.from === "xdg-open" && x.to === "open");
+    expect(t).toBeDefined();
+    expect(t!.missingOn).toContain("darwin");
+  });
+
+  test("includes pbcopy and pbpaste for Linux", () => {
+    expect(TRANSLATIONS.find((x) => x.from === "pbcopy")).toBeDefined();
+    expect(TRANSLATIONS.find((x) => x.from === "pbpaste")).toBeDefined();
+  });
+});
+
+describe("translateBashCommand", () => {
+  beforeEach(() => clearCommandExistsCache());
+  afterEach(() => clearCommandExistsCache());
+
+  test("no-op on unrelated commands", () => {
+    const r = translateBashCommand("ls -la", "linux");
+    expect(r.translated).toBe(false);
+    expect(r.command).toBe("ls -la");
+  });
+
+  test("no-op on empty command", () => {
+    const r = translateBashCommand("", "linux");
+    expect(r.translated).toBe(false);
+  });
+
+  test("no-op on unknown platform", () => {
+    const r = translateBashCommand("open x.html", "win32" as NodeJS.Platform);
+    expect(r.translated).toBe(false);
+  });
+
+  test("on Linux, `open x.html` translates to `xdg-open x.html`", () => {
+    // Runtime gate: xdg-open must exist AND open must not exist.
+    // On the dev host `open` should not be in PATH (pure Linux).
+    const { which } = require("bun");
+    void which;
+    const r = translateBashCommand("open file.html", "linux");
+    // If the host has neither `open` nor `xdg-open`, skip.
+    if (!r.translated) return;
+    expect(r.translated).toBe(true);
+    expect(r.command).toBe("xdg-open file.html");
+    expect(r.note).toMatch(/open.*xdg-open/);
+  });
+
+  test("translation preserves arguments including quoted ones", () => {
+    const r = translateBashCommand(`open "My File.pdf"`, "linux");
+    if (!r.translated) return;
+    expect(r.command).toBe(`xdg-open "My File.pdf"`);
+  });
+
+  test("translation preserves env var prefixes", () => {
+    const r = translateBashCommand("DISPLAY=:0 open file.html", "linux");
+    if (!r.translated) return;
+    expect(r.command).toBe("DISPLAY=:0 xdg-open file.html");
+  });
+
+  test("translation preserves chained commands", () => {
+    const r = translateBashCommand("cd /tmp && open file.html", "linux");
+    if (!r.translated) return;
+    expect(r.command).toBe("cd /tmp && xdg-open file.html");
+  });
+
+  test("translation of pbcopy includes the full replacement invocation", () => {
+    const r = translateBashCommand("echo hi | pbcopy", "linux");
+    // pbcopy is pipe-target; extractFirstExecutable picks pbcopy (last segment)
+    if (!r.translated) return;
+    expect(r.command).toContain("xsel");
+  });
+
+  test("does not translate when the from-command exists on the host", () => {
+    // On this host `ls` exists, and we have no translation for `ls`
+    // anyway, so no-op. The real assertion is that the TRANSLATIONS
+    // table only fires for missing commands.
+    const r = translateBashCommand("ls -la", "linux");
+    expect(r.translated).toBe(false);
+  });
+
+  test("note is included only when translation happens", () => {
+    const r1 = translateBashCommand("ls -la", "linux");
+    expect(r1.note).toBeUndefined();
+
+    const r2 = translateBashCommand("open file.html", "linux");
+    if (r2.translated) {
+      expect(r2.note).toBeDefined();
+      expect(r2.note).toContain("translated");
+    }
+  });
+});

--- a/src/core/bash-platform-translate.ts
+++ b/src/core/bash-platform-translate.ts
@@ -1,0 +1,213 @@
+// KCode - Bash Platform Translation (phase 14)
+//
+// Transparently rewrites platform-specific commands that the model
+// chose for the wrong OS. Catches the pattern observed in a real
+// session where grok-4.20 tried `open file.html` on Linux, got
+// "bash: open: orden no encontrada", then burned a turn telling
+// the user to run `xdg-open` instead.
+//
+// Design constraints:
+//   - Only rewrite the FIRST executable token (leave arguments alone).
+//   - Only rewrite when (a) the original executable does NOT exist
+//     in PATH on the current host, AND (b) the translated
+//     equivalent DOES exist. This prevents surprising the user when
+//     both are available.
+//   - Preserve quoting and env-var prefixes exactly.
+//   - Emit a short, concrete note in the tool result so the model
+//     sees what was done and can learn for later calls in the same
+//     session.
+//   - Narrow scope: macOS ↔ Linux only, and only for commands where
+//     the behavior is exact or near-exact (open/xdg-open, pbcopy/
+//     xsel --clipboard --input, etc.). Do NOT touch commands like
+//     `sed`, `find`, `date`, `readlink`, `stat` where BSD and GNU
+//     flags differ — those translations would change semantics.
+
+import { spawnSync } from "node:child_process";
+import { log } from "./logger.js";
+
+// ─── Translation table ────────────────────────────────────────────
+
+export interface Translation {
+  /** The executable the model wrote. */
+  from: string;
+  /** Replacement invocation that keeps the rest of the arg list working. */
+  to: string;
+  /** Short human-readable reason for the translation report. */
+  reason: string;
+  /** Platforms on which the "from" command does NOT exist natively. */
+  missingOn: ("linux" | "darwin")[];
+}
+
+/**
+ * Narrow mapping of commands that are safe to auto-translate across
+ * macOS and Linux. Each entry has to pass two gates at runtime:
+ *   1. The `from` command must NOT be available on the host.
+ *   2. The `to` command (first token) must BE available on the host.
+ * Gate 1 prevents us from surprising a user who has installed e.g.
+ * `xdg-utils` on macOS via homebrew. Gate 2 prevents us from
+ * replacing with something that also doesn't work.
+ */
+export const TRANSLATIONS: readonly Translation[] = [
+  {
+    from: "open",
+    to: "xdg-open",
+    reason: "`open` is macOS-only — Linux uses `xdg-open` to launch the default app",
+    missingOn: ["linux"],
+  },
+  {
+    from: "pbcopy",
+    to: "xsel --clipboard --input",
+    reason: "`pbcopy` is macOS-only — Linux with xsel uses `xsel --clipboard --input`",
+    missingOn: ["linux"],
+  },
+  {
+    from: "pbpaste",
+    to: "xsel --clipboard --output",
+    reason: "`pbpaste` is macOS-only — Linux with xsel uses `xsel --clipboard --output`",
+    missingOn: ["linux"],
+  },
+  {
+    from: "xdg-open",
+    to: "open",
+    reason: "`xdg-open` is Linux-only — macOS uses `open` to launch the default app",
+    missingOn: ["darwin"],
+  },
+];
+
+// ─── Command-existence cache ──────────────────────────────────────
+//
+// Running `command -v X` once per translation per Bash call would
+// add ~10-30ms of overhead. We cache the result per-session since
+// PATH typically doesn't change mid-session.
+
+const _existsCache = new Map<string, boolean>();
+
+function commandExists(cmd: string): boolean {
+  if (_existsCache.has(cmd)) return _existsCache.get(cmd)!;
+  try {
+    // Use Bun's native spawnSync via node:child_process for consistency.
+    const result = spawnSync("sh", ["-c", `command -v ${shellEscapeArg(cmd)} >/dev/null 2>&1`], {
+      timeout: 500,
+    });
+    const exists = result.status === 0;
+    _existsCache.set(cmd, exists);
+    return exists;
+  } catch {
+    _existsCache.set(cmd, false);
+    return false;
+  }
+}
+
+/** Test helper: wipe the exists cache so individual tests stay deterministic. */
+export function clearCommandExistsCache(): void {
+  _existsCache.clear();
+}
+
+// Minimal shell-escape for a single argument (used only for the
+// sub-shell `command -v` check — not for the actual user command).
+function shellEscapeArg(arg: string): string {
+  if (/^[A-Za-z0-9_./+@=:,-]+$/.test(arg)) return arg;
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+// ─── First-executable extraction ──────────────────────────────────
+
+/**
+ * Extract the first executable token from a command string. Handles:
+ *   - Leading env-var assignments:  `PORT=3000 npm run dev` → `npm`
+ *   - `sudo`, `nohup`, `exec`, `time` prefixes → first non-prefix word
+ *   - `cd /x && <cmd>` → the command after `&&`
+ *   - Absolute paths: `/usr/bin/open x` → basename `open`
+ * Returns null when no executable can be identified.
+ */
+export function extractFirstExecutable(command: string): {
+  executable: string | null;
+  /** Byte index in the original command where the executable token starts. */
+  start: number;
+  /** Byte length of the token as it appears in the original command. */
+  length: number;
+} {
+  if (!command) return { executable: null, start: 0, length: 0 };
+
+  // If the command is a chain (cd X && Y ; Z | W), focus on the LAST
+  // meaningful segment — that's what the model actually wants to run.
+  const segments = command.split(/\s*(?:&&|\|\||;|\|)\s*/);
+  const lastSegment = segments[segments.length - 1] ?? command;
+  const segmentStart = command.lastIndexOf(lastSegment);
+
+  const trimmed = lastSegment.trimStart();
+  const leadSpaces = lastSegment.length - trimmed.length;
+  let cursor = 0;
+  // Skip env-var assignments and privilege wrappers
+  while (true) {
+    const match = trimmed.slice(cursor).match(
+      /^([A-Z_][A-Z0-9_]*=[^\s]*|sudo|nohup|exec|time|\s+)\s*/,
+    );
+    if (!match) break;
+    cursor += match[0].length;
+  }
+  // Now the next token is the executable
+  const execMatch = trimmed.slice(cursor).match(/^(\S+)/);
+  if (!execMatch) return { executable: null, start: 0, length: 0 };
+  const raw = execMatch[1]!;
+  const executable = raw.split("/").pop() ?? raw;
+  // Compute the absolute position of `raw` in the original command
+  const start = segmentStart + leadSpaces + cursor;
+  return { executable, start, length: raw.length };
+}
+
+// ─── Public API ───────────────────────────────────────────────────
+
+export interface TranslationResult {
+  /** True if the command was rewritten. */
+  translated: boolean;
+  /** The command that should actually run (translated or original). */
+  command: string;
+  /** The original command, unchanged. */
+  original: string;
+  /** Human-readable explanation of the translation, for logging. */
+  note?: string;
+}
+
+/**
+ * Apply platform translation to a Bash command. Returns the
+ * translated command + a note, or the original unchanged if no
+ * translation applies. Never throws; any failure degrades to
+ * returning the original command.
+ */
+export function translateBashCommand(
+  command: string,
+  platform: NodeJS.Platform = process.platform,
+): TranslationResult {
+  const original = command;
+  if (!command || !command.trim()) {
+    return { translated: false, command, original };
+  }
+  if (platform !== "linux" && platform !== "darwin") {
+    return { translated: false, command, original };
+  }
+  const { executable, start, length } = extractFirstExecutable(command);
+  if (!executable) return { translated: false, command, original };
+
+  for (const t of TRANSLATIONS) {
+    if (t.from !== executable) continue;
+    if (!t.missingOn.includes(platform)) continue;
+    // Gate 1: the `from` command must NOT exist on this host.
+    // If the user has installed xdg-utils on macOS, leave `open`
+    // alone so the user's explicit invocation wins.
+    if (commandExists(t.from)) continue;
+    // Gate 2: the `to` command must exist on this host.
+    const toFirstToken = t.to.split(/\s+/)[0]!;
+    if (!commandExists(toFirstToken)) continue;
+
+    // Rewrite the command: replace the executable token with `t.to`.
+    // Preserves everything else (quoting, env vars, arguments).
+    const translated = command.slice(0, start) + t.to + command.slice(start + length);
+    const note =
+      `[platform] translated \`${t.from}\` → \`${toFirstToken}\`: ${t.reason}`;
+    log.info("bash-translate", note);
+    return { translated: true, command: translated, original, note };
+  }
+
+  return { translated: false, command, original };
+}

--- a/src/tools/bash.ts
+++ b/src/tools/bash.ts
@@ -186,28 +186,50 @@ const SECURITY_TOOLS: Record<string, { category: string; timeout: number; notes:
 };
 
 /**
- * Public Bash entrypoint. Wraps the internal executor with operator-mind
- * phase-3 retry detection: if the model is about to re-issue a command
- * that just failed in the same cwd, intercept and return a STOP report
- * instead of executing. Records every attempt (success or failure) for
- * future retry detection.
+ * Public Bash entrypoint. Wraps the internal executor with:
+ *   - Phase 14: platform-aware command translation (open ↔ xdg-open,
+ *     pbcopy ↔ xsel, etc.) when the model picked a command from the
+ *     wrong OS and the target equivalent is available locally.
+ *   - Phase 3: retry detection — if the model is about to re-issue a
+ *     command that just failed in the same cwd, intercept and return
+ *     a STOP report instead of executing.
+ *   - History recording — every attempt (success or failure) is
+ *     logged for future retry detection.
  */
 export async function executeBash(input: Record<string, unknown>): Promise<ToolResult> {
-  const command = String((input as { command?: unknown }).command ?? "");
+  const originalCommand = String((input as { command?: unknown }).command ?? "");
   const cwd = process.cwd();
 
+  // Phase 14: platform translation (transparent rewrite of commands
+  // the model picked for the wrong OS).
+  let translationNote = "";
+  let effectiveCommand = originalCommand;
+  if (originalCommand) {
+    try {
+      const { translateBashCommand } = await import("../core/bash-platform-translate.js");
+      const t = translateBashCommand(originalCommand);
+      if (t.translated) {
+        effectiveCommand = t.command;
+        translationNote = t.note ?? "";
+        input = { ...input, command: t.command };
+      }
+    } catch (err) {
+      log.debug("tool", `bash-platform-translate failed (non-fatal): ${err}`);
+    }
+  }
+
   // Phase 3: detect immediate retry of a command that just failed
-  if (command) {
+  if (effectiveCommand) {
     try {
       const { detectImmediateRetry, acknowledgeRetryWarning } = await import(
         "../core/bash-spawn-history.js"
       );
-      const warning = detectImmediateRetry(command, cwd);
+      const warning = detectImmediateRetry(effectiveCommand, cwd);
       if (warning) {
         // After showing the warning once, mark it acknowledged so the
         // very next attempt (the model's actual response to the warning)
         // runs normally without seeing it again.
-        acknowledgeRetryWarning(command, cwd);
+        acknowledgeRetryWarning(effectiveCommand, cwd);
         return {
           tool_use_id: "",
           content: warning.report,
@@ -221,11 +243,23 @@ export async function executeBash(input: Record<string, unknown>): Promise<ToolR
 
   const result = await _executeBashInner(input);
 
+  // Prepend the translation note to the result content so the model
+  // sees why its `open` became `xdg-open` (or vice versa) and can
+  // learn for future calls in this session.
+  if (translationNote) {
+    result.content = `${translationNote}\n\n${result.content}`;
+  }
+
   // Record this attempt for future retry detection
-  if (command) {
+  if (effectiveCommand) {
     try {
       const { recordBashAttempt } = await import("../core/bash-spawn-history.js");
-      recordBashAttempt(command, cwd, result.is_error ?? false, String(result.content ?? ""));
+      recordBashAttempt(
+        effectiveCommand,
+        cwd,
+        result.is_error ?? false,
+        String(result.content ?? ""),
+      );
     } catch (err) {
       log.debug("tool", `bash-spawn-history record failed (non-fatal): ${err}`);
     }


### PR DESCRIPTION
## The bug from yesterday's NASA Explorer session

Model on Linux called:

\`\`\`
⚡ Bash: open nasa-explorer-refactored.html
✗ Bash failed
bash: línea 1: open: orden no encontrada
\`\`\`

\`open\` is a macOS-only command. Linux uses \`xdg-open\`. The model knew Linux was the platform (the system prompt has \`Platform: linux\` in the env section) but still picked the wrong command. It self-corrected in the final response — *"use xdg-open instead"* — but only after burning a tool call. On cloud models that's real money; on local models it's latency.

## The fix

Transparent rewrite at the tool layer. When the Bash tool gets a command whose first executable doesn't exist on the current host AND has a known cross-platform equivalent that DOES exist, swap them and prepend a one-line \`[platform] translated\` note to the tool result.

### Four gates before any rewrite

| Gate | Rule |
|---|---|
| 1 | First executable (after env-vars, sudo/nohup/exec/time, cd chains) matches a \`TRANSLATIONS\` entry |
| 2 | Current platform is in the entry's \`missingOn\` list (e.g. \`open\` on linux) |
| 3 | The \`from\` command does NOT exist in PATH on this host |
| 4 | The \`to\` command DOES exist in PATH on this host |

Gate 3 is key: if you installed \`xdg-utils\` on macOS via homebrew, your explicit \`xdg-open\` call still wins. KCode only rewrites when the original is genuinely unavailable.

### Initial translation table

Conservative — only exact/near-exact equivalents. BSD-vs-GNU flag differences for \`sed\`, \`find\`, \`date\`, \`readlink\`, \`stat\` are **NOT** translated because their semantics diverge enough to break scripts.

| from | to | missingOn |
|---|---|---|
| \`open\` | \`xdg-open\` | linux |
| \`pbcopy\` | \`xsel --clipboard --input\` | linux |
| \`pbpaste\` | \`xsel --clipboard --output\` | linux |
| \`xdg-open\` | \`open\` | darwin |

Easy to extend as we find more.

### Preservation guarantees

Translation keeps the rest of the command intact:

| Input | Output |
|---|---|
| \`open file.html\` | \`xdg-open file.html\` |
| \`open "My File.pdf"\` | \`xdg-open "My File.pdf"\` |
| \`DISPLAY=:0 open file.html\` | \`DISPLAY=:0 xdg-open file.html\` |
| \`cd /tmp && open file.html\` | \`cd /tmp && xdg-open file.html\` |
| \`echo hi \| pbcopy\` | \`echo hi \| xsel --clipboard --input\` |
| \`/usr/bin/open file.pdf\` | \`xdg-open file.pdf\` (replaces the whole absolute path token) |

### Command-existence cache

\`commandExists()\` runs \`sh -c 'command -v X'\` once per executable per session and memoizes. PATH doesn't typically change mid-session so repeated calls are ~0ms.

## End-to-end verification

\`\`\`
=== case 1: the exact failing command ===
translated: true
command: xdg-open nasa-explorer-refactored.html
note: [platform] translated \`open\` → \`xdg-open\`: \`open\` is macOS-only — Linux uses \`xdg-open\` to launch the default app

=== case 2: with env var + chain ===
translated: true
command: cd /tmp && xdg-open file.html

=== case 3: pbcopy ===
translated: true
command: echo hello | xsel --clipboard --input

=== case 4: unknown command no-op ===
translated: false
\`\`\`

## Files

| | |
|---|---|
| \`src/core/bash-platform-translate.ts\` | 213-line module: translation table, existence cache, executable extractor, translator |
| \`src/core/bash-platform-translate.test.ts\` | 31 unit cases |
| \`src/tools/bash.ts\` | Wire into public \`executeBash\` wrapper before phase-3 retry check |

## Test plan

- [x] \`bun test src/core/bash-platform-translate.test.ts\` — **31 / 0**
- [x] \`bun test\` (full) — **6240 pass / 11 skip / 3 fail** (the 3 fails are all pre-existing environmental: 2 file-sync EMFILE + 1 MeshNode port-in-use)
- [x] \`bun run build\` — production binary deployed to all 3 paths, reports v2.10.50
- [x] **End-to-end translation**: the exact \`open nasa-explorer-refactored.html\` command becomes \`xdg-open nasa-explorer-refactored.html\` with a clear note
- [x] **No-op preservation**: \`ls -la\`, unknown commands, empty strings all pass through unchanged
- [x] **Argument preservation**: quoted args, env vars, chains, absolute paths all preserved correctly
- [ ] **Manual smoke**: re-run a session where the model calls \`open X\`, verify the command runs successfully and the tool result includes the platform note

## Token economy impact

Before: model calls \`open X\` → error → model self-corrects in next turn (another ~100 tokens of reasoning + a new tool call). 2 tool calls minimum, plus retry-guard state pollution.

After: KCode rewrites the command silently, runs \`xdg-open X\`, returns success with a single-line note. 1 tool call, zero model correction.

On cloud this matters per-call. On local this matters per-latency.

## Bumps version to 2.10.50