### PR TITLE
fix(request-builder): surface endpoint origin + 5xx hint in API errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.57",
+  "version": "2.10.58",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/request-builder.test.ts
+++ b/src/core/request-builder.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { estimateToolDefinitionTokens, resolveApiKey } from "./request-builder.ts";
+import {
+  classifyApiErrorHint,
+  estimateToolDefinitionTokens,
+  formatApiErrorMessage,
+  resolveApiKey,
+} from "./request-builder.ts";
 import type { KCodeConfig } from "./types.ts";
 
 // ─── resolveApiKey ─────────────────────────────────────────────
@@ -167,5 +172,93 @@ describe("estimateToolDefinitionTokens", () => {
       50;
     const expectedTokens = Math.ceil(expectedChars / 3.5);
     expect(tokens).toBe(expectedTokens);
+  });
+});
+
+// ─── API error formatting ───────────────────────────────────────
+
+describe("classifyApiErrorHint", () => {
+  test("returns billing hint on 402", () => {
+    expect(classifyApiErrorHint(402, "")).toMatch(/billing\/credits/);
+  });
+
+  test("returns billing hint when body mentions credits", () => {
+    expect(classifyApiErrorHint(400, "insufficient credit balance")).toMatch(
+      /billing/,
+    );
+  });
+
+  test("returns auth hint on 401/403", () => {
+    expect(classifyApiErrorHint(401, "")).toMatch(/API key permissions/);
+    expect(classifyApiErrorHint(403, "")).toMatch(/API key permissions/);
+  });
+
+  test("returns context hint on 400 with 'too many tokens'", () => {
+    expect(classifyApiErrorHint(400, "too many tokens in prompt")).toMatch(
+      /context window/,
+    );
+  });
+
+  test("returns 5xx hint on 500/502/503 (Orbital session fix)", () => {
+    expect(classifyApiErrorHint(500, "")).toMatch(/transient/);
+    expect(classifyApiErrorHint(502, "")).toMatch(/transient/);
+    expect(classifyApiErrorHint(503, "")).toMatch(/transient/);
+    expect(classifyApiErrorHint(500, "")).toMatch(/\/toggle to another model/);
+  });
+
+  test("returns empty string for unclassified errors", () => {
+    expect(classifyApiErrorHint(418, "")).toBe("");
+  });
+});
+
+describe("formatApiErrorMessage", () => {
+  test("includes endpoint origin so dual local+cloud setups are disambiguated", () => {
+    const msg = formatApiErrorMessage({
+      status: 500,
+      statusText: "Internal Server Error",
+      errorText: "upstream down",
+      url: "https://api.x.ai/v1/chat/completions",
+      hint: " (hint: retry)",
+    });
+    expect(msg).toContain("500 Internal Server Error");
+    expect(msg).toContain("from https://api.x.ai/v1/chat/completions");
+    expect(msg).toContain("upstream down");
+    expect(msg).toContain("(hint: retry)");
+  });
+
+  test("works with localhost endpoints", () => {
+    const msg = formatApiErrorMessage({
+      status: 500,
+      statusText: "Internal Server Error",
+      errorText: "",
+      url: "http://localhost:8090/v1/chat/completions",
+      hint: "",
+    });
+    expect(msg).toContain("from http://localhost:8090/v1/chat/completions");
+  });
+
+  test("gracefully handles invalid URLs (no origin label)", () => {
+    const msg = formatApiErrorMessage({
+      status: 500,
+      statusText: "Server Error",
+      errorText: "",
+      url: "not-a-url",
+      hint: "",
+    });
+    expect(msg).toContain("500 Server Error");
+    expect(msg).not.toContain("from ");
+  });
+
+  test("omits empty errorText and empty hint cleanly", () => {
+    const msg = formatApiErrorMessage({
+      status: 502,
+      statusText: "Bad Gateway",
+      errorText: "",
+      url: "https://api.example.com/v1/foo",
+      hint: "",
+    });
+    expect(msg).toBe(
+      "API request failed: 502 Bad Gateway from https://api.example.com/v1/foo",
+    );
   });
 });

--- a/src/core/request-builder.ts
+++ b/src/core/request-builder.ts
@@ -49,6 +49,73 @@ export function isRateLimitError(err: unknown): err is RateLimitError {
   return err instanceof Error && (err as RateLimitError).isRateLimit === true;
 }
 
