### PR TITLE
feat(auto-launch): phase 22 — proactive dev-server launch at end of turn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.59",
+  "version": "2.10.60",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/auto-launch-dev-server.test.ts
+++ b/src/core/auto-launch-dev-server.test.ts
@@ -1,0 +1,219 @@
+// Tests for phase 22 auto-launch dev server hook.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  __autoLaunchSessionState,
+  hasRunnableWriteInTurn,
+  hasRuntimeIntent,
+  resetAutoLaunchState,
+} from "./auto-launch-dev-server";
+import type { Message } from "./types";
+
+afterEach(() => {
+  resetAutoLaunchState();
+});
+
+describe("hasRuntimeIntent", () => {
+  test("fires on Spanish action verbs", () => {
+    expect(hasRuntimeIntent(["levantalo"])).toBe(true);
+    expect(hasRuntimeIntent(["levanta el servidor web"])).toBe(true);
+    expect(hasRuntimeIntent(["ejecuta el proyecto"])).toBe(true);
+    expect(hasRuntimeIntent(["arrancame el dashboard"])).toBe(true);
+    expect(hasRuntimeIntent(["lanzalo"])).toBe(true);
+    expect(hasRuntimeIntent(["corre la app"])).toBe(true);
+  });
+
+  test("fires on English action verbs", () => {
+    expect(hasRuntimeIntent(["run the server"])).toBe(true);
+    expect(hasRuntimeIntent(["launch it"])).toBe(true);
+    expect(hasRuntimeIntent(["spin up the dashboard"])).toBe(true);
+    expect(hasRuntimeIntent(["start the app"])).toBe(true);
+  });
+
+  test("fires on runtime nouns and port references", () => {
+    expect(hasRuntimeIntent(["quiero un dashboard"])).toBe(true);
+    expect(hasRuntimeIntent(["abre en http://localhost:3000"])).toBe(true);
+    expect(hasRuntimeIntent(["en el puerto 24564"])).toBe(true);
+    expect(hasRuntimeIntent(["on port 3000"])).toBe(true);
+    expect(hasRuntimeIntent(["que se levante automaticamente"])).toBe(true);
+    expect(hasRuntimeIntent(["to see it running"])).toBe(true);
+  });
+
+  test("fires on the actual Orbital prompt fragment", () => {
+    const orbitalFragment =
+      "Incluir al final del archivo un servidor web simple usando Node.js + Express " +
+      "que levante automáticamente la aplicación en el puerto 24564";
+    expect(hasRuntimeIntent([orbitalFragment])).toBe(true);
+  });
+
+  test("does NOT fire on off-topic prompts", () => {
+    expect(hasRuntimeIntent(["fix the typo in config.ts"])).toBe(false);
+    expect(hasRuntimeIntent(["explain how this function works"])).toBe(false);
+    expect(hasRuntimeIntent(["write a markdown summary"])).toBe(false);
+    expect(hasRuntimeIntent([])).toBe(false);
+    expect(hasRuntimeIntent([""])).toBe(false);
+  });
+
+  test("scans all user messages, not just the latest", () => {
+    const texts = [
+      "levanta el servidor web en puerto 24564",
+      "ahora cambia el color del header",
+      "y añade un footer",
+    ];
+    expect(hasRuntimeIntent(texts)).toBe(true);
+  });
+});
+
+describe("hasRunnableWriteInTurn", () => {
+  test("returns true when this turn contains a successful Write", () => {
+    const messages: Message[] = [
+      { role: "user", content: "create orbital.html" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "w1",
+            name: "Write",
+            input: { file_path: "/tmp/orbital.html", content: "<html></html>" },
+          } as unknown as never,
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "w1",
+            is_error: false,
+            content: "Created /tmp/orbital.html (1026 lines)",
+          } as unknown as never,
+        ],
+      },
+    ];
+    expect(hasRunnableWriteInTurn(messages)).toBe(true);
+  });
+
+  test("returns false when the turn has only Read/Edit", () => {
+    const messages: Message[] = [
+      { role: "user", content: "read the config" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "r1",
+            name: "Read",
+            input: { file_path: "/tmp/cfg.ts" },
+          } as unknown as never,
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "r1",
+            is_error: false,
+            content: "file contents...",
+          } as unknown as never,
+        ],
+      },
+    ];
+    expect(hasRunnableWriteInTurn(messages)).toBe(false);
+  });
+
+  test("returns false when Write failed (is_error=true)", () => {
+    const messages: Message[] = [
+      { role: "user", content: "create it" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "w1",
+            name: "Write",
+            input: { file_path: "/tmp/x.html", content: "..." },
+          } as unknown as never,
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "w1",
+            is_error: true,
+            content: "BLOCKED: something",
+          } as unknown as never,
+        ],
+      },
+    ];
+    expect(hasRunnableWriteInTurn(messages)).toBe(false);
+  });
+
+  test("scopes to the current turn only (ignores earlier user text)", () => {
+    const messages: Message[] = [
+      { role: "user", content: "earlier request" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "w0",
+            name: "Write",
+            input: { file_path: "/tmp/old.html", content: "..." },
+          } as unknown as never,
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "w0",
+            is_error: false,
+            content: "Created /tmp/old.html (100 lines)",
+          } as unknown as never,
+        ],
+      },
+      // NEW turn begins:
+      { role: "user", content: "now add a paragraph" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "e1",
+            name: "Edit",
+            input: { file_path: "/tmp/old.html", old_string: "a", new_string: "b" },
+          } as unknown as never,
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "e1",
+            is_error: false,
+            content: "Edited old.html (1 replacement)",
+          } as unknown as never,
+        ],
+      },
+    ];
+    // The Write in the earlier turn should NOT count for the current turn
+    expect(hasRunnableWriteInTurn(messages)).toBe(false);
+  });
+});
+
+describe("resetAutoLaunchState", () => {
+  test("clears session state flags", () => {
+    __autoLaunchSessionState.launched = true;
+    __autoLaunchSessionState.launchedAt = Date.now();
+    __autoLaunchSessionState.launchedCwd = "/tmp";
+    resetAutoLaunchState();
+    expect(__autoLaunchSessionState.launched).toBe(false);
+    expect(__autoLaunchSessionState.launchedCwd).toBe("");
+  });
+});

