### PR TITLE
feat(reality-check): phase 20 — content-claim vs content-reality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.55",
+  "version": "2.10.56",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/claim-reality-check.test.ts
+++ b/src/core/claim-reality-check.test.ts
@@ -3,10 +3,14 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildClaimMismatchReminder,
+  buildContentMismatchReminder,
   buildRealityCheckReminder,
   checkClaimReality,
+  checkContentMismatch,
+  collectTurnToolActivity,
   countSuccessfulMutations,
   extractClaims,
+  extractProseUrls,
 } from "./claim-reality-check";
 import type { Message } from "./types";
 
@@ -402,5 +406,209 @@ describe("phase 18: claim/mutation mismatch", () => {
     expect(reminder).toMatch(/a\)/);
     expect(reminder).toMatch(/b\)/);
     expect(reminder).toContain("Updated star-bg");
+  });
+});
+
+// ─── Phase 20: content-level mismatch ────────────────────────────
+
+describe("extractProseUrls", () => {
+  test("extracts URLs from markdown code blocks and prose", () => {
+    const text = `
+      I updated the array:
+      url: 'https://picsum.photos/id/1015/600/380'
+      url: 'https://picsum.photos/id/133/600/380'
+
+      More info at https://example.com/docs.
+    `;
+    const urls = extractProseUrls(text);
+    expect(urls).toContain("https://picsum.photos/id/1015/600/380");
+    expect(urls).toContain("https://picsum.photos/id/133/600/380");
+    expect(urls).toContain("https://example.com/docs");
+  });
+
+  test("strips trailing punctuation", () => {
+    const text = `See https://example.com/foo, and then https://bar.com/baz.`;
+    const urls = extractProseUrls(text);
+    expect(urls).toContain("https://example.com/foo");
+    expect(urls).toContain("https://bar.com/baz");
+  });
+
+  test("deduplicates", () => {
+    const text = `https://a.com/x and https://a.com/x again`;
+    const urls = extractProseUrls(text);
+    expect(urls.length).toBe(1);
+  });
+
+  test("returns empty on text with no URLs", () => {
+    expect(extractProseUrls("no urls here").length).toBe(0);
+  });
+});
+
+describe("collectTurnToolActivity", () => {
+  test("includes tool_use inputs and tool_result content", () => {
+    const messages: Message[] = [
+      { role: "user", content: "do work" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "t1",
+            name: "Edit",
+            input: {
+              file_path: "/tmp/f.html",
+              old_string: "old",
+              new_string: "https://real.example.com/a.jpg",
+            },
+          } as unknown as never,
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t1",
+            is_error: false,
+            content: "Edited f.html (1 replacement, +1 lines)",
+          } as unknown as never,
+        ],
+      },
+    ];
+    const blob = collectTurnToolActivity(messages);
+    expect(blob).toContain("https://real.example.com/a.jpg");
+    expect(blob).toContain("Edited f.html");
+  });
+});
+
+describe("phase 20: checkContentMismatch", () => {
+  function buildMessagesWithEditedUrl(urlInEdit: string): Message[] {
+    return [
+      { role: "user", content: "fix the images" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "e1",
+            name: "Edit",
+            input: {
+              file_path: "/tmp/orbital.html",
+              old_string: "url: 'https://old.com/a.jpg'",
+              new_string: `url: '${urlInEdit}'`,
+            },
+          } as unknown as never,
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "e1",
+            is_error: false,
+            content: `Edited orbital.html (1 replacement, +0 lines)`,
+          } as unknown as never,
+        ],
+      },
+    ];
+  }
+
+  test("fires on Orbital/Mars session: prose picsum URLs, Edit had photojournal URLs", () => {
+    const messages = buildMessagesWithEditedUrl(
+      "https://photojournal.jpl.nasa.gov/jpeg/PIA26090.jpg",
+    );
+    // The model's final text claims it used picsum URLs — which were
+    // never in any tool call
+    const text = `
+      Cambios realizados:
+      url: 'https://picsum.photos/id/1015/600/380'
+      url: 'https://picsum.photos/id/133/600/380'
+      url: 'https://picsum.photos/id/160/600/380'
+      url: 'https://picsum.photos/id/201/600/380'
+    `;
+    const v = checkContentMismatch(text, messages);
+    expect(v.isContentMismatch).toBe(true);
+    expect(v.missingLiterals.length).toBeGreaterThanOrEqual(2);
+    expect(
+      v.missingLiterals.some((u) => u.includes("picsum.photos/id/1015")),
+    ).toBe(true);
+  });
+
+  test("does NOT fire when prose URLs match what was in the Edit", () => {
+    const messages = buildMessagesWithEditedUrl("https://real.example.com/a.jpg");
+    const text = `
+      I updated the image:
+      Now using https://real.example.com/a.jpg
+      and https://real.example.com/b.jpg
+    `;
+    const v = checkContentMismatch(text, messages);
+    // Only 1 URL is missing (b.jpg), which is below the 2-missing threshold
+    expect(v.isContentMismatch).toBe(false);
+  });
+
+  test("does NOT fire with fewer than 2 URLs in prose", () => {
+    const messages = buildMessagesWithEditedUrl("https://real.example.com/a.jpg");
+    const text = `See https://some-other.com/fake for more info.`;
+    const v = checkContentMismatch(text, messages);
+    expect(v.isContentMismatch).toBe(false);
+  });
+
+  test("does NOT fire when all prose URLs are found in failed tool inputs", () => {
+    // Even if the Edit failed, the URL was legitimately attempted
+    const messages: Message[] = [
+      { role: "user", content: "fix" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "e1",
+            name: "Edit",
+            input: {
+              file_path: "/tmp/f.html",
+              old_string: "nomatch",
+              new_string:
+                "url: 'https://attempted1.com/a.jpg' and 'https://attempted2.com/b.jpg'",
+            },
+          } as unknown as never,
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "e1",
+            is_error: true,
+            content: "Edit failed: old_string not found",
+          } as unknown as never,
+        ],
+      },
+    ];
+    const text = `
+      I attempted to set https://attempted1.com/a.jpg and
+      https://attempted2.com/b.jpg but the edit failed.
+    `;
+    const v = checkContentMismatch(text, messages);
+    expect(v.isContentMismatch).toBe(false);
+  });
+
+  test("reminder names missing URLs and offers resolutions", () => {
+    const reminder = buildContentMismatchReminder({
+      isContentMismatch: true,
+      missingLiterals: [
+        "https://picsum.photos/id/1015/600/380",
+        "https://picsum.photos/id/133/600/380",
+        "https://picsum.photos/id/160/600/380",
+      ],
+      foundLiterals: [],
+    });
+    expect(reminder).toContain("CONTENT MISMATCH");
+    expect(reminder).toContain("picsum.photos/id/1015");
+    expect(reminder).toContain("picsum.photos/id/133");
+    expect(reminder).toMatch(/a\)/);
+    expect(reminder).toMatch(/b\)/);
+    expect(reminder).toMatch(/Retract/i);
   });
 });

