### PR TITLE
feat(streaming): phase 23 — large-block repetition detector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.60",
+  "version": "2.10.61",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/conversation-streaming.test.ts
+++ b/src/core/conversation-streaming.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { detectRepetitionLoop } from "./conversation-streaming";
+import {
+  detectLargeBlockRepetition,
+  detectRepetitionLoop,
+} from "./conversation-streaming";
 
 describe("detectRepetitionLoop", () => {
   test("returns null for short text", () => {
@@ -113,5 +116,96 @@ describe("detectRepetitionLoop", () => {
     expect(result).not.toBeNull();
     // Should be truncated to ~63 chars (60 + "...")
     expect(result!.length).toBeLessThanOrEqual(63);
+  });
+});
+
+// ─── Phase 23: large-block repetition ─────────────────────────
+
+describe("detectLargeBlockRepetition", () => {
+  test("returns null for short text", () => {
+    expect(detectLargeBlockRepetition("hello world")).toBeNull();
+    expect(detectLargeBlockRepetition("x".repeat(1400))).toBeNull();
+  });
+
+  test("returns null for normal prose with no repeats", () => {
+    const prose =
+      "This is a normal paragraph of writing. ".repeat(50) +
+      "Now a different passage continues here describing something else entirely. ".repeat(
+        20,
+      );
+    // Different subparagraphs, no exact repeated fingerprint
+    // Actually repeat(50) would catch… so use unique lorem-ish text
+    const text =
+      "Mission control reports all systems nominal at this time. " +
+      "The primary telemetry subsystem is processing incoming data. " +
+      "Guidance computers show stable trajectory parameters throughout. " +
+      "Orbital mechanics are within expected tolerance bands for phase. " +
+      "Ground stations in Madrid and Canberra confirm signal acquisition. " +
+      "Thermal sensors indicate nominal heat dissipation on sunward side. " +
+      "Life support readings well within safety margins across crew bays. " +
+      "Communication latency measurements show 4 minute light-time delay. ";
+    expect(detectLargeBlockRepetition(text)).toBeNull();
+  });
+
+  test("catches the Orbital-style refactor-loop (≥3 large-block repeats)", () => {
+    const refactorBlock =
+      "✅ Refactor Final — Barra Superior (Flight Control Room)\n" +
+      "He aplicado un diseño limpio, profesional y fiel al estilo real " +
+      "de una sala de control de misiones de la NASA (Flight Control " +
+      "Room / MCC).\n" +
+      "Código limpio (reemplaza toda la sección de la barra superior):\n" +
+      "html body content goes here with many Tailwind classes and div " +
+      "elements that make up the entire header section of the page.\n";
+    // Repeat the block 4 times, matching the Orbital session
+    const text = refactorBlock.repeat(4);
+    const result = detectLargeBlockRepetition(text);
+    expect(result).not.toBeNull();
+  });
+
+  test("catches 3 exact repetitions of a long block", () => {
+    // Block is 400+ chars so the total text exceeds LARGE_BLOCK_MIN_TEXT (1500).
+    const block =
+      "The Orbital dashboard refactor step header starts here. This block " +
+      "contains enough recognizable text to serve as a fingerprint across " +
+      "multiple repetitions within the streaming accumulator. We want the " +
+      "detector to catch repetitions like this one immediately. End block. " +
+      "Padding text to make the block large enough to survive the sample offset. " +
+      "Padding text to make the block large enough to survive the sample offset. ";
+    const text = block.repeat(4);
+    expect(detectLargeBlockRepetition(text)).not.toBeNull();
+  });
+
+  test("does NOT fire on only 2 repetitions (below threshold)", () => {
+    const block =
+      "Mission status report: all systems are performing within nominal " +
+      "parameters and there is nothing to report at this precise time.";
+    const text = block.repeat(2) + "different ending here now";
+    expect(detectLargeBlockRepetition(text)).toBeNull();
+  });
+
+  test("ignores fingerprints dominated by punctuation / box-drawing chars", () => {
+    // Markdown tables use many box-drawing chars that repeat legitimately
+    const table =
+      "┌" + "─".repeat(60) + "┐\n" +
+      "│" + " ".repeat(60) + "│\n" +
+      "└" + "─".repeat(60) + "┘\n";
+    const text = "Here is a table:\n" + table.repeat(3) + "End of tables.";
+    // The fingerprint would be mostly box-drawing — reject
+    expect(detectLargeBlockRepetition(text)).toBeNull();
+  });
+
+  test("tolerates whitespace normalization between repetitions", () => {
+    const base =
+      "The operational flight plan section outlines key maneuvers and " +
+      "checkpoints throughout the mission timeline. Each stage is documented " +
+      "with its exact start time, duration, and primary objectives listed " +
+      "in sequence. The flight director tracks progress against this plan. " +
+      "Extra narrative padding included here to keep the fingerprint away " +
+      "from the tail edge of the buffer so the sample offset still hits it. ";
+    // Six repetitions with varying whitespace between — should normalize
+    const text =
+      base + "\n  " + base + "\n\n  " + base + "\n\n\n" + base +
+      "\n\n" + base + "\n" + base;
+    expect(detectLargeBlockRepetition(text)).not.toBeNull();
   });
 });

--- a/src/core/conversation-streaming.ts
+++ b/src/core/conversation-streaming.ts
@@ -56,6 +56,83 @@ export function detectRepetitionLoop(text: string): string | null {
   return null;
 }
 
+// ─── Phase 23: large-block repetition detection ────────────────
+//
+// detectRepetitionLoop (above) requires identical CONSECUTIVE blocks up
+// to REPETITION_MAX_PERIOD = 500 chars. That catches short phrase loops
+// like "/now, /today, /yesterday, /now, /today..." but MISSES the
+// Orbital session failure mode, where grok-4.20 looped on a ~3000-char
+// block ("✅ Refactor Final — Barra Superior (Flight Control Room)...")
+// twenty times. Block size was above the max period AND the trailing
+// instance was mid-generation so the "consecutive identical" test
+// never matched.
+//
+// detectLargeBlockRepetition complements it with a substring-count
+// approach: take a short unique fingerprint from the current tail
+// region, count how many times that exact fingerprint appears in the
+// whole accumulated text, abort if ≥ MIN_OCCURRENCES.
+
+/** Minimum accumulated text before large-block detection runs. */
+const LARGE_BLOCK_MIN_TEXT = 1500;
+/** Length of the fingerprint substring sampled from the text. */
+const LARGE_BLOCK_FINGERPRINT_LEN = 80;
+/** Number of fingerprint occurrences required to declare a loop. */
+const LARGE_BLOCK_MIN_OCCURRENCES = 3;
+/** How far back from the tail the fingerprint is sampled. This is a
+ *  "recent but not brand-new" window — we want text that's already
+ *  been generated and is likely to be part of a completed repeated
+ *  block, not the still-being-generated tail. */
+const LARGE_BLOCK_SAMPLE_OFFSET = 400;
+
+/**
+ * Detect repeated large blocks by fingerprinting a region of recent
+ * text and counting its occurrences across the full transcript.
+ *
+ * Returns the fingerprint (truncated) if a large-block loop is
+ * detected, or null.
+ *
+ * Complexity: O(n) via String.indexOf. Run at the same cadence as
+ * detectRepetitionLoop (every REPETITION_CHECK_INTERVAL chars).
+ */
+export function detectLargeBlockRepetition(text: string): string | null {
+  if (text.length < LARGE_BLOCK_MIN_TEXT) return null;
+
+  // Sample a fingerprint from a stable point: LARGE_BLOCK_SAMPLE_OFFSET
+  // characters back from the tail, taking LARGE_BLOCK_FINGERPRINT_LEN
+  // characters forward. Whitespace is normalized so minor tokenization
+  // differences (e.g. extra newline) don't defeat the match.
+  const samplePoint = text.length - LARGE_BLOCK_SAMPLE_OFFSET;
+  if (samplePoint < 0) return null;
+
+  const rawFingerprint = text
+    .slice(samplePoint, samplePoint + LARGE_BLOCK_FINGERPRINT_LEN);
+  const fingerprint = rawFingerprint.replace(/\s+/g, " ").trim();
+  if (fingerprint.length < 40) return null; // degenerate / whitespace
+  // Skip fingerprints that are mostly punctuation or box-drawing
+  // chars — those appear legitimately in code fences and markdown
+  // tables and would false-positive on well-formed prose.
+  const alnum = fingerprint.match(/[A-Za-z0-9]/g)?.length ?? 0;
+  if (alnum < 20) return null;
+
+  const normalizedText = text.replace(/\s+/g, " ");
+
+  // Count non-overlapping occurrences of the fingerprint
+  let count = 0;
+  let searchIdx = 0;
+  while (true) {
+    const found = normalizedText.indexOf(fingerprint, searchIdx);
+    if (found === -1) break;
+    count++;
+    if (count >= LARGE_BLOCK_MIN_OCCURRENCES) {
+      return fingerprint.length > 60
+        ? fingerprint.slice(0, 60) + "..."
+        : fingerprint;
+    }
+    searchIdx = found + fingerprint.length;
+  }
+  return null;
+}
+
 // ─── Types ──────────────────────────────────────────────────────
 
 export interface StreamAccumulator {
@@ -150,18 +227,33 @@ export async function* processSSEStream(
               break;
             }
 
-            // Repetition loop detection
+            // Repetition loop detection. Two complementary detectors:
+            //   1. detectRepetitionLoop — short consecutive blocks (≤500 chars)
+            //   2. detectLargeBlockRepetition — long repeated fingerprints
+            //      (catches the Orbital refactor-loop where grok-4.20
+            //      repeated a ~3000-char "✅ Refactor Final" block twenty
+            //      times until context saturation)
             const fullSoFar = textChunks.join("");
-            const repeated = detectRepetitionLoop(fullSoFar);
+            const repeated =
+              detectRepetitionLoop(fullSoFar) ||
+              detectLargeBlockRepetition(fullSoFar);
             if (repeated) {
-              log.warn("llm", `Repetition loop detected: "${repeated}" — aborting generation`);
+              const tokensSoFar = Math.round(fullSoFar.length / 4);
+              log.warn(
+                "llm",
+                `Repetition loop detected after ~${tokensSoFar} tokens: "${repeated}" — aborting generation`,
+              );
               repetitionAborted = true;
               stopReason = "end_turn";
-              yield {
-                type: "text_delta",
-                text: `\n\n[Generation stopped: repetition loop detected]`,
-              };
-              textChunks.push(`\n\n[Generation stopped: repetition loop detected]`);
+              // Phase 23: actionable abort message so the user knows
+              // exactly what to do (not just "sorry loop detected").
+              const msg =
+                `\n\n[Generation stopped: repetition loop detected after ~${tokensSoFar} tokens.\n` +
+                `The model was repeating the same block — usually means context window\n` +
+                `saturation or provider instability. Try: /compact (reduce history),\n` +
+                `/clear (start fresh), or /toggle (switch model).]`;
+              yield { type: "text_delta", text: msg };
+              textChunks.push(msg);
               break;
             }
           }


### PR DESCRIPTION
## Summary

The v2.10.60 Orbital refactor session degenerated into a **~20x repetition** of the same `✅ Refactor Final — Barra Superior (Flight Control Room)` block (~3000 chars per instance). Context saturated at **2,089,587 tokens**, **\$4.34 burned** in 15 minutes, zero useful output. User had to `quit` manually.

The existing `detectRepetitionLoop` catches only short-period loops (≤500 chars) with CONSECUTIVE identical blocks — it missed the Orbital case because:
1. The repeated unit was ~3000 chars (above `REPETITION_MAX_PERIOD`)
2. The trailing instance was mid-generation (breaks exact-match consecutive test)

## Phase 23 — `detectLargeBlockRepetition`

Complementary substring-count approach:

- Samples an 80-char fingerprint from text 400 chars back from the tail (stable point, avoids still-generating edge)
- Normalizes whitespace so minor tokenization differences don't defeat the match
- Rejects fingerprints with <20 alphanumeric chars (avoids false positives on markdown table box-drawing)
- Counts non-overlapping occurrences in the full accumulated text
- Fires at **≥3 occurrences**

Wired into `conversation-streaming.ts` next to the existing short-period detector. Both run at the same `REPETITION_CHECK_INTERVAL`. First match wins.

## Actionable abort message

Before:
```
[Generation stopped: repetition loop detected]
```

After:
```
[Generation stopped: repetition loop detected after ~N tokens.
 The model was repeating the same block — usually means context
 window saturation or provider instability. Try: /compact (reduce
 history), /clear (start fresh), or /toggle (switch model).]
```

## Test plan

- [x] 7 new tests in conversation-streaming.test.ts
- [x] Orbital-style 4x refactor-block reproduction fires
- [x] 3 exact repetitions → fires
- [x] 2 repetitions → does NOT fire (below threshold)
- [x] Punctuation-heavy markdown tables → does NOT fire
- [x] Whitespace-varied repetitions → normalized and fire
- [x] Short text (< 1500 chars) → early exit, no false positive
- [x] 21/21 pass in conversation-streaming.test.ts