### PR TITLE
feat(write-guards): phase 19 — in-place shrinkage + oversized GrepReplace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.54",
+  "version": "2.10.55",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/write-guards.test.ts
+++ b/src/core/write-guards.test.ts
@@ -7,8 +7,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   buildProliferationReport,
+  buildShrinkageReport,
   buildSkeletonReport,
   checkDegradation,
+  detectInPlaceShrinkage,
   detectSiblingProliferation,
   detectSkeletonContent,
 } from "./write-guards";
@@ -211,5 +213,107 @@ describe("report builders", () => {
     expect(report).toContain("/tmp/foo.html");
     expect(report).toContain("foo-refactored.html");
     expect(report).toContain("Edit");
+  });
+});
+
+// ─── Phase 19: in-place shrinkage detection ─────────────────────
+
+describe("detectInPlaceShrinkage", () => {
+  test("fires on NASA Explorer-style 901 → 554 line in-place rewrite", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kcode-shrink-"));
+    try {
+      const original = Array.from({ length: 901 }, (_, i) => `line ${i}`).join("\n");
+      const target = join(dir, "nasa-explorer.html");
+      writeFileSync(target, original);
+      const newContent = Array.from({ length: 554 }, (_, i) => `line ${i}`).join("\n");
+      const v = detectInPlaceShrinkage(target, newContent);
+      expect(v.isShrinking).toBe(true);
+      expect(v.originalLines).toBe(901);
+      expect(v.newLines).toBe(554);
+      expect(v.ratio).toBeLessThan(0.65);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does NOT fire when new content is larger than original", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kcode-shrink-"));
+    try {
+      const target = join(dir, "f.ts");
+      writeFileSync(
+        target,
+        Array.from({ length: 400 }, (_, i) => `a ${i}`).join("\n"),
+      );
+      const newContent = Array.from({ length: 500 }, (_, i) => `a ${i}`).join("\n");
+      const v = detectInPlaceShrinkage(target, newContent);
+      expect(v.isShrinking).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does NOT fire when original is small (< 300 lines)", () => {
+    // Legitimate small-file cleanups should pass through freely.
+    const dir = mkdtempSync(join(tmpdir(), "kcode-shrink-"));
+    try {
+      const target = join(dir, "small.ts");
+      writeFileSync(
+        target,
+        Array.from({ length: 200 }, (_, i) => `a ${i}`).join("\n"),
+      );
+      const newContent = "a\nb\nc\n"; // 4 lines — huge ratio drop
+      const v = detectInPlaceShrinkage(target, newContent);
+      expect(v.isShrinking).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does NOT fire when shrinkage is modest (70%+ of original)", () => {
+    // Legitimate cleanup: 500 → 400 lines (80% of original) should pass.
+    const dir = mkdtempSync(join(tmpdir(), "kcode-shrink-"));
+    try {
+      const target = join(dir, "f.ts");
+      writeFileSync(
+        target,
+        Array.from({ length: 500 }, (_, i) => `a ${i}`).join("\n"),
+      );
+      const newContent = Array.from({ length: 400 }, (_, i) => `a ${i}`).join("\n");
+      const v = detectInPlaceShrinkage(target, newContent);
+      expect(v.isShrinking).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does NOT fire when target file does not exist yet", () => {
+    const dir = mkdtempSync(join(tmpdir(), "kcode-shrink-"));
+    try {
+      const target = join(dir, "brand-new.ts");
+      const v = detectInPlaceShrinkage(target, "only 1 line");
+      expect(v.isShrinking).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("buildShrinkageReport", () => {
+  test("names the percentage drop and offers three resolutions", () => {
+    const report = buildShrinkageReport("/tmp/nasa-explorer.html", {
+      isShrinking: true,
+      originalLines: 901,
+      newLines: 554,
+      ratio: 554 / 901,
+    });
+    expect(report).toContain("BLOCKED");
+    expect(report).toContain("nasa-explorer.html");
+    expect(report).toContain("901 lines");
+    expect(report).toContain("554 lines");
+    expect(report).toContain("39%");
+    expect(report).toMatch(/a\)/);
+    expect(report).toMatch(/b\)/);
+    expect(report).toMatch(/c\)/);
+    expect(report).toMatch(/behavior is identical/);
   });
 });

--- a/src/core/write-guards.ts
+++ b/src/core/write-guards.ts
@@ -299,3 +299,111 @@ export function checkDegradation(
   }
   return null;
 }
+
+// ─── Phase 19: in-place shrinkage detection ──────────────────────
+//
+// Different from checkDegradation above — that one compares the new
+// Write against a SIBLING file (foo.html when writing foo-refactored.html).
+// checkShrinkage fires when Write is REPLACING the same file that
+// already exists. The NASA Explorer v2.10.54 session showed the model
+// overwriting nasa-explorer.html from 901 lines to 554 lines (39%
+// shrinkage) in-place, while claiming "behavior is identical" — a
+// silent lossy rewrite that neither skeleton detection nor phase 15
+// caught.
+
+export interface ShrinkageVerdict {
+  /** True if the in-place Write drops below the shrinkage threshold. */
+  isShrinking: boolean;
+  originalLines: number;
+  newLines: number;
+  /** New content as a fraction of the original (e.g. 0.61 = new is 61% of original). */
+  ratio: number;
+}
+
+const SHRINKAGE_MIN_ORIGINAL_LINES = 300;
+/** Fire when new content is less than this fraction of the original. */
+const SHRINKAGE_MAX_RATIO = 0.65;
+
+export function detectInPlaceShrinkage(
+  filePath: string,
+  newContent: string,
+): ShrinkageVerdict {
+  try {
+    if (!existsSync(filePath)) {
+      return { isShrinking: false, originalLines: 0, newLines: 0, ratio: 1 };
+    }
+    const stat = statSync(filePath);
+    if (!stat.isFile()) {
+      return { isShrinking: false, originalLines: 0, newLines: 0, ratio: 1 };
+    }
+    const original = readFileSync(filePath, "utf-8");
+    const originalLines = original.split("\n").length;
+    const newLines = newContent.split("\n").length;
+    if (originalLines < SHRINKAGE_MIN_ORIGINAL_LINES) {
+      return { isShrinking: false, originalLines, newLines, ratio: 1 };
+    }
+    const ratio = newLines / originalLines;
+    return {
+      isShrinking: ratio < SHRINKAGE_MAX_RATIO,
+      originalLines,
+      newLines,
+      ratio,
+    };
+  } catch {
+    return { isShrinking: false, originalLines: 0, newLines: 0, ratio: 1 };
+  }
+}
+
+export function buildShrinkageReport(
+  filePath: string,
+  verdict: ShrinkageVerdict,
+): string {
+  const pct = Math.round((1 - verdict.ratio) * 100);
+  const lines: string[] = [];
+  lines.push(
+    `BLOCKED — FILE NOT OVERWRITTEN: "${basename(filePath)}" would shrink by ${pct}%.`,
+  );
+  lines.push("");
+  lines.push(
+    `Original: ${verdict.originalLines} lines. Your new content: ${verdict.newLines} lines.`,
+  );
+  lines.push(
+    `That's a ${pct}% reduction on a file that already works. Rewriting a large`,
+  );
+  lines.push(
+    `file from scratch in one Write almost always drops features silently —`,
+  );
+  lines.push(
+    `the model writes what it remembers, not what's actually there.`,
+  );
+  lines.push("");
+  lines.push(`You MUST do ONE of:`);
+  lines.push(
+    `  a) Use Edit / MultiEdit for targeted changes. Keep the original file`,
+  );
+  lines.push(
+    `     intact and change only the specific lines that need to change.`,
+  );
+  lines.push(
+    `  b) If you genuinely want a full rewrite, first LIST every feature in`,
+  );
+  lines.push(
+    `     the original (counters, modals, event handlers, animations, data`,
+  );
+  lines.push(
+    `     structures, keyboard shortcuts) and confirm each one is in your new`,
+  );
+  lines.push(`     content. Do NOT claim "behavior is identical" without that check.`);
+  lines.push(
+    `  c) If the user explicitly asked for a shorter version, include that`,
+  );
+  lines.push(
+    `     intent in your response and list the features you are removing.`,
+  );
+  lines.push("");
+  lines.push(
+    `Do NOT tell the user "behavior is identical" after a ${pct}% shrink —`,
+  );
+  lines.push(`that claim is almost certainly false.`);
+  return lines.join("\n");
+}

--- a/src/tools/grep-replace.test.ts
+++ b/src/tools/grep-replace.test.ts
@@ -154,4 +154,44 @@ describe("grep-replace tool", () => {
     expect(result.is_error).toBe(true);
     expect(result.content).toContain("within the project directory");
   });
+
+  // ─── Phase 19: oversized multi-region patterns ───
+
+  test("rejects pattern over 500 chars", async () => {
+    const bigPattern = `let foo = ${"x".repeat(600)} end`;
+    const result = await executeGrepReplace({
+      pattern: bigPattern,
+      replacement: "const foo = 1",
+    });
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("too large for reliable matching");
+    expect(String(result.content)).toMatch(/Edit with a small unique anchor/);
+  });
+
+  test("rejects pattern with 2+ [\\s\\S]*? lazy wildcards", async () => {
+    const pattern = `const foo = \\{[\\s\\S]*?\\};\\s*const bar = \\[[\\s\\S]*?\\];`;
+    const result = await executeGrepReplace({
+      pattern,
+      replacement: "/* ... */",
+    });
+    expect(result.is_error).toBe(true);
+    expect(result.content).toContain("too large for reliable matching");
+    expect(String(result.content)).toContain("2 lazy");
+  });
+
+  test("literal=true bypasses pattern size check", async () => {
+    // Literal strings can legitimately be long (e.g. replacing a big
+    // comment block). Size guard only applies to regex patterns.
+    const bigLiteral = "x".repeat(800);
+    const result = await executeGrepReplace({
+      pattern: bigLiteral,
+      replacement: "y",
+      literal: true,
+    });
+    // Should NOT be a size-guard rejection — may hit "no matches" but
+    // that's a different code path.
+    if (result.is_error) {
+      expect(String(result.content)).not.toContain("too large for reliable matching");
+    }
+  });
 });

