### PR TITLE
fix(operator-recovery): phase 16 — reactive not proactive + v2.10.52

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.51",
+  "version": "2.10.52",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/operator-recovery.test.ts
+++ b/src/core/operator-recovery.test.ts
@@ -32,6 +32,26 @@ describe("buildOperatorRecoveryGuidance", () => {
     const out = buildOperatorRecoveryGuidance();
     expect(out).toContain("You are the operator. Operate.");
   });
+
+  // Phase 16: recovery must be reactive, not proactive.
+  test("phase 16: contains the reactive-not-proactive rule", () => {
+    const out = buildOperatorRecoveryGuidance();
+    expect(out).toMatch(/reactive, not proactive/i);
+  });
+
+  test("phase 16: warns against speculative preemptive pkill", () => {
+    const out = buildOperatorRecoveryGuidance();
+    expect(out).toMatch(/speculatively/i);
+    expect(out).toContain("pkill");
+    // The rule should explicitly name the pkill-before-failure antipattern
+    expect(out).toMatch(/before any tool has failed is[\s\S]*NOT helpful/i);
+  });
+
+  test("phase 16: tells the model what to do when no tool has failed", () => {
+    const out = buildOperatorRecoveryGuidance();
+    expect(out).toMatch(/do the actual task directly/i);
+    expect(out).toMatch(/only after seeing the failure message/i);
+  });
 });
 
 describe("inotify refusal AUTHORIZED RECOVERY language", () => {

--- a/src/core/system-prompt-layers.ts
+++ b/src/core/system-prompt-layers.ts
@@ -495,7 +495,18 @@ The block follows this shape:
         <command>
     Step 3 — retry the original command.
 
-Your obligation when you see one:
+**CRITICAL — recovery is reactive, not proactive.** Only run an
+AUTHORIZED RECOVERY command AFTER a tool call has actually failed with
+the specific error that the recovery addresses. Do NOT run recovery
+commands speculatively "just in case" at the start of a task. A fresh
+\`pkill -9 -f 'next-server|vite|nodemon'\` before any tool has failed is
+NOT helpful — it is wasted tool calls, wasted tokens, and it may kill
+legitimate dev servers the user is actively using in another terminal.
+If no tool has failed yet, do the actual task directly. Run recovery
+ONLY after seeing the failure message that authorized it.
+
+Your obligation when you see an AUTHORIZED RECOVERY block in a failed
+tool result:
 
 1. **Execute the steps yourself, in order.** Do not paste them into a
    message for the user. Do not ask "should I run this?" The block


### PR DESCRIPTION
## Minor regression from the previous phases

Last NASA Explorer session was objectively the cleanest yet — 2 tool calls total, no Edit retry loops, no fabrication, no false completion claims, no AUDIT_REPORT.md confusion, task completed honestly in a single Write. **But** one minor regression showed up:

\`\`\`
⚡ Bash: pkill -9 -u $(whoami) -f 'next-server|vite|bun --watch|nodemon' || echo "No proc"
  ✓ PID: 488382 (3.0s)
⚡ Write: nasa-explorer.html
  ✓ Created nasa-explorer.html (899 lines)
\`\`\`

The model's **very first** tool call was a \`pkill\`. Nothing had failed yet. The task was "create a static HTML file" — no inotify saturation, no port collision, no leaked dev servers to clean up. The pkill was 100% ceremonial: 3s of wall time + ~50 output tokens wasted.

## Root cause

Phase 6's operator-recovery section taught the model to run AUTHORIZED RECOVERY commands when a tool fails. grok-4.20 generalized that into "always clean up first, just in case" — pre-emptive cleanup as standard prep. That directly contradicts the **token economy** principle the user explicitly stated ("ahorrar tokens ya sea de un modelo cloud o local").

## The fix

Add an explicit **reactive-not-proactive** rule at the TOP of the operator-recovery guidance block, before the numbered obligations. New rule spells out:

> **CRITICAL — recovery is reactive, not proactive.** Only run an AUTHORIZED RECOVERY command AFTER a tool call has actually failed with the specific error that the recovery addresses. Do NOT run recovery commands speculatively "just in case" at the start of a task. A fresh \`pkill -9 -f 'next-server|vite|nodemon'\` before any tool has failed is NOT helpful — it is wasted tool calls, wasted tokens, and it may kill legitimate dev servers the user is actively using in another terminal. If no tool has failed yet, do the actual task directly. Run recovery ONLY after seeing the failure message that authorized it.

The five numbered obligations below this rule stay unchanged — they fire when a real failure happens, and they are still correct. The block ending ("You are the operator. Operate.") stays too.

## Token-economy impact

Per-session savings (extrapolating from the observed session):
- 1 unnecessary Bash tool call avoided (pkill + its 3s wait)
- ~50 output tokens from the pkill "PID: N (3.0s)" result that never enters useful context
- ~30 input tokens from the new rule added to system prompt per turn

Break-even: after 1 session where the model would otherwise have run a speculative pkill. Net positive thereafter. Also prevents the harder-to-quantify "killed a legitimate dev server the user was using in another tmux pane" risk.

## Tests

3 new assertions in \`operator-recovery.test.ts\`:

\`\`\`ts
test("phase 16: contains the reactive-not-proactive rule", () => {
  expect(out).toMatch(/reactive, not proactive/i);
});

test("phase 16: warns against speculative preemptive pkill", () => {
  expect(out).toMatch(/speculatively/i);
  expect(out).toMatch(/before any tool has failed is[\s\S]*NOT helpful/i);
});

test("phase 16: tells the model what to do when no tool has failed", () => {
  expect(out).toMatch(/do the actual task directly/i);
  expect(out).toMatch(/only after seeing the failure message/i);
});
\`\`\`

## Test plan

- [x] \`bun test src/core/operator-recovery.test.ts\` — **9 / 0** (was 6, added 3 for phase 16)
- [x] \`bun test\` (full) — **6266 pass / 11 skip / 0 fail**
- [x] \`bun run build\` — production binary deployed to all 3 paths, reports v2.10.52
- [ ] **Manual smoke**: re-run the NASA Explorer session, verify the model goes directly to Write without running a pre-emptive pkill

## Bumps version to 2.10.52