--- a/src/core/auto-launch-dev-server.ts
+++ b/src/core/auto-launch-dev-server.ts
@@ -1,0 +1,282 @@
+// KCode - Phase 22 auto-launch dev server
+//
+// When the user's original prompt had runtime intent ("levantalo",
+// "quiero verlo", "server", "dashboard", etc.) AND the current turn
+// produced a runnable project via Write, proactively start the dev
+// server at end-of-turn so the user doesn't have to type "lanzalo"
+// afterward. Also report the PID and how to stop it.
+//
+// Evidence: the v2.10.59 Orbital session ended with orbital.html on
+// disk and no running server. The user said "no levanto el servicio
+// web" — meaning the model created the file but never executed the
+// runtime step the user had asked for in the original prompt.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { log } from "./logger.js";
+import {
+  detectDevServer,
+  startDevServer,
+} from "./task-orchestrator/level1-handlers.js";
+import type { Message } from "./types.js";
+
+// ─── Session state ───────────────────────────────────────────────
+
+interface SessionState {
+  launched: boolean;
+  launchedAt: number;
+  launchedCwd: string;
+}
+
+const _sessionState: SessionState = {
+  launched: false,
+  launchedAt: 0,
+  launchedCwd: "",
+};
+
+export function resetAutoLaunchState(): void {
+  _sessionState.launched = false;
+  _sessionState.launchedAt = 0;
+  _sessionState.launchedCwd = "";
+}
+
+export function wasAutoLaunched(): boolean {
+  return _sessionState.launched;
+}
+
+// ─── Runtime intent detection ───────────────────────────────────
+
+/**
+ * Keywords in user prose that indicate they want the deliverable to
+ * actually RUN at the end, not just have source files on disk.
+ * Narrow list — false positives here would auto-launch things the
+ * user didn't ask to run.
+ */
+const RUNTIME_INTENT_KEYWORDS = [
+  // Spanish action verbs
+  /\blevant(?:a|e|ar|al[oa])\b/i,
+  /\bejecut(?:a|e|ar|al[oa])\b/i,
+  /\barranc(?:a|e|ar|al[oa])\b/i,
+  /\blanza(?:r|l[oa])?\b/i,
+  /\bcorre(?:r|l[oa])?\b/i,
+  /\binicia(?:r|l[oa])?\b/i,
+  /\babre(?:l[oa])?\b/i,
+  /\bmontar(?:l[oa])?\b/i,
+  // English action verbs
+  /\brun\s+(?:it|the\s+(?:server|app|project))\b/i,
+  /\blaunch\b/i,
+  /\bstart\s+(?:the\s+)?(?:server|app|project)\b/i,
+  /\bspin\s+up\b/i,
+  // Runtime nouns that strongly imply a live service
+  /\bservidor\s+web\b/i,
+  /\bweb\s+server\b/i,
+  /\bdev\s+server\b/i,
+  /\bdashboard\b/i,
+  /\bhttp:\/\/localhost\b/i,
+  /\bport\s*\d+/i,
+  /\bpuerto\s*\d+/i,
+  /\bautom[aá]ticamente\b/i,
+  /\bautomatically\s+(?:start|run|launch)/i,
+  /\bque\s+se\s+levante\b/i,
+  /\bpara\s+verlo\b/i,
+  /\bto\s+see\s+it\b/i,
+];
+
+export function hasRuntimeIntent(userTexts: readonly string[]): boolean {
+  for (const text of userTexts) {
+    if (!text) continue;
+    for (const re of RUNTIME_INTENT_KEYWORDS) {
+      if (re.test(text)) return true;
+    }
+  }
+  return false;
+}
+
+// ─── Write-in-turn detection ─────────────────────────────────────
+
+/**
+ * Walk the messages for the current turn and look for a successful
+ * Write tool result. The turn is everything after the most recent
+ * user-authored text message.
+ */
+export function hasRunnableWriteInTurn(messages: Message[]): boolean {
+  let i = messages.length - 1;
+  while (i >= 0) {
+    const msg = messages[i];
+    if (!msg) {
+      i--;
+      continue;
+    }
+    if (msg.role !== "user") {
+      i--;
+      continue;
+    }
+    if (typeof msg.content === "string") break;
+    if (Array.isArray(msg.content)) {
+      const onlyToolResults = msg.content.every(
+        (b) => (b as { type?: string }).type === "tool_result",
+      );
+      if (!onlyToolResults) break;
+    }
+    i--;
+  }
+  const turnMessages = messages.slice(i + 1);
+
+  // Map tool_use id -> name so we can correlate tool_result to Write
+  const toolNameById = new Map<string, string>();
+  for (const msg of turnMessages) {
+    if (msg.role === "assistant" && Array.isArray(msg.content)) {
+      for (const block of msg.content) {
+        const b = block as { type?: string; id?: string; name?: string };
+        if (b.type === "tool_use" && b.id && b.name) {
+          toolNameById.set(b.id, b.name);
+        }
+      }
+    }
+  }
+
+  for (const msg of turnMessages) {
+    if (msg.role === "user" && Array.isArray(msg.content)) {
+      for (const block of msg.content) {
+        const b = block as {
+          type?: string;
+          tool_use_id?: string;
+          is_error?: boolean;
+          content?: unknown;
+        };
+        if (b.type !== "tool_result") continue;
+        if (b.is_error) continue;
+        const toolName = b.tool_use_id ? toolNameById.get(b.tool_use_id) : undefined;
+        if (toolName !== "Write") continue;
+        const contentStr =
+          typeof b.content === "string"
+            ? b.content
+            : Array.isArray(b.content)
+              ? b.content
+                  .map((sub) => {
+                    const s = sub as { type?: string; text?: string };
+                    return s.type === "text" && s.text ? s.text : "";
+                  })
+                  .join("\n")
+              : "";
+        if (/\bcreated\b/i.test(contentStr)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+// ─── Already-running server detection ────────────────────────────
+
+/**
+ * Check if a process already has the target port open. Uses ss with a
+ * 1s timeout — if it fails we return false (fail open) rather than
+ * blocking the auto-launch.
+ */
+function portInUse(port: number): boolean {
+  try {
+    const { execSync } = require("node:child_process") as typeof import("node:child_process");
+    const out = execSync(`ss -tlnp state listening "( sport = :${port} )"`, {
+      timeout: 1000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString();
+    return out.trim().split("\n").length > 1;
+  } catch {
+    return false;
+  }
+}
+
+/** Guard against looping re-launches if we recently started a server. */
+function launchedRecently(cwd: string): boolean {
+  if (!_sessionState.launched) return false;
+  if (_sessionState.launchedCwd !== cwd) return false;
+  return Date.now() - _sessionState.launchedAt < 60_000;
+}
+
+// ─── Main entry ──────────────────────────────────────────────────
+
+export interface AutoLaunchResult {
+  notice: string;
+  pid?: number;
+  url?: string;
+}
+
+export async function maybeAutoLaunchDevServer(
+  cwd: string,
+  messages: Message[],
+  userTexts: readonly string[],
+): Promise<AutoLaunchResult | null> {
+  try {
+    // Guard 1: user's prompts must have runtime intent
+    if (!hasRuntimeIntent(userTexts)) {
+      log.debug("auto-launch", "skipped: no runtime intent in user text");
+      return null;
+    }
+
+    // Guard 2: a Write must have completed this turn
+    if (!hasRunnableWriteInTurn(messages)) {
+      log.debug("auto-launch", "skipped: no successful Write in this turn");
+      return null;
+    }
+
+    // Guard 3: a runnable project must exist in cwd
+    const srv = detectDevServer(cwd);
+    if (!srv) {
+      log.debug("auto-launch", "skipped: detectDevServer returned null");
+      return null;
+    }
+
+    // Guard 4: don't re-launch if recently started for same cwd
+    if (launchedRecently(cwd)) {
+      log.debug("auto-launch", "skipped: already launched recently");
+      return null;
+    }
+
+    // Guard 5: skip if the target port is already bound (maybe by a
+    // previous kcode session or external process)
+    if (srv.port > 0 && portInUse(srv.port)) {
+      log.debug("auto-launch", `skipped: port ${srv.port} already in use`);
+      return null;
+    }
+
+    // Launch
+    const result = startDevServer(srv, cwd);
+    if (!result.handled) return null;
+
+    // Extract PID and URL from the level1 result output so we can
+    // build our own notice framing
+    const output = result.output ?? "";
+    const pidMatch = output.match(/PID:\s*(\d+)/);
+    const urlMatch = output.match(/http:\/\/[^\s]+/);
+    const pid = pidMatch?.[1] ? Number(pidMatch[1]) : undefined;
+    const url = urlMatch?.[0];
+
+    _sessionState.launched = true;
+    _sessionState.launchedAt = Date.now();
+    _sessionState.launchedCwd = cwd;
+
+    const lines: string[] = [];
+    lines.push("");
+    lines.push("  ── Auto-launched dev server ──");
+    if (url) lines.push(`  🌐 ${url}`);
+    if (pid !== undefined) lines.push(`  PID: ${pid}`);
+    lines.push("  To stop:");
+    if (pid !== undefined) lines.push(`    kill ${pid}`);
+    lines.push(`    or: pkill -f '${srv.command.split(" ")[0]}'`);
+    lines.push('    or in kcode: "para el server" / /stop');
+    lines.push("");
+
+    const notice = lines.join("\n");
+    log.info(
+      "auto-launch",
+      `started ${srv.name} on :${srv.port}${pid ? ` (PID ${pid})` : ""}`,
+    );
+    return { notice, pid, url };
+  } catch (err) {
+    log.debug("auto-launch", `check failed (non-fatal): ${err}`);
+    return null;
+  }
+}
+
+// Exported for tests so they can inspect without running level1
+export { _sessionState as __autoLaunchSessionState };

--- a/src/core/conversation.ts
+++ b/src/core/conversation.ts
@@ -1897,6 +1897,34 @@ export class ConversationManager {
         guardState.consecutiveDenials = 0;
       }
 
+      // Phase 22: if the model just finished its final response AND the
+      // user's original prompt had runtime intent AND a Write just
+      // completed, proactively launch the dev server and tell the user
+      // how to stop it. Fires only on "end_turn" — never during
+      // tool_use continuation, so we don't launch mid-reasoning.
+      if (stopReason === "end_turn") {
+        try {
+          const { maybeAutoLaunchDevServer } = await import(
+            "./auto-launch-dev-server.js"
+          );
+          const { getUserTexts } = await import("./session-tracker.js");
+          const launchResult = await maybeAutoLaunchDevServer(
+            this.config.workingDirectory,
+            this.state.messages,
+            getUserTexts(),
+          );
+          if (launchResult) {
+            this.state.messages.push({
+              role: "assistant",
+              content: launchResult.notice,
+            });
+            yield { type: "text", text: launchResult.notice };
+          }
+        } catch (err) {
+          log.debug("auto-launch", `hook failed (non-fatal): ${err}`);
+        }
+      }
+
       yield { type: "turn_end", stopReason };
       // Loop continues for next agent turn
     }

--- a/src/core/task-orchestrator/level1-handlers.ts
+++ b/src/core/task-orchestrator/level1-handlers.ts
@@ -222,12 +222,19 @@ function generateCommitMessage(cwd: string): { message: string; files: string } 
 
 // ── Dev Server Detection ──────────────────────────────────────
 
-interface DevServer {
+export interface DevServer {
   name: string;
   command: string;
   port: number;
   installCmd?: string;
   needsInstall: boolean;
+  /**
+   * When the dev-server is a static-HTML server, this is the filename
+   * that should be linked in the "open at" URL. Used so the auto-launch
+   * hook can point the user at http://localhost:PORT/orbital.html
+   * instead of the bare directory listing.
+   */
+  htmlFile?: string;
 }
 
 /**
@@ -278,7 +285,7 @@ function findFreePort(start: number, end: number): number {
 const KCODE_PORT_FLOOR = 11000;
 const KCODE_PORT_CEILING = 11999;
 
-function detectDevServer(cwd: string, requestedPort?: number): DevServer | null {
+export function detectDevServer(cwd: string, requestedPort?: number): DevServer | null {
   // If the caller gave a specific port, honor it (even if below 11000 —
   // the user knows what they want). Otherwise find a free one in the
   // kcode dev-server port range.
@@ -396,18 +403,41 @@ function detectDevServer(cwd: string, requestedPort?: number): DevServer | null 
   // (a) CLAUDE.md says "Always use Bun" and (b) bunx serve starts
   // faster and supports live reload with --single. Falls back to
   // python3 only if bunx is not on PATH.
-  if (existsSync(join(cwd, "index.html")) && !existsSync(join(cwd, "package.json"))) {
+  if (!existsSync(join(cwd, "package.json"))) {
+    // Prefer index.html if present, otherwise fall back to any single
+    // .html file in the directory root. This handles the Orbital-style
+    // case where the model creates orbital.html instead of index.html.
+    let htmlFile: string | null = null;
     try {
-      const size = statSync(join(cwd, "index.html")).size;
-      if (size >= 500) {
-        const hasBunx = tryWhich("bunx");
-        const command = hasBunx
-          ? `bunx serve -l ${port} .`
-          : `python3 -m http.server ${port}`;
-        return { name: "Static", command, port, needsInstall: false };
+      if (existsSync(join(cwd, "index.html"))) {
+        htmlFile = "index.html";
+      } else {
+        const entries = readdirSync(cwd, { withFileTypes: true });
+        const htmlFiles = entries
+          .filter((e) => e.isFile() && e.name.toLowerCase().endsWith(".html"))
+          .map((e) => e.name);
+        // Only auto-serve when there's EXACTLY one HTML file — multiple
+        // HTML files are ambiguous and would need a user hint.
+        if (htmlFiles.length === 1) htmlFile = htmlFiles[0]!;
+      }
+      if (htmlFile) {
+        const size = statSync(join(cwd, htmlFile)).size;
+        if (size >= 500) {
+          const hasBunx = tryWhich("bunx");
+          const command = hasBunx
+            ? `bunx serve -l ${port} .`
+            : `python3 -m http.server ${port}`;
+          return {
+            name: "Static",
+            command,
+            port,
+            needsInstall: false,
+            htmlFile,
+          };
+        }
       }
     } catch {
-      /* ignore stat errors */
+      /* ignore stat/readdir errors */
     }
   }
 
@@ -424,7 +454,7 @@ function tryWhich(bin: string): boolean {
   }
 }
 
-function startDevServer(srv: DevServer, cwd: string): Level1Result {
+export function startDevServer(srv: DevServer, cwd: string): Level1Result {
   // Step 1: Install dependencies if needed
   if (srv.needsInstall && srv.installCmd) {
     const installResult = run(srv.installCmd, cwd, 120_000);
@@ -468,7 +498,8 @@ function startDevServer(srv: DevServer, cwd: string): Level1Result {
       // Non-fatal: the server is started; only last-project write failed.
     }
 
-    const portInfo = srv.port > 0 ? `\n  🌐 http://localhost:${srv.port}` : "";
+    const urlPath = srv.htmlFile && srv.htmlFile !== "index.html" ? `/${srv.htmlFile}` : "";
+    const portInfo = srv.port > 0 ? `\n  🌐 http://localhost:${srv.port}${urlPath}` : "";
     // Show explicit shell commands so the user can copy them into
     // another terminal (or their notes) to manage the server manually.
     // The `kill` command uses the child PID directly — that's the


### PR DESCRIPTION
## Summary

The v2.10.59 Orbital session ended with `orbital.html` on disk but no running server. The user's prompt explicitly asked for a server "que levante automáticamente la aplicación en el puerto 24564" — the model created the file but never executed the runtime step. The user said "kcode debe levantar el servicio y explicarle al usuario como detenerlo".

## How it works

Post-turn hook in `conversation.ts` fires once per session when ALL four guards pass:

1. **Runtime intent**: user's session text contains `levantar`, `ejecutar`, `arrancar`, `lanzar`, `run`, `launch`, `start`, `dashboard`, `servidor web`, `puerto N`, `port N`, `http://localhost`, etc.
2. **Successful Write this turn**: walks the current turn (after last user text) looking for a Write tool_result with `is_error: false` and `Created` in the output
3. **Runnable project in cwd**: `detectDevServer(cwd)` returns a descriptor
4. **Target port free**: `ss` probe with 1s timeout, fails open

If all pass, calls the existing `startDevServer` and injects a user-visible notice:

```
── Auto-launched dev server ──
🌐 http://localhost:11000/orbital.html
PID: 822685
To stop:
  kill 822685
  or: pkill -f 'bunx'
  or in kcode: "para el server" / /stop
```

## Other changes

- **`detectDevServer`** extended to match any single `*.html` file in the cwd, not only `index.html`. Handles the Orbital-style case where the model named its file `orbital.html`.
- **`DevServer`** interface gained an optional `htmlFile` field so `startDevServer` can build the URL path as `http://host:port/orbital.html` instead of the bare directory listing.
- **`detectDevServer`** and **`startDevServer`** exported from `task-orchestrator/level1-handlers.ts` so the new auto-launch module can reuse them.
- Hook runs ONLY when `stopReason === "end_turn"` — never during tool_use continuation, so we don't launch mid-reasoning.

## Test plan

- [x] 11 new tests in `auto-launch-dev-server.test.ts`: runtime-intent classification, per-turn Write scoping, session state reset
- [x] Full regression: **6340 pass / 0 fail** (up from 6329)
- [x] `hasRuntimeIntent` fires on the actual Orbital prompt fragment
- [x] `hasRunnableWriteInTurn` correctly scopes to the current turn and ignores earlier Writes
- [x] Failed Writes (`is_error: true`) do not trigger auto-launch