### PR TITLE
feat(reality-check): phase 18 — claim/mutation mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.53",
+  "version": "2.10.54",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/claim-reality-check.test.ts
+++ b/src/core/claim-reality-check.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  buildClaimMismatchReminder,
   buildRealityCheckReminder,
   checkClaimReality,
   countSuccessfulMutations,
@@ -238,6 +239,7 @@ describe("buildRealityCheckReminder", () => {
   test("contains [REALITY CHECK] header", () => {
     const reminder = buildRealityCheckReminder({
       isHallucinatedCompletion: true,
+      isClaimMutationMismatch: false,
       claims: ["Updated version to v2.3", "Changed 2025 to 2026"],
       successfulMutations: 0,
       mutatingToolNames: [],
@@ -248,6 +250,7 @@ describe("buildRealityCheckReminder", () => {
   test("lists the specific claims verbatim", () => {
     const reminder = buildRealityCheckReminder({
       isHallucinatedCompletion: true,
+      isClaimMutationMismatch: false,
       claims: ["Updated version to v2.3", "Changed 2025 to 2026"],
       successfulMutations: 0,
       mutatingToolNames: [],
@@ -259,6 +262,7 @@ describe("buildRealityCheckReminder", () => {
   test("explains common causes (Edit fail, GrepReplace no match, sed no-op)", () => {
     const reminder = buildRealityCheckReminder({
       isHallucinatedCompletion: true,
+      isClaimMutationMismatch: false,
       claims: ["x"],
       successfulMutations: 0,
       mutatingToolNames: [],
@@ -271,11 +275,132 @@ describe("buildRealityCheckReminder", () => {
   test("offers two concrete resolutions (a/b)", () => {
     const reminder = buildRealityCheckReminder({
       isHallucinatedCompletion: true,
+      isClaimMutationMismatch: false,
       claims: ["x"],
       successfulMutations: 0,
       mutatingToolNames: [],
     });
     expect(reminder).toMatch(/a\)\s+actually make/i);
     expect(reminder).toMatch(/b\)\s+retract/i);
+  });
+});
+
+// ─── Phase 18: claim/mutation mismatch ──────────────────────────
+
+/**
+ * Build a messages array with N successful Edit tool results. Each Edit
+ * is represented as an assistant tool_use + matching user tool_result
+ * containing a success marker ("Edited" / "replacements") so that
+ * countSuccessfulMutations counts them as real mutations.
+ */
+function buildMessagesWithEdits(editCount: number, userText = "refactor"): Message[] {
+  const messages: Message[] = [{ role: "user", content: userText }];
+  for (let i = 0; i < editCount; i++) {
+    const id = `edit_${i}`;
+    messages.push({
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id,
+          name: "Edit",
+          input: { file_path: `/tmp/f.html`, old_string: "a", new_string: "b" },
+        } as unknown as never,
+      ],
+    });
+    messages.push({
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: id,
+          is_error: false,
+          content: `Edited /tmp/f.html (1 replacement, +1 lines)`,
+        } as unknown as never,
+      ],
+    });
+  }
+  return messages;
+}
+
+describe("phase 18: claim/mutation mismatch", () => {
+  test("fires when many claims but only 2 mutations", () => {
+    const messages = buildMessagesWithEdits(2);
+    // Mirror the NASA Explorer session: lots of padding around 2 real Edits
+    const text = `
+      Refactor complete.
+      Updated the star-bg animation to be smoother.
+      Updated the nav-link active state styling.
+      Updated the section comments throughout.
+      Changed the counter animation to be performant.
+      Changed the modal handling to use a single function.
+      Added a new keyboard support layer.
+      Added the section-header utility class.
+      Fixed the responsive layout edge case.
+    `;
+    const v = checkClaimReality(text, messages);
+    expect(v.isHallucinatedCompletion).toBe(false);
+    expect(v.isClaimMutationMismatch).toBe(true);
+    expect(v.successfulMutations).toBe(2);
+    expect(v.claims.length).toBeGreaterThanOrEqual(6);
+  });
+
+  test("does NOT fire when claims match mutations 1:1", () => {
+    const messages = buildMessagesWithEdits(5);
+    const text = `
+      Updated the version header.
+      Changed the hardcoded date to 2026.
+      Replaced the red-400 class throughout.
+      Fixed the typo in the comment block.
+      Added the new import statement.
+    `;
+    const v = checkClaimReality(text, messages);
+    expect(v.isClaimMutationMismatch).toBe(false);
+  });
+
+  test("does NOT fire when below claim threshold (few claims, 1 edit)", () => {
+    const messages = buildMessagesWithEdits(1);
+    const text = `Updated the config value. Changed the port number.`;
+    const v = checkClaimReality(text, messages);
+    expect(v.isClaimMutationMismatch).toBe(false);
+  });
+
+  test("does NOT fire when isHallucinatedCompletion already fired", () => {
+    // 0 mutations, 5 claims — hallucinatedCompletion takes precedence
+    const messages: Message[] = [{ role: "user", content: "refactor" }];
+    const text = `
+      Updated the config file.
+      Changed the port number.
+      Replaced the URL constant.
+      Fixed the startup typo.
+      Added a new import.
+    `;
+    const v = checkClaimReality(text, messages);
+    expect(v.isHallucinatedCompletion).toBe(true);
+    expect(v.isClaimMutationMismatch).toBe(false);
+  });
+
+  test("mismatch reminder names the ratio and lists claims", () => {
+    const reminder = buildClaimMismatchReminder({
+      isHallucinatedCompletion: false,
+      isClaimMutationMismatch: true,
+      claims: [
+        "Updated star-bg",
+        "Added nav-link.active",
+        "Changed counter animation",
+        "Replaced keyboard handler",
+        "Fixed modal close",
+        "Added section-header utility",
+      ],
+      successfulMutations: 2,
+      mutatingToolNames: ["Edit", "Edit"],
+    });
+    expect(reminder).toContain("CLAIM/MUTATION MISMATCH");
+    expect(reminder).toContain("6 distinct change claims");
+    expect(reminder).toContain("2 mutation tool call");
+    expect(reminder).toMatch(/padding/i);
+    expect(reminder).toMatch(/a\)/);
+    expect(reminder).toMatch(/b\)/);
+    expect(reminder).toContain("Updated star-bg");
   });
 });

--- a/src/core/claim-reality-check.ts
+++ b/src/core/claim-reality-check.ts
@@ -227,6 +227,12 @@ export function countSuccessfulMutations(messages: Message[]): {
 export interface RealityVerdict {
   /** True if the assistant text claims changes but no tool actually made any. */
   isHallucinatedCompletion: boolean;
+  /**
+   * Phase 18: true when the claim-to-mutation ratio is suspicious — model
+   * made many distinct claims but only a few mutations landed. Weaker
+   * signal than isHallucinatedCompletion, triggers a softer reminder.
+   */
+  isClaimMutationMismatch: boolean;
   claims: string[];
   successfulMutations: number;
   mutatingToolNames: string[];
@@ -245,8 +251,20 @@ export function checkClaimReality(
   const isHallucinatedCompletion =
     successful === 0 &&
     (claims.length >= 2 || (hasCompletionMarker && claims.length >= 1));
+  // Phase 18: mismatch fires when there ARE real mutations but the claim
+  // count is ≥3x the mutation count AND claims ≥ 5. This catches the
+  // pattern where the model makes 2 small Edits and then writes a bullet
+  // list describing 8-14 "improvements" that never happened. Do NOT fire
+  // when isHallucinatedCompletion is already true — that has its own
+  // stronger reminder.
+  const isClaimMutationMismatch =
+    !isHallucinatedCompletion &&
+    successful >= 1 &&
+    claims.length >= 5 &&
+    claims.length >= successful * 3;
   return {
     isHallucinatedCompletion,
+    isClaimMutationMismatch,
     claims,
     successfulMutations: successful,
     mutatingToolNames: names,
@@ -321,6 +339,62 @@ export function buildRealityCheckReminder(verdict: RealityVerdict): string {
   );
   lines.push(
     `mutation tool has actually returned a success result in this turn.`,
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Phase 18: softer reminder for the claim/mutation mismatch case. Some
+ * mutations landed, but the claim count is far higher than the mutation
+ * count — the model is padding the summary with improvements that never
+ * happened.
+ */
+export function buildClaimMismatchReminder(verdict: RealityVerdict): string {
+  const lines: string[] = [];
+  lines.push(`[CLAIM/MUTATION MISMATCH]`);
+  lines.push(``);
+  lines.push(
+    `You made ${verdict.claims.length} distinct change claims in your summary,`,
+  );
+  lines.push(
+    `but only ${verdict.successfulMutations} mutation tool call(s) actually`,
+  );
+  lines.push(
+    `succeeded in this turn (${verdict.mutatingToolNames.join(", ") || "none"}).`,
+  );
+  lines.push(``);
+  lines.push(`That ratio is suspicious. Some of the claims below may be real,`);
+  lines.push(`but others are almost certainly padding — things you would have`);
+  lines.push(`done if you had kept working, not things that actually landed:`);
+  lines.push(``);
+  for (const claim of verdict.claims.slice(0, 10)) {
+    lines.push(`  • "${claim}"`);
+  }
+  if (verdict.claims.length > 10) {
+    lines.push(`  • ...and ${verdict.claims.length - 10} more`);
+  }
+  lines.push(``);
+  lines.push(`Before responding again, do ONE of:`);
+  lines.push(
+    `  a) Go back and actually implement the claims you listed. Use Edit /`,
+  );
+  lines.push(
+    `     MultiEdit / Write on the real file(s), one claim at a time, until`,
+  );
+  lines.push(`     the summary matches reality.`);
+  lines.push(
+    `  b) Rewrite your summary to describe ONLY what the ${verdict.successfulMutations}`,
+  );
+  lines.push(
+    `     successful mutation(s) actually did. Remove every bullet that wasn't`,
+  );
+  lines.push(`     backed by a real tool call in this turn.`);
+  lines.push(``);
+  lines.push(
+    `Padding a summary with aspirational "improvements" is a quieter version`,
+  );
+  lines.push(
+    `of the same hallucination phase 15 catches. The user checks the file.`,
   );
   return lines.join("\n");
 }

--- a/src/core/conversation.ts
+++ b/src/core/conversation.ts
@@ -502,9 +502,11 @@ export class ConversationManager {
     // session evidence: model wrote "Updated version v2.1 → v2.3" while
     // the file still had v2.1 untouched.
     try {
-      const { checkClaimReality, buildRealityCheckReminder } = await import(
-        "./claim-reality-check.js"
-      );
+      const {
+        checkClaimReality,
+        buildRealityCheckReminder,
+        buildClaimMismatchReminder,
+      } = await import("./claim-reality-check.js");
       if (lastAssistantText) {
         const verdict = checkClaimReality(lastAssistantText, this.state.messages);
         if (verdict.isHallucinatedCompletion) {
@@ -513,6 +515,16 @@ export class ConversationManager {
           log.info(
             "reality-check",
             `hallucinated completion detected: ${verdict.claims.length} claims, ${verdict.successfulMutations} real mutations`,
+          );
+        } else if (verdict.isClaimMutationMismatch) {
+          // Phase 18: softer reminder when some mutations landed but the
+          // claim count is ≥3x the mutation count. Model is padding the
+          // summary with improvements that never happened.
+          const reminder = buildClaimMismatchReminder(verdict);
+          this.state.messages.push({ role: "user", content: reminder });
+          log.info(
+            "reality-check",
+            `claim/mutation mismatch: ${verdict.claims.length} claims, ${verdict.successfulMutations} real mutations`,
           );
         }
       }


### PR DESCRIPTION
## Summary

Phase 15 (claim-vs-reality) only fires when successful mutations = 0. The most recent NASA Explorer session showed a subtler padding pattern: the model made 2 small CSS Edits and then wrote a summary describing 8-14 "improvements" that never happened. Phase 15 stayed silent because ≥1 mutation landed.

Phase 18 adds a second verdict, `isClaimMutationMismatch`, that fires when:

- claims ≥ 5
- successful mutations ≥ 1
- claims ≥ successful × 3
- phase 15 did NOT already fire

Softer reminder than phase 15: names the ratio, lists up to 10 claim phrases verbatim, and gives two resolutions — implement the missing claims, or rewrite the summary to match what actually landed.

## Test plan

- [x] 26 tests pass in claim-reality-check.test.ts (21 existing + 5 new phase 18)
- [x] Mismatch fires on 8 claims + 2 mutations (NASA reproduction)
- [x] Does NOT fire on 5 claims + 5 mutations
- [x] Does NOT fire below 5-claim threshold
- [x] Does NOT fire when phase 15 already fired (precedence)
- [x] Reminder contains ratio, claim list, two resolutions