### PR TITLE
fix(request-builder): overload-specific hint on 5xx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.58",
+  "version": "2.10.59",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/request-builder.test.ts
+++ b/src/core/request-builder.test.ts
@@ -206,6 +206,27 @@ describe("classifyApiErrorHint", () => {
     expect(classifyApiErrorHint(500, "")).toMatch(/\/toggle to another model/);
   });
 
+  test("returns overload-specific hint when body mentions 'overloaded'", () => {
+    // xAI grok capacity errors:
+    //   {"error":{"message":"Primary model overloaded"}}
+    //   {"error":{"message":"Model overloaded"}}
+    //   {"error":{"message":"Internal server error: model overloaded"}}
+    const h1 = classifyApiErrorHint(
+      500,
+      '{"error":{"message":"Primary model overloaded"}}',
+    );
+    expect(h1).toMatch(/overloaded right now/);
+    expect(h1).toMatch(/\/toggle to another provider/);
+    expect(h1).not.toMatch(/transient/);
+
+    expect(classifyApiErrorHint(500, "Model overloaded")).toMatch(
+      /overloaded right now/,
+    );
+    expect(
+      classifyApiErrorHint(503, "Internal server error: model overloaded"),
+    ).toMatch(/overloaded right now/);
+  });
+
   test("returns empty string for unclassified errors", () => {
     expect(classifyApiErrorHint(418, "")).toBe("");
   });

--- a/src/core/request-builder.ts
+++ b/src/core/request-builder.ts
@@ -85,8 +85,13 @@ export function classifyApiErrorHint(status: number, errorText: string): string 
     return " (hint: request may exceed model context window — try /compact or reduce conversation length)";
   }
   if (status >= 500 && status < 600) {
-    // 5xx from an upstream provider is almost always transient. The
-    // user needs to know retry / model switch is the fix.
+    // 5xx with an explicit "overloaded" body is a provider capacity
+    // problem (e.g. xAI grok saturation, Anthropic model overload).
+    // Point the user at the right fix directly.
+    if (errLower.includes("overload")) {
+      return " (hint: provider model is overloaded right now — retry or /toggle to another provider)";
+    }
+    // Generic 5xx: transient upstream issue, same advice
     return " (hint: provider returned a server error — transient, retry in a moment or /toggle to another model)";
   }
   return "";


### PR DESCRIPTION
## Summary

When the upstream 5xx body contains `overload` (xAI grok and Anthropic return strings like `Primary model overloaded` / `Model overloaded` / `Internal server error: model overloaded`), return a more specific hint instead of the generic 5xx one.

Evidence from today's `kcode-2026-04-14.log`:

```
[WARN] Request failed 500: server: {"error":{"message":"Primary model overloaded"}}
[WARN] Request failed 500: server: {"error":{"message":"Internal server error: model overloaded"}}
[WARN] Request failed 500: server: {"error":{"message":"Model overloaded"}}
```

The user sees a generic "transient" hint and wonders whether KCode is broken — the specific hint leaves zero ambiguity about what happened and what to do.

### Before
```
(hint: provider returned a server error — transient, retry in a moment or /toggle to another model)
```

### After (when body contains 'overload')
```
(hint: provider model is overloaded right now — retry or /toggle to another provider)
```

## Test plan

- [x] 1 new test verifies overload strings map to the new hint
- [x] 25 tests total in request-builder.test.ts, 0 fail
- [x] Generic 5xx without overload keyword still gets the original transient hint