### PR TITLE
fix(auto-launch): skip [SYSTEM] injections in turn-boundary walk (Bug #10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.65",
+  "version": "2.10.66",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/auto-launch-dev-server.test.ts
+++ b/src/core/auto-launch-dev-server.test.ts
@@ -153,6 +153,47 @@ describe("hasRunnableWriteInTurn", () => {
     expect(hasRunnableWriteInTurn(messages)).toBe(false);
   });
 
+  test("Bug #10: skips [SYSTEM]-injected user messages when walking back", () => {
+    // Reproduces the Orbital v2.10.65 case where truncation retries
+    // injected [SYSTEM] Your response was cut off messages AFTER
+    // the original Writes, and hasRunnableWriteInTurn then treated
+    // the [SYSTEM] message as the turn boundary — hiding the Write.
+    const messages: Message[] = [
+      { role: "user", content: "levante la aplicación en puerto 24564" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "w1",
+            name: "Write",
+            input: { file_path: "/tmp/orbital.html", content: "<html></html>" },
+          } as unknown as never,
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "w1",
+            is_error: false,
+            content: "Created /tmp/orbital.html (987 lines)",
+          } as unknown as never,
+        ],
+      },
+      // handlePostTurn truncation retry injection
+      {
+        role: "user",
+        content:
+          '[SYSTEM] Your response was cut off. Here is how it ended: "..." Continue EXACTLY from that point.',
+      },
+      // Model generates more text (no tool call)
+      { role: "assistant", content: "More text here" },
+    ];
+    expect(hasRunnableWriteInTurn(messages)).toBe(true);
+  });
+
   test("scopes to the current turn only (ignores earlier user text)", () => {
     const messages: Message[] = [
       { role: "user", content: "earlier request" },

--- a/src/core/auto-launch-dev-server.ts
+++ b/src/core/auto-launch-dev-server.ts
@@ -111,7 +111,21 @@ export function hasRunnableWriteInTurn(messages: Message[]): boolean {
       i--;
       continue;
     }
-    if (typeof msg.content === "string") break;
+    if (typeof msg.content === "string") {
+      // Bug #10 fix: skip system-injected user messages when walking
+      // back to the turn boundary. `[SYSTEM]` messages come from
+      // truncation retries, stop-hook blocks, reality-check reminders,
+      // etc., and they should NOT count as the start of a new turn —
+      // the real user's request is still further back. Without this
+      // skip, hasRunnableWriteInTurn rejects phase 22 whenever
+      // handlePostTurn has done any iteration housekeeping, even
+      // though the user's actual Writes are visible.
+      if (msg.content.startsWith("[SYSTEM]")) {
+        i--;
+        continue;
+      }
+      break;
+    }
     if (Array.isArray(msg.content)) {
       const onlyToolResults = msg.content.every(
         (b) => (b as { type?: string }).type === "tool_result",

--- a/src/core/conversation.ts
+++ b/src/core/conversation.ts
@@ -1552,37 +1552,40 @@ export class ConversationManager {
 
         if (postTurnResult.action === "break") {
           // Phase 22: the model has finished its final response and the
-          // agent loop is about to exit. This is the correct firing
-          // point for auto-launch — the previous placement at the
-          // bottom of the while iteration was dead code because
-          // handlePostTurn breaks out of the loop BEFORE reaching it.
-          // The hook itself is guarded by runtime-intent + write-in-turn
-          // checks so it's safe to call on every normal break.
-          if (stopReason === "end_turn") {
-            try {
-              const { maybeAutoLaunchDevServer } = await import(
-                "./auto-launch-dev-server.js"
+          // agent loop is about to exit. The inner hasRuntimeIntent +
+          // hasRunnableWriteInTurn guards inside maybeAutoLaunchDevServer
+          // are sufficient; we drop the stopReason === "end_turn" gate
+          // because (a) the break path already implies the turn is
+          // ending, and (b) the gate was blocking firing on max_tokens
+          // or other legitimate end states. Safe to call on every break.
+          try {
+            const { maybeAutoLaunchDevServer } = await import(
+              "./auto-launch-dev-server.js"
+            );
+            const { getUserTexts } = await import("./session-tracker.js");
+            const launchResult = await maybeAutoLaunchDevServer(
+              this.config.workingDirectory,
+              this.state.messages,
+              getUserTexts(),
+            );
+            if (launchResult) {
+              this.state.messages.push({
+                role: "assistant",
+                content: launchResult.notice,
+              });
+              yield { type: "text_delta", text: launchResult.notice };
+              log.info(
+                "auto-launch",
+                `phase 22 fired: ${launchResult.url ?? "no url"}`,
               );
-              const { getUserTexts } = await import("./session-tracker.js");
-              const launchResult = await maybeAutoLaunchDevServer(
-                this.config.workingDirectory,
-                this.state.messages,
-                getUserTexts(),
+            } else {
+              log.debug(
+                "auto-launch",
+                `phase 22 skipped at break (stopReason=${stopReason})`,
               );
-              if (launchResult) {
-                this.state.messages.push({
-                  role: "assistant",
-                  content: launchResult.notice,
-                });
-                yield { type: "text_delta", text: launchResult.notice };
-                log.info(
-                  "auto-launch",
-                  `phase 22 fired: ${launchResult.url ?? "no url"}`,
-                );
-              }
-            } catch (err) {
-              log.debug("auto-launch", `hook failed (non-fatal): ${err}`);
             }
+          } catch (err) {
+            log.debug("auto-launch", `hook failed (non-fatal): ${err}`);
           }
           this.abortController = null;
           break;


### PR DESCRIPTION
## Summary

The v2.10.65 Orbital log confirmed Bug #8 fix was correct but phase 22 STILL didn't fire. Today's `~/.kcode/logs/kcode-2026-04-14.log` revealed two more bugs blocking the feature.

## Bug #10 — hasRunnableWriteInTurn turn-boundary

`handlePostTurn` injects `[SYSTEM]` user messages on truncation retries:
```
[SYSTEM] Your response was cut off. Here is how it ended: "..."
Continue EXACTLY from that point.
```

`hasRunnableWriteInTurn` walks back from `messages.length - 1` looking for any user message with string content to mark the turn boundary. It treated the `[SYSTEM]` injection as the turn boundary — so the original Writes were in the **previous** turn from the guard's perspective, and the guard rejected every Orbital session where grok hit the truncation retry path.

The Orbital log had 2x `Response looks truncated (attempt 1) — pushing for continuation` at 21:11:40, confirming the retry path was taken.

**Fix**: when walking back, skip user messages whose content starts with `[SYSTEM]`. The real user's request is further back in history.

## Bug #11 — `stopReason === "end_turn"` gate

The outer gate around the phase 22 hook at `conversation.ts:1561` was blocking legitimate firings on `max_tokens` or other valid end states. The `break` branch already implies the agent loop is exiting; the inner `hasRuntimeIntent` + `hasRunnableWriteInTurn` guards are sufficient.

**Fix**: drop the outer stopReason gate. Added `log.debug("auto-launch", "phase 22 skipped at break (stopReason=...)")` so the next audit can see exactly why phase 22 didn't fire.

## Test plan

- [x] 1 new test in `auto-launch-dev-server.test.ts` reproducing the Orbital truncation-retry scenario with a `[SYSTEM]` message after the Write
- [x] 18/18 pass in `auto-launch-dev-server.test.ts`
- [x] Full regression running separately