+// ─── API error message formatting ────────────────────────────────
+
+/**
+ * Classify an HTTP error response and return an actionable hint
+ * string (with leading space), or an empty string if no hint applies.
+ * Pure — no I/O, safe to unit-test.
+ */
+export function classifyApiErrorHint(status: number, errorText: string): string {
+  const errLower = errorText.toLowerCase();
+  if (
+    errLower.includes("credit") ||
+    errLower.includes("balance") ||
+    errLower.includes("billing") ||
+    errLower.includes("payment") ||
+    status === 402
+  ) {
+    return " (hint: check your API billing/credits at the provider's dashboard)";
+  }
+  if (
+    status === 401 ||
+    status === 403 ||
+    errLower.includes("missing_scope") ||
+    errLower.includes("unauthorized")
+  ) {
+    return " (hint: check API key permissions — ensure it has the required scopes)";
+  }
+  if (
+    status === 400 &&
+    (errLower.includes("too long") ||
+      errLower.includes("too many tokens") ||
+      errLower.includes("context") ||
+      errLower.includes("maximum"))
+  ) {
+    return " (hint: request may exceed model context window — try /compact or reduce conversation length)";
+  }
+  if (status >= 500 && status < 600) {
+    // 5xx from an upstream provider is almost always transient. The
+    // user needs to know retry / model switch is the fix.
+    return " (hint: provider returned a server error — transient, retry in a moment or /toggle to another model)";
+  }
+  return "";
+}
+
+/**
+ * Build the API error message shown to the user. Includes the origin
+ * of the failing endpoint so dual local+cloud setups make it obvious
+ * whether the failure was localhost or a cloud provider (e.g. api.x.ai).
+ * Pure — no I/O, safe to unit-test.
+ */
+export function formatApiErrorMessage(opts: {
+  status: number;
+  statusText: string;
+  errorText: string;
+  url: string;
+  hint: string;
+}): string {
+  let originLabel = "";
+  try {
+    const parsed = new URL(opts.url);
+    originLabel = ` from ${parsed.origin}${parsed.pathname}`;
+  } catch {
+    /* non-URL input — skip origin label */
+  }
+  const body = opts.errorText ? ` - ${opts.errorText}` : "";
+  return `API request failed: ${opts.status} ${opts.statusText}${originLabel}${body}${opts.hint}`;
+}
+
 // ─── Tool Token Estimation ───────────────────────────────────────
 
 import { CHARS_PER_TOKEN } from "./token-budget";
@@ -717,18 +784,16 @@ export async function executeModelRequest(
       updateRateLimitUsage(response.headers);
       throw err;
     } else {
-      // Classify error and provide actionable hint
-      const errLower = errorText.toLowerCase();
-      if (errLower.includes("credit") || errLower.includes("balance") || errLower.includes("billing") || errLower.includes("payment") || response.status === 402) {
-        hint = " (hint: check your API billing/credits at the provider's dashboard)";
-      } else if (response.status === 401 || response.status === 403 || errLower.includes("missing_scope") || errLower.includes("unauthorized")) {
-        hint = " (hint: check API key permissions — ensure it has the required scopes)";
-      } else if (response.status === 400 && (errLower.includes("too long") || errLower.includes("too many tokens") || errLower.includes("context") || errLower.includes("maximum"))) {
-        hint = " (hint: request may exceed model context window — try /compact or reduce conversation length)";
-      }
+      hint = classifyApiErrorHint(response.status, errorText);
     }
     throw new Error(
-      `API request failed: ${response.status} ${response.statusText}${errorText ? ` - ${errorText}` : ""}${hint}`,
+      formatApiErrorMessage({
+        status: response.status,
+        statusText: response.statusText,
+        errorText,
+        url: req.url,
+        hint,
+      }),
     );
   }
 


### PR DESCRIPTION
## Summary

The Orbital NASA session hit a 500 from `api.x.ai` (grok-4.20 cloud) while the user's local llama-server was up on `:8090` with a different model. KCode's error was just `API request failed: 500 Internal Server Error` with no indication of WHICH endpoint failed. For a dual local+cloud setup the user reasonably assumed KCode / phase 21 had broken something, when the real cause was a transient upstream issue at xAI.

## Changes

1. **Extract** the error-message formatting from `executeModelRequest` into two pure helpers (`classifyApiErrorHint`, `formatApiErrorMessage`) so they can be unit-tested without mocking `fetch`.
2. **`formatApiErrorMessage`** parses the request URL and injects `origin + pathname` into the error, e.g.:
   ```
   API request failed: 500 Internal Server Error from https://api.x.ai/v1/chat/completions - upstream down (hint: provider returned a server error — transient, retry in a moment or /toggle to another model)
   ```
3. **`classifyApiErrorHint`** adds a hint for any 5xx: transient, retry or `/toggle` to another model.

## Test plan

- [x] 11 new unit tests in request-builder.test.ts covering hint classification (402, 401/403, 400-context, 500/502/503, unclassified) and origin-label formatting (cloud URL, localhost, invalid URL, empty body/hint)
- [x] `bun test src/core/request-builder.test.ts` → 24 pass / 0 fail