### PR TITLE
feat(streaming): phase 23.5 — completion-marker loop detector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.66",
+  "version": "2.10.67",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/conversation-streaming.test.ts
+++ b/src/core/conversation-streaming.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  detectCompletionMarkerLoop,
   detectLargeBlockRepetition,
   detectRepetitionLoop,
 } from "./conversation-streaming";
@@ -207,5 +208,86 @@ describe("detectLargeBlockRepetition", () => {
       base + "\n  " + base + "\n\n  " + base + "\n\n\n" + base +
       "\n\n" + base + "\n" + base;
     expect(detectLargeBlockRepetition(text)).not.toBeNull();
+  });
+});
+
+// ─── Phase 23.5: completion-marker loop detection ───────────────
+
+describe("detectCompletionMarkerLoop", () => {
+  test("returns null for short text", () => {
+    expect(detectCompletionMarkerLoop("hi")).toBeNull();
+    expect(detectCompletionMarkerLoop("✅ done")).toBeNull();
+  });
+
+  test("returns null on a single completion marker with real content after", () => {
+    // Normal flow: model says "done" once, then provides the summary
+    const text =
+      "✅ Aplicación Orbital completada con éxito. " +
+      "x".repeat(1500) + " Additional details here continue below. ";
+    expect(detectCompletionMarkerLoop(text)).toBeNull();
+  });
+
+  test("fires on the Orbital semantic-repetition pattern (3+ variants)", () => {
+    // This is the actual sequence from the v2.10.65 kcode.log —
+    // several completion-summary restarts with slightly different
+    // wording. Phase 23's byte-identical fingerprint matcher misses
+    // it because the wording varies block to block.
+    const block1 =
+      "✅ ¡Aplicación 'Orbital' completada con éxito! " +
+      "Se ha generado un archivo 100% autónomo con todas las " +
+      "secciones solicitadas implementadas correctamente. " +
+      "x".repeat(500) + " ";
+    const block2 =
+      "✅ ¡Orbital completada! " +
+      "He creado una aplicación web profesional y visualmente " +
+      "impactante tal como se solicitó en el prompt original. " +
+      "y".repeat(500) + " ";
+    const block3 =
+      "✅ ¡Orbital completada con éxito! " +
+      "He generado una aplicación web completa con todos los " +
+      "requisitos del Mission Control de la NASA implementados. " +
+      "z".repeat(500) + " ";
+    const text = block1 + block2 + block3;
+    expect(text.length).toBeGreaterThan(1500);
+    const result = detectCompletionMarkerLoop(text);
+    expect(result).not.toBeNull();
+    expect(result).toMatch(/completad/i);
+  });
+
+  test("fires on English Task Complete restarts", () => {
+    const block =
+      "✅ Task complete! The application has been done with all the features " +
+      "requested. Here is a summary of what was done: " + "x".repeat(400);
+    const text = block + " ... " + block + " ... " + block;
+    expect(detectCompletionMarkerLoop(text)).not.toBeNull();
+  });
+
+  test("does NOT fire on 2 restarts (below threshold)", () => {
+    const block =
+      "✅ Orbital completada. Summary follows: " + "x".repeat(500);
+    const text = block + block; // only 2 markers
+    expect(detectCompletionMarkerLoop(text)).toBeNull();
+  });
+
+  test("does NOT fire on legitimate prose mentioning completion verbs", () => {
+    // "The user asked me to complete the task. I finished the setup.
+    // This is done by running X." — no ✅ or restart pattern
+    const text =
+      "The user asked me to complete the task. I finished the setup. " +
+      "This is done by running the command. The completion was smooth. " +
+      "When you are done, the next step is to verify. " +
+      "x".repeat(600) +
+      " More legitimate prose that mentions completion and finish but " +
+      "isn't a restart loop. The task is truly done now. " +
+      "y".repeat(600);
+    expect(detectCompletionMarkerLoop(text)).toBeNull();
+  });
+
+  test("counts position-distinct markers even when two patterns overlap", () => {
+    // ✅ starts a marker, and "Task complete!" ALSO starts one —
+    // if they overlap at the same position, should count once
+    const block = "✅ Task complete! " + "x".repeat(500);
+    const text = block + block + block;
+    expect(detectCompletionMarkerLoop(text)).not.toBeNull();
   });
 });

