### PR TITLE
fix(auto-launch): place phase 22 hook inside break branch (Bug #8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.64",
+  "version": "2.10.65",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/conversation.ts
+++ b/src/core/conversation.ts
@@ -1551,6 +1551,39 @@ export class ConversationManager {
         for (const msg of postTurnResult.injectMessages) this.state.messages.push(msg);
 
         if (postTurnResult.action === "break") {
+          // Phase 22: the model has finished its final response and the
+          // agent loop is about to exit. This is the correct firing
+          // point for auto-launch — the previous placement at the
+          // bottom of the while iteration was dead code because
+          // handlePostTurn breaks out of the loop BEFORE reaching it.
+          // The hook itself is guarded by runtime-intent + write-in-turn
+          // checks so it's safe to call on every normal break.
+          if (stopReason === "end_turn") {
+            try {
+              const { maybeAutoLaunchDevServer } = await import(
+                "./auto-launch-dev-server.js"
+              );
+              const { getUserTexts } = await import("./session-tracker.js");
+              const launchResult = await maybeAutoLaunchDevServer(
+                this.config.workingDirectory,
+                this.state.messages,
+                getUserTexts(),
+              );
+              if (launchResult) {
+                this.state.messages.push({
+                  role: "assistant",
+                  content: launchResult.notice,
+                });
+                yield { type: "text_delta", text: launchResult.notice };
+                log.info(
+                  "auto-launch",
+                  `phase 22 fired: ${launchResult.url ?? "no url"}`,
+                );
+              }
+            } catch (err) {
+              log.debug("auto-launch", `hook failed (non-fatal): ${err}`);
+            }
+          }
           this.abortController = null;
           break;
         }
@@ -1897,37 +1930,12 @@ export class ConversationManager {
         guardState.consecutiveDenials = 0;
       }
 
-      // Phase 22: if the model just finished its final response AND the
-      // user's original prompt had runtime intent AND a Write just
-      // completed, proactively launch the dev server and tell the user
-      // how to stop it. Fires only on "end_turn" — never during
-      // tool_use continuation, so we don't launch mid-reasoning.
-      if (stopReason === "end_turn") {
-        try {
-          const { maybeAutoLaunchDevServer } = await import(
-            "./auto-launch-dev-server.js"
-          );
-          const { getUserTexts } = await import("./session-tracker.js");
-          const launchResult = await maybeAutoLaunchDevServer(
-            this.config.workingDirectory,
-            this.state.messages,
-            getUserTexts(),
-          );
-          if (launchResult) {
-            this.state.messages.push({
-              role: "assistant",
-              content: launchResult.notice,
-            });
-            // Must be text_delta — StreamEvent has no "text" variant.
-            // The UI renders text_delta events via print-mode and
-            // stream-handler. The bug from the initial phase 22 ship
-            // was yielding type: "text", which silently dropped.
-            yield { type: "text_delta", text: launchResult.notice };
-          }
-        } catch (err) {
-          log.debug("auto-launch", `hook failed (non-fatal): ${err}`);
-        }
-      }
+      // Phase 22 moved: the correct firing point is inside the
+      // handlePostTurn break branch earlier in the loop. Placing it
+      // here was dead code — handlePostTurn's `action: "break"` path
+      // exits the loop BEFORE reaching this line for every normal
+      // end_turn, so the hook never ran in production. See Bug #8
+      // in the v2.10.64 audit.
 
       yield { type: "turn_end", stopReason };
       // Loop continues for next agent turn


### PR DESCRIPTION
## Summary

The latest Orbital `kcode.log` proves **phase 22 has never actually executed in production**. Zero mentions of `auto-launch` or `maybeAutoLaunchDevServer` in `~/.kcode/logs/kcode-2026-04-14.log`, despite the feature shipping in v2.10.60 and being "fixed" twice since (v2.10.63 for the `text_delta` bug, v2.10.64 for the detectDevServer early-return).

## Root cause

The hook was placed at the end of the agent-loop iteration (line 1905), but `handlePostTurn` at line 1517 returns `action: "break"` for every normal `end_turn` and the subsequent `break` at line 1555 exits the while loop **before** reaching line 1905.

Phase 22 has always been dead code on the happy path. The two previous "fixes" (#29 text_delta, #30 Bug #6) were therefore also dead code — fixing code that never ran. 

## Fix

Move the hook into the `if (postTurnResult.action === "break")` branch itself, just before the `break` statement. Guards remain the same. The dead code at line 1905 is replaced with a comment pointing at this audit finding.

## Audit trail for phase 22

| PR | Bug | What was wrong |
|---|---|---|
| #26 | ship | Initial phase 22 |
| #29 | #1 | `yield { type: "text" }` — not a valid StreamEvent variant |
| #29 | #2 | `detectServerSpawn` missing `node <file>.js` pattern |
| #30 | #6 | `detectDevServer` early-return before static-HTML branch |
| #30 | — | port extraction from user prompt |
| **#31** | **#8** | **hook placement — dead code on happy path** |

Without Bug #8 fix, every other phase 22 PR was fixing unreachable code.

## Test plan

- [x] 38 pass in `auto-launch-dev-server.test.ts` + `conversation-streaming.test.ts`
- [x] Full regression running separately
- [ ] Real end-to-end Orbital session (user will verify)