### PR TITLE
fix: audit followup — phase 22 stream event type + phase 24 node pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.62",
+  "version": "2.10.63",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/bash-spawn-verifier.test.ts
+++ b/src/core/bash-spawn-verifier.test.ts
@@ -33,6 +33,18 @@ describe("detectServerSpawn", () => {
     ["nodemon index.js", "nodemon"],
     ["serve -s build", "static-serve"],
     ["http-server -p 10080", "static-serve"],
+    // Phase 24 audit fix: bare `node <server-file>` shapes used
+    // when the user bypasses `npm run dev` (exactly the Orbital
+    // case where the model invoked `node server.js` directly).
+    ["node server.js", "node-direct"],
+    ["node app.js", "node-direct"],
+    ["node index.js", "node-direct"],
+    ["node main.js", "node-direct"],
+    ["node src/server.js", "node-direct"],
+    ["node ./server.mjs", "node-direct"],
+    ["node server.cjs", "node-direct"],
+    ["bun server.ts", "bun-direct"],
+    ["bun run app.ts", "bun-direct"],
   ])("detects %p as %p", (cmd, framework) => {
     const d = detectServerSpawn(cmd);
     expect(d).not.toBeNull();
@@ -50,6 +62,15 @@ describe("detectServerSpawn", () => {
     ["cat package.json"],
     ["npm run build"],
     ["npm run test"],
+    // Phase 24 audit fix: bare node invocations that are NOT a
+    // server (migration scripts, one-shot tools, benchmarks).
+    // These must NOT be auto-backgrounded — the user needs to see
+    // stdout and exit code inline.
+    ["node scripts/migrate.js"],
+    ["node benchmarks/bench.js"],
+    ["node tools/generate.js"],
+    ["node build.js"],
+    ["node ./scripts/cleanup.cjs"],
   ])("does NOT match one-shot command %p", (cmd) => {
     expect(detectServerSpawn(cmd)).toBeNull();
   });

--- a/src/core/bash-spawn-verifier.ts
+++ b/src/core/bash-spawn-verifier.ts
@@ -86,6 +86,28 @@ export function detectServerSpawn(command: string): SpawnDetection | null {
   if (/\bserve\s/.test(c) || /\bhttp-server\b/.test(c))
     return { framework: "static-serve", defaultPort: 3000 };
 
+  // Bare `node <file>.js` invocations where the filename hints at a
+  // server. `node server.js`, `node app.js`, `node index.js`, and
+  // `node main.js` are the canonical "run the server directly" shapes
+  // used when the user bypasses `npm run dev`. Only trigger on the
+  // filename allowlist to avoid hijacking one-shot scripts like
+  // `node scripts/migrate.js` or `node benchmarks/bench.js`.
+  if (
+    /\bnode\s+(?:[\w\-/.]+\/)?(?:server|app|index|main)\.(?:js|mjs|cjs)\b/.test(
+      c,
+    )
+  ) {
+    return { framework: "node-direct", defaultPort: 3000 };
+  }
+  // Bun equivalent
+  if (
+    /\bbun\s+(?:run\s+)?(?:[\w\-/.]+\/)?(?:server|app|index|main)\.(?:ts|js|mjs|cjs)\b/.test(
+      c,
+    )
+  ) {
+    return { framework: "bun-direct", defaultPort: 3000 };
+  }
+
   return null;
 }
 

--- a/src/core/conversation.ts
+++ b/src/core/conversation.ts
@@ -1918,7 +1918,11 @@ export class ConversationManager {
               role: "assistant",
               content: launchResult.notice,
             });
-            yield { type: "text", text: launchResult.notice };
+            // Must be text_delta — StreamEvent has no "text" variant.
+            // The UI renders text_delta events via print-mode and
+            // stream-handler. The bug from the initial phase 22 ship
+            // was yielding type: "text", which silently dropped.
+            yield { type: "text_delta", text: launchResult.notice };
           }
         } catch (err) {
           log.debug("auto-launch", `hook failed (non-fatal): ${err}`);

--- a/src/tools/bash.test.ts
+++ b/src/tools/bash.test.ts
@@ -206,55 +206,11 @@ try {
     expect(result.is_error).toBeFalsy();
   });
 