--- a/src/core/conversation-streaming.ts
+++ b/src/core/conversation-streaming.ts
@@ -133,6 +133,83 @@ export function detectLargeBlockRepetition(text: string): string | null {
   return null;
 }
 
+// ─── Phase 23.5: completion-marker loop detection ───────────────
+//
+// detectLargeBlockRepetition requires a byte-identical 80-char
+// fingerprint appearing 3+ times. That fails when the model re-emits
+// a completion summary with slightly different wording each time:
+//
+//   "✅ ¡Aplicación 'Orbital' completada con éxito!..."
+//   "✅ ¡Orbital completada!..."
+//   "✅ ¡Orbital completada con éxito!..."
+//   "✅ ¡Orbital completada!..."
+//   "✅ ¡Orbital completada con éxito!..."
+//
+// Each block is ~2KB of prose with different phrasing, so byte-
+// identical fingerprints don't match 3+ times, and phase 23 stays
+// silent while the model burns tokens restating the same summary.
+//
+// This detector scans for completion-marker phrases and counts how
+// many DISTINCT occurrences exist in the accumulated text. When the
+// model re-emits ≥ 3 completion summaries in a single turn, that's
+// almost always a loop — a well-behaved model summarizes exactly
+// once.
+
+/** Minimum text length before the completion-marker detector runs. */
+const COMPLETION_MARKER_MIN_TEXT = 1500;
+/** Number of completion-marker occurrences required to declare a loop. */
+const COMPLETION_MARKER_MIN_OCCURRENCES = 3;
+
+/**
+ * Patterns that indicate the model is starting a "task complete"
+ * summary. Narrow enough to avoid false positives on normal prose —
+ * requires a leading ✅, 🎉, or explicit "task complete" phrase
+ * near a completion verb (completed, finished, done, listo,
+ * creada, generada, etc.).
+ */
+const COMPLETION_MARKER_PATTERNS: RegExp[] = [
+  // ✅ ¡Completada! / ✅ Task complete! / ✅ Done! (must have emoji
+  // followed within 80 chars by a completion verb)
+  /[✅✔✓🎉🚀]\s*[¡!]?[^\n]{0,80}\b(?:completad[ao]|complete[d]?|creada|creado|generad[ao]|finalizad[ao]|listo|lista|done|finished|ready|terminad[ao])\b/gi,
+  // Explicit "task complete", "aplicación creada", "done!", "listo!"
+  /\b(?:task\s+complete|aplicaci[oó]n\s+(?:completad[ao]|creada|lista|generad[ao]|terminad[ao])|done[.!]?\s*[¡!]?\s*$|listo\s*[¡!]?\s*$)/gim,
+];
+
+/**
+ * Detect when the model has emitted multiple completion-summary
+ * markers in one streamed turn. Returns the first matching marker
+ * phrase when the count reaches COMPLETION_MARKER_MIN_OCCURRENCES,
+ * or null otherwise.
+ *
+ * Deduplicates overlapping matches (two patterns hitting the same
+ * phrase only count once) by normalizing to the string-indexed
+ * position.
+ */
+export function detectCompletionMarkerLoop(text: string): string | null {
+  if (text.length < COMPLETION_MARKER_MIN_TEXT) return null;
+
+  const positions = new Set<number>();
+  let firstMatch: string | null = null;
+
+  for (const pattern of COMPLETION_MARKER_PATTERNS) {
+    pattern.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = pattern.exec(text)) !== null) {
+      if (!firstMatch) {
+        firstMatch = m[0].trim().slice(0, 80);
+      }
+      positions.add(m.index);
+      // Prevent zero-length match infinite loop
+      if (m.index === pattern.lastIndex) pattern.lastIndex++;
+    }
+  }
+
+  if (positions.size >= COMPLETION_MARKER_MIN_OCCURRENCES) {
+    return firstMatch ?? "completion marker";
+  }
+  return null;
+}
+
 // ─── Types ──────────────────────────────────────────────────────
 
 export interface StreamAccumulator {
@@ -227,16 +304,20 @@ export async function* processSSEStream(
               break;
             }
 
-            // Repetition loop detection. Two complementary detectors:
+            // Repetition loop detection. Three complementary detectors:
             //   1. detectRepetitionLoop — short consecutive blocks (≤500 chars)
-            //   2. detectLargeBlockRepetition — long repeated fingerprints
-            //      (catches the Orbital refactor-loop where grok-4.20
-            //      repeated a ~3000-char "✅ Refactor Final" block twenty
-            //      times until context saturation)
+            //   2. detectLargeBlockRepetition — long byte-identical blocks
+            //      (catches "✅ Refactor Final" 20x loop)
+            //   3. detectCompletionMarkerLoop — semantic variant of (2)
+            //      catches the case where the model re-emits a completion
+            //      summary with slightly different wording each time
+            //      ("✅ ¡Orbital completada!" / "✅ Aplicación completada
+            //      con éxito!" etc.)
             const fullSoFar = textChunks.join("");
             const repeated =
               detectRepetitionLoop(fullSoFar) ||
-              detectLargeBlockRepetition(fullSoFar);
+              detectLargeBlockRepetition(fullSoFar) ||
+              detectCompletionMarkerLoop(fullSoFar);
             if (repeated) {
               const tokensSoFar = Math.round(fullSoFar.length / 4);
               log.warn(


### PR DESCRIPTION
## Summary

The v2.10.65 Orbital log showed grok emit **5 consecutive** `"✅ ¡Orbital completada con éxito!"` summary blocks in a single streamed turn, each ~2KB of prose with **slightly different wording**:

```
✅ ¡Aplicación 'Orbital' completada con éxito! ...
✅ ¡Orbital completada! ...
✅ ¡Orbital completada con éxito! ...
✅ ¡Orbital completada! ...
✅ ¡Orbital completada con éxito! ...
```

Neither existing phase 23 detector caught it:
- **`detectRepetitionLoop`** — requires identical consecutive blocks ≤500 chars
- **`detectLargeBlockRepetition`** — requires byte-identical 80-char fingerprint 3+ times

Each block varied in wording, so the fingerprint at sample-offset 400 landed on different substrings per block → no match → silent token burn.

## `detectCompletionMarkerLoop`

Semantic-level detector. Scans for completion-summary markers and fires when ≥3 distinct positions match. A well-behaved model summarizes exactly once; ≥3 restarts is a loop.

Patterns (narrow to avoid false positives):

1. **Emoji + completion verb within 80 chars**: `[✅✔✓🎉🚀]...(?:completad[ao]|complete[d]?|creada|generad[ao]|finalizad[ao]|listo|done|finished|ready|terminad[ao])`
2. **Explicit phrases**: `task complete`, `aplicación (completada|creada|lista|generada|terminada)`, `done!` / `listo!` at end of line

Dedup by byte-position so overlapping matches from both patterns at the same offset count once. Guarded by `COMPLETION_MARKER_MIN_TEXT = 1500` to prevent short responses from firing.

Wired as the third detector in the streaming short-circuit OR chain:
```ts
const repeated =
  detectRepetitionLoop(fullSoFar) ||
  detectLargeBlockRepetition(fullSoFar) ||
  detectCompletionMarkerLoop(fullSoFar);
```

## Test plan

- [x] 6 new tests in `conversation-streaming.test.ts`:
  - Orbital 3-variant reproduction fires ✓
  - English "Task complete!" fires ✓
  - 2 markers (below threshold) does NOT fire ✓
  - Legitimate prose mentioning completion verbs does NOT fire ✓
  - Overlapping pattern dedup ✓
  - Short text early exit ✓
- [x] 28/28 pass in `conversation-streaming.test.ts`
- [x] Full regression running