--- a/src/core/claim-reality-check.ts
+++ b/src/core/claim-reality-check.ts
@@ -238,6 +238,23 @@ export interface RealityVerdict {
   mutatingToolNames: string[];
 }
 
+/**
+ * Phase 20: content-level mismatch — the assistant prose references
+ * specific URLs (or other distinctive literals) that never appear in
+ * ANY tool call this turn, whether as input, successful output, or
+ * failed output. Different from phase 15/18 which both reason about
+ * mutation counts. Phase 20 catches the case where the model wrote a
+ * fabricated diff in prose while having made a legitimate but DIFFERENT
+ * edit to the file.
+ */
+export interface ContentMismatchVerdict {
+  isContentMismatch: boolean;
+  /** Literals mentioned in prose that don't appear in any tool activity this turn. */
+  missingLiterals: string[];
+  /** Literals mentioned in prose that DO appear somewhere in tool activity. */
+  foundLiterals: string[];
+}
+
 export function checkClaimReality(
   assistantText: string,
   messages: Message[],
@@ -395,6 +412,188 @@ export function buildClaimMismatchReminder(verdict: RealityVerdict): string {
   );
   lines.push(
     `of the same hallucination phase 15 catches. The user checks the file.`,
+  );
+  return lines.join("\n");
+}
+
+// ─── Phase 20: content-claim vs content-reality ───────────────────
+
+/**
+ * Extract distinctive URL literals from assistant prose. We deliberately
+ * focus on URLs because they're specific, easy to verify substring-wise,
+ * and the most common fabrication target (NASA image URLs, CDN links,
+ * API endpoints, etc.). Returns deduplicated URLs with trailing
+ * punctuation stripped.
+ */
+export function extractProseUrls(text: string): string[] {
+  if (!text) return [];
+  const urls = new Set<string>();
+  const re = /https?:\/\/[^\s\])"'<>,;|`]+/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    let url = m[0];
+    // Strip trailing punctuation that's clearly sentence-level, not part of the URL
+    url = url.replace(/[.,;:!?)\]]+$/, "");
+    if (url.length >= 12) urls.add(url);
+  }
+  return Array.from(urls);
+}
+
+/**
+ * Collect every string the model ACTUALLY interacted with through tools
+ * in the current turn: tool_use inputs (Write/Edit content) AND
+ * tool_result content (both successful and failed — we're checking
+ * whether the URL was in the conversation ground truth, not whether
+ * the edit succeeded). Returns a single concatenated blob for
+ * substring matching.
+ */
+export function collectTurnToolActivity(messages: Message[]): string {
+  let i = messages.length - 1;
+  while (i >= 0) {
+    const msg = messages[i];
+    if (!msg) {
+      i--;
+      continue;
+    }
+    if (msg.role !== "user") {
+      i--;
+      continue;
+    }
+    if (typeof msg.content === "string") break;
+    if (Array.isArray(msg.content)) {
+      const onlyToolResults = msg.content.every(
+        (b) => (b as { type?: string }).type === "tool_result",
+      );
+      if (!onlyToolResults) break;
+    }
+    i--;
+  }
+  const turnMessages = messages.slice(i + 1);
+  const parts: string[] = [];
+
+  for (const msg of turnMessages) {
+    if (!Array.isArray(msg.content)) continue;
+    for (const block of msg.content) {
+      const b = block as {
+        type?: string;
+        input?: unknown;
+        content?: unknown;
+      };
+      if (b.type === "tool_use" && b.input) {
+        // Serialize tool_use input so URLs inside Edit old_string /
+        // new_string / Write content are visible in the blob.
+        try {
+          parts.push(JSON.stringify(b.input));
+        } catch {
+          /* skip unserializable */
+        }
+      }
+      if (b.type === "tool_result") {
+        const contentStr =
+          typeof b.content === "string"
+            ? b.content
+            : Array.isArray(b.content)
+              ? b.content
+                  .map((sub) => {
+                    const s = sub as { type?: string; text?: string };
+                    return s.type === "text" && s.text ? s.text : "";
+                  })
+                  .join("\n")
+              : "";
+        if (contentStr) parts.push(contentStr);
+      }
+    }
+  }
+  return parts.join("\n");
+}
+
+/**
+ * Phase 20 check: extract URLs from assistant text, check whether
+ * each one appears anywhere in the turn's tool activity. Fires when
+ * ≥2 URLs are missing — the model is describing a diff that never
+ * happened.
+ */
+export function checkContentMismatch(
+  assistantText: string,
+  messages: Message[],
+): ContentMismatchVerdict {
+  const proseUrls = extractProseUrls(assistantText);
+  if (proseUrls.length < 2) {
+    return { isContentMismatch: false, missingLiterals: [], foundLiterals: [] };
+  }
+  const toolBlob = collectTurnToolActivity(messages);
+  const missing: string[] = [];
+  const found: string[] = [];
+  for (const url of proseUrls) {
+    if (toolBlob.includes(url)) {
+      found.push(url);
+    } else {
+      missing.push(url);
+    }
+  }
+  // Require at least 2 missing URLs to fire. A single off-topic URL
+  // (e.g. the model mentioning docs.example.com in passing) should
+  // not trip the guard.
+  return {
+    isContentMismatch: missing.length >= 2,
+    missingLiterals: missing,
+    foundLiterals: found,
+  };
+}
+
+export function buildContentMismatchReminder(
+  verdict: ContentMismatchVerdict,
+): string {
+  const lines: string[] = [];
+  lines.push(`[CONTENT MISMATCH]`);
+  lines.push(``);
+  lines.push(
+    `Your summary references ${verdict.missingLiterals.length} URL(s) that do NOT`,
+  );
+  lines.push(
+    `appear in ANY tool call this turn — not in any Edit/Write input, and`,
+  );
+  lines.push(`not in any tool result (successful OR failed):`);
+  lines.push(``);
+  for (const lit of verdict.missingLiterals.slice(0, 6)) {
+    lines.push(`  • ${lit}`);
+  }
+  if (verdict.missingLiterals.length > 6) {
+    lines.push(`  • ...and ${verdict.missingLiterals.length - 6} more`);
+  }
+  lines.push(``);
+  lines.push(
+    `You cannot claim you "updated the code to use X" when X was never in`,
+  );
+  lines.push(
+    `a tool_use.input and was never written to the file. The user will`,
+  );
+  lines.push(
+    `open the file and see completely different URLs. This is the`,
+  );
+  lines.push(
+    `failure mode that showed up in the Orbital/Mars session: the model`,
+  );
+  lines.push(
+    `wrote a markdown code block showing picsum.photos URLs while the`,
+  );
+  lines.push(`actual file still had the photojournal.jpl.nasa.gov ones.`);
+  lines.push(``);
+  lines.push(`You MUST do ONE of:`);
+  lines.push(
+    `  a) Actually make the change now — call Edit or Write with the exact`,
+  );
+  lines.push(
+    `     URL(s) you described, then verify with a Read of the file.`,
+  );
+  lines.push(
+    `  b) Retract the claim clearly: "my previous summary described URLs`,
+  );
+  lines.push(
+    `     that were never actually written. The file still contains [the`,
+  );
+  lines.push(
+    `     real URLs]." Then ask the user how to proceed.`,
   );
   return lines.join("\n");
 }

