### PR TITLE
fix(auto-launch): detect single-html cwd (Bug #6) + extract user port

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.63",
+  "version": "2.10.64",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/auto-launch-dev-server.test.ts
+++ b/src/core/auto-launch-dev-server.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   __autoLaunchSessionState,
+  extractRequestedPort,
   hasRunnableWriteInTurn,
   hasRuntimeIntent,
   resetAutoLaunchState,
@@ -215,5 +216,47 @@ describe("resetAutoLaunchState", () => {
     resetAutoLaunchState();
     expect(__autoLaunchSessionState.launched).toBe(false);
     expect(__autoLaunchSessionState.launchedCwd).toBe("");
+  });
+});
+
+describe("extractRequestedPort", () => {
+  test("extracts port from Orbital prompt fragment", () => {
+    const orbitalFragment =
+      "Incluir al final del archivo un servidor web simple usando Node.js + Express " +
+      "que levante automáticamente la aplicación en el puerto 24564";
+    expect(extractRequestedPort([orbitalFragment])).toBe(24564);
+  });
+
+  test("extracts English 'port N' phrasing", () => {
+    expect(extractRequestedPort(["start the server on port 3000"])).toBe(3000);
+    expect(extractRequestedPort(["listen at port 8080"])).toBe(8080);
+  });
+
+  test("extracts 'puerto N' and 'puerto:N' phrasing", () => {
+    expect(extractRequestedPort(["usa el puerto 5173"])).toBe(5173);
+    expect(extractRequestedPort(["puerto: 9090"])).toBe(9090);
+  });
+
+  test("ignores out-of-range ports", () => {
+    // Privileged / too-low ports are rejected
+    expect(extractRequestedPort(["port 22"])).toBeUndefined();
+    expect(extractRequestedPort(["port 80"])).toBeUndefined();
+    // 1024 is the floor — this test documents the boundary
+    expect(extractRequestedPort(["port 1023"])).toBeUndefined();
+    expect(extractRequestedPort(["port 1024"])).toBe(1024);
+  });
+
+  test("returns undefined when no port mentioned", () => {
+    expect(extractRequestedPort(["make a web app"])).toBeUndefined();
+    expect(extractRequestedPort([])).toBeUndefined();
+  });
+
+  test("scans across all user texts, returns first match", () => {
+    const texts = [
+      "crea una aplicacion",
+      "en el puerto 24564",
+      "ponle un header",
+    ];
+    expect(extractRequestedPort(texts)).toBe(24564);
   });
 });

--- a/src/core/auto-launch-dev-server.ts
+++ b/src/core/auto-launch-dev-server.ts
@@ -201,6 +201,24 @@ export interface AutoLaunchResult {
   url?: string;
 }
 
+/**
+ * Extract an explicit port number from the user's text. Matches shapes
+ * like "en el puerto 24564", "on port 3000", "puerto: 8080". Returns
+ * the first valid port found, or undefined.
+ */
+export function extractRequestedPort(userTexts: readonly string[]): number | undefined {
+  const re = /\b(?:puerto|port)\s*[:=]?\s*(\d{2,5})\b/i;
+  for (const text of userTexts) {
+    if (!text) continue;
+    const m = text.match(re);
+    if (m?.[1]) {
+      const n = parseInt(m[1], 10);
+      if (n >= 1024 && n <= 65535) return n;
+    }
+  }
+  return undefined;
+}
+
 export async function maybeAutoLaunchDevServer(
   cwd: string,
   messages: Message[],
@@ -219,8 +237,11 @@ export async function maybeAutoLaunchDevServer(
       return null;
     }
 
-    // Guard 3: a runnable project must exist in cwd
-    const srv = detectDevServer(cwd);
+    // Guard 3: a runnable project must exist in cwd. If the user's
+    // prompt mentioned an explicit port (e.g. "en el puerto 24564"),
+    // honor it by passing to detectDevServer.
+    const requestedPort = extractRequestedPort(userTexts);
+    const srv = detectDevServer(cwd, requestedPort);
     if (!srv) {
       log.debug("auto-launch", "skipped: detectDevServer returned null");
       return null;

--- a/src/core/task-orchestrator/level1-handlers.test.ts
+++ b/src/core/task-orchestrator/level1-handlers.test.ts
@@ -8,10 +8,10 @@
 // file locks down the exact boundaries so we don't regress.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { tryLevel1 } from "./level1-handlers";
+import { detectDevServer, tryLevel1 } from "./level1-handlers";
 
 describe("tryLevel1 — start-verb boundaries", () => {
   let cwd: string;
@@ -101,5 +101,66 @@ describe("tryLevel1 — other verb anchors (regression guards)", () => {
   test("'git status for the branch' is NOT intercepted", () => {
     const r = tryLevel1("git status for the branch", cwd);
     expect(r.handled).toBe(false);
+  });
+});
+
+// ─── Phase 22 Bug #6 regression — single-HTML detection ─────────
+
+describe("detectDevServer — static HTML files", () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "kcode-detect-html-"));
+  });
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  test("detects orbital.html (single non-index .html at cwd root) — Bug #6 regression", () => {
+    // Pre-fix: cwd with orbital.html but no index.html and no
+    // package.json hit the early-return subdirectory-scan block
+    // and returned null without reaching the static-HTML branch.
+    const content = "<!DOCTYPE html><html><head><title>Orbital</title></head><body>" +
+      "x".repeat(600) + "</body></html>";
+    writeFileSync(join(cwd, "orbital.html"), content);
+    const srv = detectDevServer(cwd);
+    expect(srv).not.toBeNull();
+    expect(srv!.name).toBe("Static");
+    expect(srv!.htmlFile).toBe("orbital.html");
+  });
+
+  test("detects index.html at cwd root (existing behavior)", () => {
+    const content = "<!DOCTYPE html><html><body>" + "x".repeat(600) + "</body></html>";
+    writeFileSync(join(cwd, "index.html"), content);
+    const srv = detectDevServer(cwd);
+    expect(srv).not.toBeNull();
+    expect(srv!.htmlFile).toBe("index.html");
+  });
+
+  test("returns null when cwd has multiple .html files (ambiguous)", () => {
+    // Multiple HTML files without a clear entry point should be
+    // ambiguous — we don't want to pick one at random.
+    const content = "<!DOCTYPE html><html><body>" + "x".repeat(600) + "</body></html>";
+    writeFileSync(join(cwd, "foo.html"), content);
+    writeFileSync(join(cwd, "bar.html"), content);
+    const srv = detectDevServer(cwd);
+    expect(srv).toBeNull();
+  });
+
+  test("returns null when orbital.html is too small (< 500 bytes)", () => {
+    writeFileSync(join(cwd, "orbital.html"), "<!DOCTYPE html>placeholder");
+    expect(detectDevServer(cwd)).toBeNull();
+  });
+
+  test("returns null on empty cwd", () => {
+    expect(detectDevServer(cwd)).toBeNull();
+  });
+
+  test("honors requestedPort argument", () => {
+    const content = "<!DOCTYPE html><html><body>" + "x".repeat(600) + "</body></html>";
+    writeFileSync(join(cwd, "orbital.html"), content);
+    const srv = detectDevServer(cwd, 24564);
+    expect(srv).not.toBeNull();
+    expect(srv!.port).toBe(24564);
   });
 });

