### PR TITLE
feat(write-guards): phase 17 — skeleton + sibling proliferation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.52",
+  "version": "2.10.53",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/write-guards.test.ts
+++ b/src/core/write-guards.test.ts
@@ -1,0 +1,215 @@
+// Tests for phase 17 — skeleton detection + sibling proliferation guards
+// on the Write tool.
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildProliferationReport,
+  buildSkeletonReport,
+  checkDegradation,
+  detectSiblingProliferation,
+  detectSkeletonContent,
+} from "./write-guards";
+
+describe("detectSkeletonContent", () => {
+  test("fires on NASA Explorer-style skeleton (mixed stubs)", () => {
+    const content = `
+      const DATA = {
+        apod: { /* ... */ },
+        rovers: [ /* Curiosity, Perseverance, Opportunity data */ ],
+        earthImages: [ /* EPIC images */ ],
+        launches: [ /* Upcoming launches */ ]
+      };
+
+      function hideModals() { /* ... */ }
+      function showModal(title, html, actions = '') { /* reusable modal system */ }
+
+      <!-- ==================== EARTH & LIVE & FACTS (condensed for brevity) ==================== -->
+      <!-- (Sections for Earth, Live, Quick Facts, Footer, and Modals follow the same clean pattern as above) -->
+    `;
+    const v = detectSkeletonContent(content);
+    expect(v.isSkeleton).toBe(true);
+    expect(v.hitNames.length).toBeGreaterThanOrEqual(2);
+    expect(v.totalOccurrences).toBeGreaterThanOrEqual(5);
+  });
+
+  test("does not fire on real code with ordinary comments", () => {
+    const content = `
+      // Main entry point
+      function init() {
+        const config = loadConfig();
+        /* TOCTOU-safe: we re-check after fd open */
+        return config;
+      }
+
+      /**
+       * Handles incoming requests.
+       * Returns a parsed result.
+       */
+      function handle(req) {
+        return parse(req);
+      }
+    `;
+    const v = detectSkeletonContent(content);
+    expect(v.isSkeleton).toBe(false);
+  });
+
+  test("fires on 3+ empty function bodies in a row", () => {
+    const content = `
+      function renderMarsGallery(index) { /* ... */ }
+      function renderEarthGrid() { /* ... */ }
+      function renderLaunches() { /* ... */ }
+    `;
+    const v = detectSkeletonContent(content);
+    expect(v.isSkeleton).toBe(true);
+  });
+
+  test("fires on condensed-for-brevity HTML comment + one more signal", () => {
+    const content = `
+      <section>real content</section>
+      <!-- condensed for brevity -->
+      <!-- follow the same pattern as above -->
+    `;
+    const v = detectSkeletonContent(content);
+    expect(v.isSkeleton).toBe(true);
+  });
+
+  test("single ordinary /* ... */ stub alone does not fire", () => {
+    const content = `
+      function f() {
+        return 42;
+      }
+      // one TODO-style note
+      // ...
+    `;
+    const v = detectSkeletonContent(content);
+    expect(v.isSkeleton).toBe(false);
+  });
+});
+
+describe("detectSiblingProliferation", () => {
+  test("flags foo-refactored.html when foo.html exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kcode-prolif-"));
+    try {
+      writeFileSync(join(dir, "nasa-explorer.html"), "<html></html>");
+      const v = detectSiblingProliferation(join(dir, "nasa-explorer-refactored.html"));
+      expect(v.isProliferation).toBe(true);
+      expect(v.variant).toBe("refactored");
+      expect(v.existingSibling).toBe(join(dir, "nasa-explorer.html"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("flags foo-organized.html when foo.html exists", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kcode-prolif-"));
+    try {
+      writeFileSync(join(dir, "nasa-explorer.html"), "<html></html>");
+      const v = detectSiblingProliferation(join(dir, "nasa-explorer-organized.html"));
+      expect(v.isProliferation).toBe(true);
+      expect(v.variant).toBe("organized");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does NOT flag when the base file does not exist", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kcode-prolif-"));
+    try {
+      const v = detectSiblingProliferation(join(dir, "nasa-explorer-refactored.html"));
+      expect(v.isProliferation).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does NOT flag non-variant suffixes (e.g. foo-utils.ts)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kcode-prolif-"));
+    try {
+      writeFileSync(join(dir, "foo.ts"), "export {};");
+      const v = detectSiblingProliferation(join(dir, "foo-utils.ts"));
+      expect(v.isProliferation).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does NOT flag a file with no hyphen (regular new file)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kcode-prolif-"));
+    try {
+      const v = detectSiblingProliferation(join(dir, "newfile.html"));
+      expect(v.isProliferation).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("flags underscore variant (foo_refactored.py when foo.py exists)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kcode-prolif-"));
+    try {
+      writeFileSync(join(dir, "parser.py"), "pass");
+      const v = detectSiblingProliferation(join(dir, "parser_refactored.py"));
+      expect(v.isProliferation).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("checkDegradation", () => {
+  test("flags when original file has significantly more lines", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kcode-degrade-"));
+    try {
+      const big = Array.from({ length: 100 }, (_, i) => `line ${i}`).join("\n");
+      writeFileSync(join(dir, "nasa.html"), big);
+      const tinyContent = "line 1\nline 2\nline 3\n";
+      const d = checkDegradation(join(dir, "nasa-refactored.html"), tinyContent);
+      expect(d).not.toBeNull();
+      expect(d!.originalLines).toBe(100);
+      expect(d!.newLines).toBe(4);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does NOT flag when new content is similar or larger", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kcode-degrade-"));
+    try {
+      const small = "line 1\nline 2\n";
+      writeFileSync(join(dir, "nasa.html"), small);
+      const similarContent = "line 1\nline 2\nline 3\n";
+      const d = checkDegradation(join(dir, "nasa-refactored.html"), similarContent);
+      expect(d).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("report builders", () => {
+  test("skeleton report contains actionable language", () => {
+    const v = detectSkeletonContent(
+      `function a() { /* ... */ }\nfunction b() { /* ... */ }\nrovers: [ /* data */ ]`,
+    );
+    const report = buildSkeletonReport("/tmp/foo.html", v);
+    expect(report).toContain("BLOCKED");
+    expect(report).toContain("SKELETON");
+    expect(report).toContain("NOT function");
+    expect(report).toContain("FULL implementation");
+    expect(report).toContain("Do NOT tell the user the file was created");
+  });
+
+  test("proliferation report names both files and suggests Edit", () => {
+    const report = buildProliferationReport("/tmp/foo-refactored.html", {
+      isProliferation: true,
+      existingSibling: "/tmp/foo.html",
+      variant: "refactored",
+    });
+    expect(report).toContain("BLOCKED");
+    expect(report).toContain("/tmp/foo.html");
+    expect(report).toContain("foo-refactored.html");
+    expect(report).toContain("Edit");
+  });
+});

--- a/src/core/write-guards.ts
+++ b/src/core/write-guards.ts
@@ -1,0 +1,301 @@
+// KCode - Write guards (phase 17)
+//
+// Two post-Read / pre-Write checks to catch the failure modes we saw
+// in the NASA Explorer session:
+//
+//   1. Skeleton degradation — the model writes a smaller file full of
+//      placeholder stubs (`{ /* ... */ }`, `[ /* data */ ]`,
+//      `<!-- condensed for brevity -->`) and declares it "refactored"
+//      or "organized". Phase 15 (claim-reality) doesn't catch this
+//      because the Write succeeds with is_error: false — the file
+//      IS written, just with garbage content.
+//
+//   2. Sibling proliferation — the model writes
+//      `nasa-explorer-refactored.html` and then
+//      `nasa-explorer-organized.html` as siblings of the original
+//      `nasa-explorer.html` instead of editing the original in place.
+//      Three files where one was asked for.
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { basename, dirname, extname, join } from "node:path";
+
+// ─── Skeleton detection ──────────────────────────────────────────
+
+interface SkeletonHit {
+  name: string;
+  snippet: string;
+}
+
+/**
+ * Regex signatures that strongly indicate placeholder stubs. Each entry
+ * is a single pattern — if it matches, that's one hit. We deliberately
+ * keep the patterns narrow so we don't flag real comments.
+ */
+const SKELETON_PATTERNS: Array<{ name: string; regex: RegExp }> = [
+  // function body containing only a placeholder comment:
+  //   function foo() { /* ... */ }
+  //   function bar(x, y) { /* reusable modal system */ }
+  {
+    name: "empty-fn-body-with-placeholder",
+    regex: /\)\s*(?:=>\s*)?\{\s*\/\*[^{}]{1,120}\*\/\s*\}/g,
+  },
+  // array literal containing only a placeholder comment:
+  //   rovers: [ /* Curiosity, Perseverance, Opportunity data */ ]
+  //   earthImages: [ /* EPIC images */ ]
+  {
+    name: "array-with-placeholder-comment",
+    regex: /\[\s*\/\*[^\[\]{}]{3,120}\*\/\s*\]/g,
+  },
+  // object literal containing only a placeholder comment:
+  //   apod: { /* ... */ }
+  {
+    name: "object-with-placeholder-comment",
+    regex: /:\s*\{\s*\/\*[^{}]{1,120}\*\/\s*\}/g,
+  },
+  // HTML "condensed for brevity" style stubs
+  {
+    name: "condensed-for-brevity",
+    regex: /<!--[^>]*\b(?:condensed\s+for\s+brevity|for\s+brevity)\b[^>]*-->/gi,
+  },
+  // HTML "same pattern as above / follow the same" stubs
+  {
+    name: "follow-same-pattern",
+    regex: /<!--[^>]*\b(?:follow\s+the\s+same|same\s+(?:clean\s+)?pattern\s+as\s+above)\b[^>]*-->/gi,
+  },
+  // bare placeholder comment lines like `/* ... */` sitting alone
+  {
+    name: "bare-ellipsis-comment",
+    regex: /^\s*\/\*\s*\.\.\.\s*\*\/\s*$/gm,
+  },
+  // ellipsis-only single-line comments used as body stubs
+  //   // ...
+  //   # ...
+  {
+    name: "ellipsis-line-comment",
+    regex: /^\s*(?:\/\/|#)\s*\.\.\.\s*$/gm,
+  },
+];
+
+export interface SkeletonVerdict {
+  /** Whether the content has enough placeholder signals to be considered a skeleton. */
+  isSkeleton: boolean;
+  /** Distinct signature names that matched (deduped). */
+  hitNames: string[];
+  /** Total number of individual placeholder occurrences across all patterns. */
+  totalOccurrences: number;
+  /** Up to 5 sample snippets to show the model what triggered the check. */
+  samples: SkeletonHit[];
+}
+
+export function detectSkeletonContent(content: string): SkeletonVerdict {
+  const hitNames: string[] = [];
+  const samples: SkeletonHit[] = [];
+  let totalOccurrences = 0;
+
+  for (const { name, regex } of SKELETON_PATTERNS) {
+    regex.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    let sawOne = false;
+    while ((m = regex.exec(content)) !== null) {
+      totalOccurrences++;
+      sawOne = true;
+      if (samples.length < 5) {
+        const snippet = m[0].replace(/\s+/g, " ").trim().slice(0, 100);
+        samples.push({ name, snippet });
+      }
+    }
+    if (sawOne) hitNames.push(name);
+  }
+
+  // Fire when ≥2 DISTINCT signatures match, OR ≥3 total occurrences of
+  // any one signature. Distinct signatures catches mixed stubs (the
+  // NASA Explorer case: empty-fn-body + array-placeholder +
+  // condensed-for-brevity). Total-occurrence threshold catches a file
+  // that stubs every function the same way.
+  const isSkeleton = hitNames.length >= 2 || totalOccurrences >= 3;
+  return { isSkeleton, hitNames, totalOccurrences, samples };
+}
+
+// ─── Sibling proliferation detection ─────────────────────────────
+
+/**
+ * Suffix words that indicate a "variant" filename — when one of these
+ * appears after a hyphen or underscore just before the extension, the
+ * model is probably writing a copy instead of editing the original.
+ */
+const VARIANT_SUFFIXES = new Set([
+  "refactored",
+  "refactor",
+  "organized",
+  "organised",
+  "cleaned",
+  "cleanup",
+  "fixed",
+  "updated",
+  "improved",
+  "new",
+  "copy",
+  "final",
+  "backup",
+  "old",
+  "v2",
+  "v3",
+  "rewrite",
+  "rewritten",
+  "revised",
+  "improved2",
+]);
+
+export interface ProliferationVerdict {
+  /** True if target is `<base>-<variant>.<ext>` AND `<base>.<ext>` already exists. */
+  isProliferation: boolean;
+  /** The existing sibling the model should edit instead. */
+  existingSibling: string | null;
+  /** Variant suffix that triggered the check (e.g. "refactored"). */
+  variant: string | null;
+}
+
+export function detectSiblingProliferation(filePath: string): ProliferationVerdict {
+  const ext = extname(filePath);
+  if (!ext) return { isProliferation: false, existingSibling: null, variant: null };
+
+  const dir = dirname(filePath);
+  const name = basename(filePath, ext);
+
+  // Split on the last hyphen or underscore. If the trailing segment
+  // is a variant suffix and what's left is non-empty, that's a
+  // candidate sibling.
+  const m = name.match(/^(.+)[-_]([A-Za-z0-9]+)$/);
+  if (!m) return { isProliferation: false, existingSibling: null, variant: null };
+
+  const baseName = m[1]!;
+  const suffix = m[2]!.toLowerCase();
+  if (!VARIANT_SUFFIXES.has(suffix)) {
+    return { isProliferation: false, existingSibling: null, variant: null };
+  }
+
+  const siblingPath = join(dir, `${baseName}${ext}`);
+  try {
+    if (existsSync(siblingPath) && statSync(siblingPath).isFile()) {
+      return { isProliferation: true, existingSibling: siblingPath, variant: suffix };
+    }
+  } catch {
+    /* dir not readable — treat as no sibling */
+  }
+  return { isProliferation: false, existingSibling: null, variant: null };
+}
+
+// ─── Report builders ─────────────────────────────────────────────
+
+export function buildSkeletonReport(filePath: string, verdict: SkeletonVerdict): string {
+  const lines: string[] = [];
+  lines.push(`BLOCKED — FILE NOT CREATED: "${basename(filePath)}" looks like a SKELETON.`);
+  lines.push("");
+  lines.push(
+    `Your content contains ${verdict.totalOccurrences} placeholder stub(s) across ` +
+      `${verdict.hitNames.length} distinct signature(s):`,
+  );
+  for (const h of verdict.samples) {
+    lines.push(`  [${h.name}] ${h.snippet}`);
+  }
+  lines.push("");
+  lines.push(
+    `Placeholder stubs like \`{ /* ... */ }\`, \`[ /* data */ ]\`, and`,
+  );
+  lines.push(
+    `\`<!-- condensed for brevity -->\` mean the file will NOT function. Writing`,
+  );
+  lines.push(
+    `a skeleton and declaring it "refactored" or "organized" is a completion`,
+  );
+  lines.push(`hallucination — the user will open the file and see a broken stub.`);
+  lines.push("");
+  lines.push(`You MUST do ONE of:`);
+  lines.push(
+    `  a) Re-issue the Write with the FULL implementation inlined — no`,
+  );
+  lines.push(`     \`/* ... */\` placeholders, no \`<!-- condensed -->\` comments.`);
+  lines.push(
+    `  b) Use Edit on the ORIGINAL file to make a targeted change instead`,
+  );
+  lines.push(`     of rewriting from scratch.`);
+  lines.push("");
+  lines.push(
+    `Do NOT tell the user the file was created. It was not.`,
+  );
+  return lines.join("\n");
+}
+
+export function buildProliferationReport(
+  filePath: string,
+  verdict: ProliferationVerdict,
+): string {
+  const lines: string[] = [];
+  lines.push(`BLOCKED — FILE NOT CREATED: "${basename(filePath)}" would proliferate siblings.`);
+  lines.push("");
+  lines.push(
+    `"${verdict.existingSibling}" already exists. Creating "${basename(filePath)}"`,
+  );
+  lines.push(
+    `alongside it leaves two divergent copies — the user will not know which`,
+  );
+  lines.push(`one is authoritative, and the next session will find three.`);
+  lines.push("");
+  lines.push(`You MUST do ONE of:`);
+  lines.push(
+    `  a) Use Edit or MultiEdit on "${verdict.existingSibling}" to make the`,
+  );
+  lines.push(`     changes in place.`);
+  lines.push(
+    `  b) Use Write on "${verdict.existingSibling}" directly to replace its`,
+  );
+  lines.push(`     contents (NOT a new ${verdict.variant ?? "variant"} copy).`);
+  lines.push("");
+  lines.push(
+    `If the user explicitly asked for a separate file under a different name,`,
+  );
+  lines.push(
+    `pick a name that does NOT look like a variant of an existing file.`,
+  );
+  return lines.join("\n");
+}
+
+// ─── Degradation check (optional strengthener) ───────────────────
+
+/**
+ * When skeleton detection fires, check whether the same-basename file
+ * already exists in the target directory — if it does and has MORE
+ * lines than the new content, that's strong evidence the model is
+ * degrading an existing implementation.
+ */
+export function checkDegradation(
+  filePath: string,
+  newContent: string,
+): { original: string; originalLines: number; newLines: number } | null {
+  const dir = dirname(filePath);
+  const ext = extname(filePath);
+  const name = basename(filePath, ext);
+
+  // Strip any variant suffix to find the original
+  const m = name.match(/^(.+)[-_]([A-Za-z0-9]+)$/);
+  const candidates: string[] = [filePath];
+  if (m && VARIANT_SUFFIXES.has(m[2]!.toLowerCase())) {
+    candidates.push(join(dir, `${m[1]}${ext}`));
+  }
+
+  for (const candidate of candidates) {
+    try {
+      if (!existsSync(candidate)) continue;
+      if (candidate === filePath) continue; // skip self
+      const original = readFileSync(candidate, "utf-8");
+      const originalLines = original.split("\n").length;
+      const newLines = newContent.split("\n").length;
+      if (originalLines > newLines * 1.3) {
+        return { original: candidate, originalLines, newLines };
+      }
+    } catch {
+      /* unreadable — skip */
+    }
+  }
+  return null;
+}

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -391,6 +391,43 @@ async function _executeWriteInner(input: Record<string, unknown>): Promise<ToolR
     }
   }
 
+  // Phase 17: skeleton + sibling proliferation guards.
+  // Run AFTER audit guards (audit reports are allowed to be long prose
+  // with their own content validation) but BEFORE sensitive-file /
+  // symlink checks so a real write attempt never has placeholder
+  // content land on disk.
+  if (!isAuditFilename(file_path)) {
+    const {
+      detectSiblingProliferation,
+      buildProliferationReport,
+      detectSkeletonContent,
+      buildSkeletonReport,
+      checkDegradation,
+    } = await import("../core/write-guards.js");
+
+    const proliferation = detectSiblingProliferation(file_path);
+    if (proliferation.isProliferation) {
+      return {
+        tool_use_id: "",
+        content: buildProliferationReport(file_path, proliferation),
+        is_error: true,
+      };
+    }
+
+    const skeleton = detectSkeletonContent(content);
+    if (skeleton.isSkeleton) {
+      let report = buildSkeletonReport(file_path, skeleton);
+      const degradation = checkDegradation(file_path, content);
+      if (degradation) {
+        report +=
+          `\n\nDegradation detected: "${degradation.original}" has ` +
+          `${degradation.originalLines} lines; your new content has ` +
+          `${degradation.newLines}. You are shrinking a working file into a stub.`;
+      }
+      return { tool_use_id: "", content: report, is_error: true };
+    }
+  }
+
   // Block writes to sensitive files
   const isSensitive = SENSITIVE_PATTERNS.some((p) => p.test(file_path));
   if (isSensitive) {


### PR DESCRIPTION
## Summary

Two new Write-tool guards that catch failure modes phase 15 (claim-reality) cannot:

1. **Skeleton degradation** — model writes a file full of placeholder stubs (`{ /* ... */ }`, `[ /* data */ ]`, `<!-- condensed for brevity -->`) and declares it "refactored/organized". Write succeeds with `is_error: false` so claim-reality sees a successful mutation and stays silent — but the file is garbage.
2. **Sibling proliferation** — model writes `foo-refactored.html` next to an existing `foo.html` instead of editing in place. Three files where one was asked for.

### Detection

- `detectSkeletonContent` — fires on ≥2 distinct placeholder signatures OR ≥3 total occurrences. Signatures cover empty function bodies, array/object literals with only a comment, `condensed for brevity`, `follow the same pattern`, bare `/* ... */` and `// ...` stubs.
- `detectSiblingProliferation` — matches `<base>-<variant>.<ext>` where variant ∈ {refactored, organized, cleaned, fixed, v2, copy, final, backup, old, ...} and `<base>.<ext>` already exists in the same dir.
- `checkDegradation` (strengthener) — when skeleton fires, compares new line count against an original same-basename file; adds a degradation note when new is <77% of original.

Both guards run in `src/tools/write.ts` BEFORE the atomic write, AFTER audit guards (audit reports have their own content validation and are allowed to be long prose). Blocked writes return `is_error: true` with actionable guidance telling the model to re-submit the full implementation or use Edit on the original.

## Test plan

- [x] `bun test src/core/write-guards.test.ts` — 15 pass
- [x] `bun test src/tools/write.test.ts` — 10 pass (no regression)
- [x] NASA Explorer reproduction content triggers both detectors
- [x] Ordinary code with real comments does not fire