--- a/src/core/conversation.ts
+++ b/src/core/conversation.ts
@@ -506,6 +506,8 @@ export class ConversationManager {
         checkClaimReality,
         buildRealityCheckReminder,
         buildClaimMismatchReminder,
+        checkContentMismatch,
+        buildContentMismatchReminder,
       } = await import("./claim-reality-check.js");
       if (lastAssistantText) {
         const verdict = checkClaimReality(lastAssistantText, this.state.messages);
@@ -526,6 +528,25 @@ export class ConversationManager {
             "reality-check",
             `claim/mutation mismatch: ${verdict.claims.length} claims, ${verdict.successfulMutations} real mutations`,
           );
+        } else {
+          // Phase 20: content-level mismatch — prose URLs that never
+          // appeared in any tool call this turn. Catches the Orbital/Mars
+          // session pattern where the model showed picsum.photos URLs in
+          // a markdown diff while the actual Edit used totally different
+          // photojournal.jpl.nasa.gov URLs. Only runs when phase 15/18
+          // did not already fire.
+          const contentVerdict = checkContentMismatch(
+            lastAssistantText,
+            this.state.messages,
+          );
+          if (contentVerdict.isContentMismatch) {
+            const reminder = buildContentMismatchReminder(contentVerdict);
+            this.state.messages.push({ role: "user", content: reminder });
+            log.info(
+              "reality-check",
+              `content mismatch: ${contentVerdict.missingLiterals.length} fabricated URL(s) in prose`,
+            );
+          }
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

Catches the failure mode observed in the Orbital/Mars NASA session (v2.10.55 kcode.log): the model made a legitimate Edit inserting `photojournal.jpl.nasa.gov` URLs, then wrote a markdown code block in prose showing `picsum.photos` URLs and declared completion. Successful mutations = 1, claim count reasonable → phase 15 and phase 18 both stayed silent. But the prose described a diff that never happened.

## How it works

- `extractProseUrls` — matches `https?://…`, strips trailing sentence punctuation, dedupes
- `collectTurnToolActivity` — walks the current turn (everything after the last user text) and concatenates **every** `tool_use.input` AND **every** `tool_result` content (successful AND failed). This is the blob of everything the model actually touched through tools
- `checkContentMismatch` — for each prose URL, substring-check against the blob. Fires when ≥2 URLs are missing (a single off-topic URL reference won't trip it)
- `buildContentMismatchReminder` — lists the missing URLs verbatim and offers two resolutions: actually make the change, or retract clearly with explicit reference to what's still in the file

Wired in `conversation.ts` with explicit precedence: phase 15 > phase 18 > phase 20. At most one reminder per turn.

## Test plan

- [x] 36 tests pass in claim-reality-check.test.ts (26 previous + 10 new phase 20)
- [x] Orbital reproduction fires: Edit inserts photojournal URLs, prose shows picsum URLs → content mismatch
- [x] Does NOT fire when prose URLs match Edit content
- [x] Does NOT fire with < 2 URLs in prose
- [x] Does NOT fire when URLs appear in FAILED tool inputs (model attempted them)
- [x] Reminder names URLs verbatim, offers a/b resolutions