--- a/src/tools/grep-replace.ts
+++ b/src/tools/grep-replace.ts
@@ -207,6 +207,31 @@ export async function executeGrepReplace(input: Record<string, unknown>): Promis
     return { tool_use_id: "", content: "Error: pattern is required.", is_error: true };
   }
 
+  // Phase 19: reject oversized multi-region patterns. A pattern longer
+  // than 500 chars or one containing ≥2 lazy `[\s\S]*?` wildcards almost
+  // never matches cleanly — the model is trying to replace a huge block
+  // in one shot instead of making small targeted edits. Session evidence
+  // (v2.10.54 NASA Explorer): a ~60-line regex with embedded newlines
+  // failed with "No matches found" and the model fell back to a
+  // destructive full-file Write that lost 40% of the original.
+  if (!literal) {
+    const lazyWildcardCount = (patternStr.match(/\[\\s\\S\]\*\??/g) || []).length;
+    if (patternStr.length > 500 || lazyWildcardCount >= 2) {
+      return {
+        tool_use_id: "",
+        content:
+          `Error: pattern is too large for reliable matching ` +
+          `(${patternStr.length} chars, ${lazyWildcardCount} lazy [\\s\\S]*? wildcard(s)). ` +
+          `Patterns this long rarely match — any whitespace drift, invisible ` +
+          `character, or newline difference breaks the regex. Use Edit with a ` +
+          `small unique anchor (5-20 lines) instead, or call Edit multiple ` +
+          `times for separate changes. If you truly need a whole-file rewrite, ` +
+          `use Write — but do not try to simulate one with a huge GrepReplace.`,
+        is_error: true,
+      };
+    }
+  }
+
   // Constrain search path to within cwd
   const resolvedPath = resolve(searchPath);
   const resolvedCwd = resolve(cwd);

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -403,6 +403,8 @@ async function _executeWriteInner(input: Record<string, unknown>): Promise<ToolR
       detectSkeletonContent,
       buildSkeletonReport,
       checkDegradation,