-  // ─── Phase 24: modern server patterns (Orbital regression) ───
-
-  test("auto-backgrounds `npm run dev` (Orbital regression)", async () => {
-    // npm run dev was NOT in the inline regex pre-phase-24 and got
-    // killed at the 4s mark, reported as "Bash failed" even though
-    // the server was booting. Now routed via detectServerSpawn.
-    const start = Date.now();
-    await executeBash({ command: "echo 'would run npm run dev' && exit 0" });
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeLessThan(20_000);
-  });
-
-  test("auto-backgrounds `node server.js`", async () => {
-    const start = Date.now();
-    await executeBash({ command: "echo 'would run node server.js' && exit 0" });
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeLessThan(20_000);
-  });
-
-  test("auto-backgrounds `next dev`", async () => {
-    const start = Date.now();
-    await executeBash({ command: "echo 'would run next dev' && exit 0" });
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeLessThan(20_000);
-  });
-
-  test("auto-backgrounds `vite` standalone", async () => {
-    const start = Date.now();
-    await executeBash({ command: "echo 'would run vite' && exit 0" });
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeLessThan(20_000);
-  });
-
-  test("auto-backgrounds `bun run dev`", async () => {
-    const start = Date.now();
-    await executeBash({ command: "echo 'would run bun run dev' && exit 0" });
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeLessThan(20_000);
-  });
-
-  test("does NOT auto-background `node scripts/oneshot.js`", async () => {
-    // One-shot node scripts that aren't the server file should stay
-    // foreground so the user sees stdout and exit code immediately.
-    const start = Date.now();
-    const result = await executeBash({ command: "echo 'one-shot script'" });
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeLessThan(5_000);
-    expect(result.content).toContain("one-shot script");
-  });
+  // Phase 24 detection coverage now lives in bash-spawn-verifier.test.ts
+  // where detectServerSpawn is unit-tested directly. Echo-wrapped bash
+  // integration tests are tautologies — the echo exits in <20ms so the
+  // assertion passes regardless of whether auto-backgrounding runs. See
+  // the phase 24 audit for details.
 
   // ─── tool_use_id is always empty string ───
 


### PR DESCRIPTION
## Summary

Self-audit of phases 17-24 surfaced two real bugs and one test-quality issue. This PR addresses all three.

## Bug #1 — phase 22 auto-launch notice was never shown to the user

`conversation.ts:1921` yielded `{ type: "text", text: ... }` but `StreamEvent` has no `"text"` variant — the correct one is `"text_delta"`, handled by `print-mode.ts` and `stream-handler.ts`. The TypeScript error was visible in `bun run typecheck` but I'd dismissed it as pre-existing noise from conversation.ts's other pre-existing errors. It wasn't — it was mine.

**Result**: the notice was stored in `state.messages` (model sees it next turn) but **silently dropped before reaching the terminal**. User never saw the launch URL, PID, or stop instructions — the entire point of phase 22. Entire feature was cosmetically broken from the initial ship.

**Fix**: one-word change `"text"` → `"text_delta"`.

## Bug #2 — phase 24 didn't cover `node server.js`

Phase 24 added `detectServerSpawn` fallback to `bash.ts`, but `detectServerSpawn` itself had no regex for bare `node <file>.js` invocations. `npm run dev` worked; `node server.js` (exactly what the Orbital prompt generated) did not — it still got killed at ~4s in the foreground path.

**Fix**: add `node-direct` and `bun-direct` patterns matched on a **filename allowlist** (`server`, `app`, `index`, `main`) so one-shot scripts like `node scripts/migrate.js` still stay in the foreground where the user can see stdout and exit code.

## Test-quality fix — phase 24 tests were tautologies

All six new `bash.test.ts` tests used `echo 'would run X' && exit 0` as a stand-in. Echo exits in <20ms, so `elapsed < 20_000` passed whether auto-backgrounding ran or not. They validated nothing. Removed them in favor of direct unit tests on `detectServerSpawn` in `bash-spawn-verifier.test.ts`, where the decision logic is pure and actually testable:

- **9 new positive cases**: `node server.js`, `node app.js`, `node index.js`, `node main.js`, `node src/server.js`, `node ./server.mjs`, `node server.cjs`, `bun server.ts`, `bun run app.ts`
- **5 new negative cases** (must NOT match): `node scripts/migrate.js`, `node benchmarks/bench.js`, `node tools/generate.js`, `node build.js`, `node ./scripts/cleanup.cjs`

## Test plan

- [x] `bun test src/core/bash-spawn-verifier.test.ts` → 98 pass / 0 fail
- [x] `bun test src/tools/bash.test.ts` → 24 pass / 0 fail (after removing tautologies)
- [x] `bun test src/core/auto-launch-dev-server.test.ts src/core/conversation-streaming.test.ts` → 32 pass / 0 fail
- [x] Full regression running separately