--- a/src/core/task-orchestrator/level1-handlers.ts
+++ b/src/core/task-orchestrator/level1-handlers.ts
@@ -291,11 +291,29 @@ export function detectDevServer(cwd: string, requestedPort?: number): DevServer 
   // kcode dev-server port range.
   const port = requestedPort ?? findFreePort(KCODE_PORT_FLOOR, KCODE_PORT_CEILING);
 
-  // If no project in cwd, check common project subdirectory names
+  // Phase 22 Bug #6 fix: before running the subdirectory scan / early
+  // return, check whether cwd already contains an HTML file at its
+  // root. If it does, fall through to the static-HTML branch below so
+  // `orbital.html` / `dashboard.html` / any single-file site without a
+  // package.json gets picked up. Pre-fix: `!existsSync(".../index.html")`
+  // caused us to enter the subdir scan, find nothing, and return null,
+  // skipping the extended static-HTML detection entirely.
+  let cwdHasRootHtml = false;
+  try {
+    const entries = readdirSync(cwd, { withFileTypes: true });
+    cwdHasRootHtml = entries.some(
+      (e) => e.isFile() && e.name.toLowerCase().endsWith(".html"),
+    );
+  } catch {
+    /* unreadable — treat as no html, fall through to subdir scan */
+  }
+
+  // If no project in cwd AND no root HTML file, check common project
+  // subdirectory names.
   if (!existsSync(join(cwd, "package.json")) && !existsSync(join(cwd, "go.mod")) &&
       !existsSync(join(cwd, "Cargo.toml")) && !existsSync(join(cwd, "pyproject.toml")) &&
       !existsSync(join(cwd, "mix.exs")) && !existsSync(join(cwd, "docker-compose.yml")) &&
-      !existsSync(join(cwd, "index.html"))) {
+      !cwdHasRootHtml) {
     // Check well-known project directory names first (fast)
     const commonNames = ["my-site", "my-app", "app", "web", "frontend", "backend", "api", "server", "project", "site"];
     for (const name of commonNames) {


### PR DESCRIPTION
## Summary

The v2.10.63 Orbital session confirmed phase 22 still wasn't firing. Model wrote `orbital.html` to `/home/curly/projects`, prompt said "en el puerto 24564", all three main guards should have passed — but **no auto-launch notice appeared**. The audit missed Bug #6.

## Root cause

`detectDevServer` had an early-return block:

```js
if (!existsSync("package.json") && !existsSync("go.mod") && ... &&
    !existsSync("index.html")) {
  // scan subdirectories → return null
}
```

The Orbital cwd (`orbital.html` at root, no `package.json`, no `index.html`) entered this block, found nothing runnable in subdirs, and returned `null` **before reaching the extended static-HTML branch** I added in PR #26 for exactly this case. The static-HTML branch was dead code for the target scenario.

## Fix

1. Probe the cwd for any root `.html` file **before** the early-return check via `readdirSync` + `.some(e => e.name.endsWith(".html"))`. If one exists, skip the subdir scan and fall through to the static-HTML branch.
2. New `extractRequestedPort` in `auto-launch-dev-server.ts` matches `/(?:puerto|port)\s*[:=]?\s*(\d{2,5})/i` and passes to `detectDevServer`. Orbital will now launch on 24564 (the user's requested port) instead of a random 11000-range port.

## Test plan

- [x] 6 new regression tests in `level1-handlers.test.ts` for `detectDevServer`:
  - orbital.html at root → Static/htmlFile=orbital.html ✓
  - index.html at root → preserved
  - multiple .html files → null (ambiguous)
  - < 500 byte html → null
  - empty cwd → null
  - requestedPort honored
- [x] 6 new tests for `extractRequestedPort`: Orbital fragment, English/Spanish shapes, out-of-range rejection, no-mention fallthrough, multi-text scan
- [x] 46/46 pass in affected files
- [x] Full regression running