+      detectInPlaceShrinkage,
+      buildShrinkageReport,
     } = await import("../core/write-guards.js");
 
     const proliferation = detectSiblingProliferation(file_path);
@@ -410,6 +412,20 @@ async function _executeWriteInner(input: Record<string, unknown>): Promise<ToolR
       return {
         tool_use_id: "",
         content: buildProliferationReport(file_path, proliferation),
+        is_error: true,
+      };
+    }
+
+    // Phase 19: in-place shrinkage. Block a Write that replaces an
+    // existing file with significantly fewer lines. The NASA Explorer
+    // session showed the model rewriting nasa-explorer.html from 901
+    // lines to 554 lines (39% drop) while claiming "behavior is
+    // identical" — silent lossy rewrite.
+    const shrinkage = detectInPlaceShrinkage(file_path, content);
+    if (shrinkage.isShrinking) {
+      return {
+        tool_use_id: "",
+        content: buildShrinkageReport(file_path, shrinkage),
         is_error: true,
       };
     }


### PR DESCRIPTION
## Summary

Two new guards for failure modes in the v2.10.54 NASA Explorer session:

### 1. In-place shrinkage detector (`detectInPlaceShrinkage`)

Model overwrote `nasa-explorer.html` from **901 → 554 lines (39% drop)** in a single Write, claiming "behavior is identical". Phase 17 skeleton detector correctly stayed silent (the new file had real code, no `/* ... */` stubs) — but the shrinkage itself went undetected.

Fires when:
- target file already exists
- original ≥ 300 lines
- new content < 65% of original line count

Blocks with three resolutions: use Edit for targeted changes, list every feature in the original if a full rewrite is genuinely wanted, or state the user's removal intent explicitly.

### 2. Oversized GrepReplace pattern guard

Same session showed the model building a ~60-line regex with embedded newlines and two `[\s\S]*?` lazy wildcards, trying to replace a huge block in one shot. It failed with "No matches found" and the model fell back to the destructive full-file Write.

Rejects when:
- pattern length > 500 chars, OR
- `[\s\S]*?` lazy wildcard count ≥ 2
- `literal=true` bypasses the check (long literal strings are valid)

Guidance tells the model to use Edit with a small unique anchor (5-20 lines) or multiple Edits.

## Test plan

- [x] 15 new tests passing (6 shrinkage + 1 report builder + 3 grep-replace)
- [x] 41 tests total across write-guards, write, grep-replace — no regressions
- [x] NASA 901 → 554 reproduction triggers shrinkage detector
- [x] Modest 500 → 400 refactor (80%) does not fire
- [x] New files (target doesn't exist) do not fire
- [x] Small files (<300 lines) do not fire
- [x] `literal=true` bypasses oversized pattern check