### PR TITLE
feat(reality-check): phase 25 — user-repetition detector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.67",
+  "version": "2.10.68",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/conversation.ts
+++ b/src/core/conversation.ts
@@ -455,6 +455,45 @@ export class ConversationManager {
       log.debug("operator-dashboard", `probe failed (non-fatal): ${err}`);
     }
 
+    // Phase 25: user-repetition detector. When the user has reported
+    // the same topic in ≥3 recent messages AND expressed frustration
+    // ("sigue igual", "still broken", "audita esto"), inject a
+    // [USER REPETITION] reminder telling the model it's in a rut and
+    // must try a fundamentally different approach OR honestly admit
+    // it doesn't know. Catches the v2.10.67 Orbital chart-fix case
+    // where phase 15/18/20 were silent because Edits succeeded on
+    // wrong code paths.
+    try {
+      const { checkUserRepetition, buildUserRepetitionReminder } = await import(
+        "./user-repetition-check.js"
+      );
+      const verdict = checkUserRepetition(this.state.messages, userMessage);
+      if (verdict.isRepeating) {
+        // Estimate context saturation so the reminder can suggest
+        // /compact when appropriate.
+        const contextTokens = this.estimateContextTokens();
+        const saturation = this.contextWindowSize
+          ? contextTokens / this.contextWindowSize
+          : undefined;
+        const reminder = buildUserRepetitionReminder(verdict, saturation);
+        this.state.messages.push({ role: "user", content: reminder });
+        log.info(
+          "user-repetition",
+          `injected reminder: topics=[${verdict.sharedTopics
+            .slice(0, 3)
+            .join(",")}] frustration=[${verdict.frustrationSignals
+            .slice(0, 2)
+            .join(",")}]${
+            saturation !== undefined
+              ? ` saturation=${Math.round(saturation * 100)}%`
+              : ""
+          }`,
+        );
+      }
+    } catch (err) {
+      log.debug("user-repetition", `check failed (non-fatal): ${err}`);
+    }
+
     // Find the most recent assistant message text once — shared by
     // plan reconciliation (phase 12) and claim-vs-reality check (phase 15).
     let lastAssistantText = "";

--- a/src/core/user-repetition-check.test.ts
+++ b/src/core/user-repetition-check.test.ts
@@ -1,0 +1,260 @@
+// Tests for phase 25 — user-repetition detector.
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildUserRepetitionReminder,
+  checkUserRepetition,
+  collectRecentUserMessages,
+} from "./user-repetition-check";
+import type { Message } from "./types";
+
+function userMsg(content: string): Message {
+  return { role: "user", content };
+}
+function asstMsg(content: string): Message {
+  return { role: "assistant", content };
+}
+
+describe("collectRecentUserMessages", () => {
+  test("returns user text messages in chronological order", () => {
+    const messages: Message[] = [
+      userMsg("first"),
+      asstMsg("ack"),
+      userMsg("second"),
+      asstMsg("ack"),
+      userMsg("third"),
+    ];
+    expect(collectRecentUserMessages(messages)).toEqual(["first", "second", "third"]);
+  });
+
+  test("skips [SYSTEM]-prefixed and other system-injected reminders", () => {
+    const messages: Message[] = [
+      userMsg("real request"),
+      userMsg("[SYSTEM] Your response was cut off"),
+      userMsg("[REALITY CHECK]\nYour previous turn..."),
+      userMsg("[CONTENT MISMATCH] missing URLs"),
+      userMsg("[USER REPETITION — SAME ISSUE REPEATED]"),
+      userMsg("another real request"),
+    ];
+    expect(collectRecentUserMessages(messages)).toEqual([
+      "real request",
+      "another real request",
+    ]);
+  });
+
+  test("skips tool_result-only user messages", () => {
+    const messages: Message[] = [
+      userMsg("real one"),
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t1",
+            is_error: false,
+            content: "ok",
+          } as unknown as never,
+        ],
+      },
+      userMsg("another real one"),
+    ];
+    expect(collectRecentUserMessages(messages)).toEqual(["real one", "another real one"]);
+  });
+
+  test("respects limit parameter", () => {
+    const messages: Message[] = Array.from({ length: 10 }, (_, i) =>
+      userMsg(`msg ${i}`),
+    );
+    expect(collectRecentUserMessages(messages, 3)).toEqual(["msg 7", "msg 8", "msg 9"]);
+  });
+});
+
+describe("checkUserRepetition — Orbital chart case", () => {
+  const orbitalSession: Message[] = [
+    userMsg("crea la app Orbital con un dashboard NASA"),
+    asstMsg("done"),
+    userMsg("la grafica bien, pero no renderiza correctamente"),
+    asstMsg("fixed (claim only)"),
+    userMsg(
+      "la grafica de Mars Surface Temperature • Last 7 Sols (InSight) colapsa el scroll hasta el infinito y mas allá",
+    ),
+    asstMsg("fixed (claim only, wrong code path)"),
+  ];
+
+  test("fires on the actual Orbital pattern with 3 chart mentions", () => {
+    const newMsg = "el problema de la grafica sigue igual, audita el problema";
+    const verdict = checkUserRepetition(orbitalSession, newMsg);
+    expect(verdict.isRepeating).toBe(true);
+    expect(verdict.sharedTopics).toContain("grafica");
+    expect(verdict.frustrationSignals.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("does NOT fire without frustration signal", () => {
+    // Three mentions of chart but no frustration — could be normal
+    // iterative work
+    const normalFlow: Message[] = [
+      userMsg("crea una grafica de temperatura"),
+      asstMsg("done"),
+      userMsg("añade una leyenda al grafico de temperatura"),
+      asstMsg("done"),
+      userMsg("cambia el color de la grafica a cyan"),
+    ];
+    const verdict = checkUserRepetition(normalFlow);
+    expect(verdict.isRepeating).toBe(false);
+  });
+
+  test("does NOT fire with only 2 messages (below threshold)", () => {
+    const short: Message[] = [
+      userMsg("la grafica no funciona"),
+      asstMsg("fixed"),
+      userMsg("la grafica sigue igual"),
+    ];
+    const verdict = checkUserRepetition(short);
+    // Only 2 real user messages — min is 3
+    expect(verdict.isRepeating).toBe(false);
+  });
+
+  test("normalizes accents (gráfica vs grafica)", () => {
+    const session: Message[] = [
+      userMsg("la gráfica no renderiza"),
+      asstMsg("done"),
+      userMsg("la grafica colapsa"),
+      asstMsg("done"),
+    ];
+    const newMsg = "la gráfica sigue igual";
+    const verdict = checkUserRepetition(session, newMsg);
+    expect(verdict.isRepeating).toBe(true);
+    expect(verdict.sharedTopics).toContain("grafica");
+  });
+});
+
+describe("checkUserRepetition — frustration signal coverage", () => {
+  function build(signal: string): Message[] {
+    return [
+      userMsg("fix the header layout"),
+      asstMsg("done"),
+      userMsg("header still broken in the dashboard"),
+      asstMsg("done"),
+      userMsg(`the header ${signal}`),
+    ];
+  }
+
+  test.each([
+    "still broken",
+    "still not working",
+    "still the same",
+    "not fixed",
+    "didn't work",
+    "same problem",
+    "sigue igual",
+    "no funciona",
+    "sigue sin funcionar",
+    "no lo arreglaste",
+    "mismo problema",
+    "todavia tiene el mismo bug",
+  ])("detects frustration signal %p", (signal) => {
+    const messages = build(signal);
+    const verdict = checkUserRepetition(messages);
+    expect(verdict.isRepeating).toBe(true);
+    expect(verdict.frustrationSignals.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("checkUserRepetition — negative cases", () => {
+  test("does not fire on empty history", () => {
+    expect(checkUserRepetition([]).isRepeating).toBe(false);
+  });
+
+  test("does not fire when topics differ", () => {
+    const messages: Message[] = [
+      userMsg("fix the header"),
+      asstMsg("done"),
+      userMsg("add a footer"),
+      asstMsg("done"),
+      userMsg("change the sidebar colors"),
+    ];
+    expect(checkUserRepetition(messages).isRepeating).toBe(false);
+  });
+
+  test("does not fire when only tiny words overlap", () => {
+    // "que", "con", "si" — stopwords and short words shouldn't count
+    const messages: Message[] = [
+      userMsg("si, hazlo"),
+      asstMsg("done"),
+      userMsg("si, continua con eso"),
+      asstMsg("done"),
+      userMsg("si, sigue"),
+    ];
+    expect(checkUserRepetition(messages).isRepeating).toBe(false);
+  });
+
+  test("does not fire on the system reminders themselves", () => {
+    // The phase 25 detector should not see its own past reminders
+    const messages: Message[] = [
+      userMsg("[USER REPETITION — SAME ISSUE REPEATED] grafica sigue sigue sigue"),
+      userMsg("[REALITY CHECK] grafica grafica grafica"),
+      userMsg("[SYSTEM] grafica cut off"),
+    ];
+    // Collect skips all of these, so recent.length < 3 → no fire
+    expect(checkUserRepetition(messages).isRepeating).toBe(false);
+  });
+});
+
+describe("buildUserRepetitionReminder", () => {
+  test("contains the shared topics, frustration signals, and resolutions", () => {
+    const verdict = {
+      isRepeating: true,
+      sharedTopics: ["grafica", "render"],
+      frustrationSignals: ["sigue igual", "audita"],
+      recentMessages: [
+        "la grafica no renderiza",
+        "la grafica colapsa el scroll",
+        "el problema de la grafica sigue igual, audita el problema",
+      ],
+    };
+    const reminder = buildUserRepetitionReminder(verdict);
+    expect(reminder).toContain("USER REPETITION");
+    expect(reminder).toContain("grafica");
+    expect(reminder).toContain("sigue igual");
+    expect(reminder).toContain("rut");
+    expect(reminder).toMatch(/a\)/);
+    expect(reminder).toMatch(/b\)/);
+    expect(reminder).toMatch(/fundamentally different/i);
+    expect(reminder).toMatch(/honest/i);
+    expect(reminder).toContain("la grafica no renderiza");
+  });
+
+  test("adds /compact suggestion when context >= 85%", () => {
+    const verdict = {
+      isRepeating: true,
+      sharedTopics: ["x"],
+      frustrationSignals: ["sigue igual"],
+      recentMessages: ["a", "b", "c"],
+    };
+    const reminder = buildUserRepetitionReminder(verdict, 0.92);
+    expect(reminder).toContain("/compact");
+    expect(reminder).toContain("92%");
+  });
+
+  test("omits /compact suggestion when context below threshold", () => {
+    const verdict = {
+      isRepeating: true,
+      sharedTopics: ["x"],
+      frustrationSignals: ["sigue igual"],
+      recentMessages: ["a", "b", "c"],
+    };
+    const reminder = buildUserRepetitionReminder(verdict, 0.5);
+    expect(reminder).not.toContain("/compact");
+  });
+
+  test("omits /compact when saturation is undefined", () => {
+    const verdict = {
+      isRepeating: true,
+      sharedTopics: ["x"],
+      frustrationSignals: ["sigue igual"],
+      recentMessages: ["a", "b", "c"],
+    };
+    const reminder = buildUserRepetitionReminder(verdict);
+    expect(reminder).not.toContain("/compact");
+  });
+});

--- a/src/core/user-repetition-check.ts
+++ b/src/core/user-repetition-check.ts
@@ -1,0 +1,362 @@
+// KCode - Phase 25: user-repetition detector
+//
+// Detects when the user is asking for the same fix multiple times in
+// a row with frustration signals. Fires when:
+//
+//   1. ≥3 of the last 5 non-system user messages share at least one
+//      significant content token (length ≥5, not a stop word)
+//   2. AND at least one of those messages contains a frustration
+//      signal ("sigue igual", "still broken", "audita", etc.)
+//
+// On fire, the next turn gets a [USER REPETITION] reminder injected
+// as a user-role message. The reminder tells the model that its
+// previous attempts did not fix the issue, it's in a rut, and it
+// must either propose a fundamentally different fix path OR honestly
+// admit it doesn't know.
+//
+// Evidence: v2.10.67 Orbital session, Mars Surface Temperature chart
+// bug reported 4 times ("la gráfica no renderiza", "colapsa el
+// scroll", "sigue igual, audita el problema"). Model diagnosed
+// correctly each time but kept proposing the same fix in prose
+// without applying it correctly. $5.39 and 19 minutes burned.
+// Phase 15 only fired once at the very end (2 claims, 0 mutations)
+// because earlier turns had mechanical Edits that "succeeded" on
+// wrong code paths, bypassing the zero-mutation trigger.
+
+import type { Message } from "./types.js";
+
+// ─── Frustration signal patterns ─────────────────────────────────
+
+const FRUSTRATION_PATTERNS: RegExp[] = [
+  // Spanish
+  /\bsigue\s+igual\b/i,
+  /\bsigue\s+(?:sin|roto|mal|el\s+mismo|fallando)/i,
+  /\btodav[íi]a\s+(?:sigue|no|est[aá]|tiene|tengo)\b/i,
+  /\botra\s+vez\b/i,
+  /\bde\s+nuevo\b/i,
+  /\bno\s+funciona(?:ba|ron)?\b/i,
+  /\bno\s+anda\b/i,
+  /\bno\s+cambi[oó]\b/i,
+  /\bnada\s+(?:anda|funciona|cambi[oó]|arregla)/i,
+  /\bno\s+lo\s+(?:arreglaste|solucionaste|fixeaste)/i,
+  /\bno\s+est[aá]\s+arreglad/i,
+  /\bmismo\s+(?:problema|error|bug|issue|fallo)\b/i,
+  /\bel\s+problema\s+(?:sigue|persiste|continua)/i,
+  /\baudita(?:lo|r)?\b/i,
+  // English
+  /\bstill\s+(?:broken|not\s+working|the\s+same|doesn'?t|failing)\b/i,
+  /\bnot\s+(?:fixed|working)\b/i,
+  /\bsame\s+(?:problem|issue|error|bug)\b/i,
+  /\btry\s+again\b/i,
+  /\bfix\s+(?:it\s+)?again\b/i,
+  /\bdidn'?t\s+(?:work|fix)\b/i,
+  /\bstill\s+breaks?\b/i,
+];
+
+// ─── Stop words ──────────────────────────────────────────────────
+// Words that are common in frustration messages but shouldn't count
+// as "shared topic" tokens. Length ≥5 lets us skip most function
+// words automatically; this set kills the remaining noise.
+
+const STOPWORDS = new Set<string>([
+  // Spanish content-but-non-topic
+  "sigue",
+  "todavía",
+  "todavia",
+  "nuevo",
+  "funciona",
+  "arreglo",
+  "aplico",
+  "aplicado",
+  "hicimos",
+  "haces",
+  "hacer",
+  "misma",
+  "mismo",
+  "bien",
+  "nadie",
+  "tiene",
+  "puede",
+  "debe",
+  "debería",
+  "deberia",
+  "entonces",
+  "ahora",
+  "ahorita",
+  "antes",
+  "después",
+  "despues",
+  "audita",
+  "auditar",
+  "auditalo",
+  "problema",
+  "seguro",
+  "quiero",
+  "quieres",
+  "puedes",
+  "siempre",
+  "nunca",
+  "cuando",
+  "donde",
+  "porque",
+  "porqué",
+  "arreglaste",
+  "solucionaste",
+  // English content-but-non-topic
+  "still",
+  "again",
+  "broken",
+  "works",
+  "working",
+  "worked",
+  "fixing",
+  "fixed",
+  "didn",
+  "doesn",
+  "problem",
+  "issue",
+  "error",
+  "thing",
+  "thank",
+  "please",
+  "maybe",
+  "could",
+  "would",
+  "should",
+  "shall",
+  "there",
+  "these",
+  "those",
+  "where",
+  "which",
+  "while",
+  "about",
+  "after",
+  "before",
+]);
+
+// ─── Tokenization ────────────────────────────────────────────────
+
+/**
+ * Split a user message into significant content-word tokens.
+ * Keeps words of length ≥5, excludes known stopwords, lowercases.
+ * Normalizes common accented chars so "gráfica" and "grafica" match.
+ */
+function significantTokens(text: string): Set<string> {
+  const normalized = text
+    .toLowerCase()
+    // Strip accents (NFD → remove combining marks)
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    // Replace non-alphanumeric with space
+    .replace(/[^a-z0-9\s]/g, " ");
+  const tokens = normalized
+    .split(/\s+/)
+    .filter((t) => t.length >= 5 && !STOPWORDS.has(t));
+  return new Set(tokens);
+}
+
+// ─── Recent user message collection ──────────────────────────────
+
+const SYSTEM_REMINDER_PREFIXES = [
+  "[SYSTEM]",
+  "[REALITY CHECK]",
+  "[CLAIM/MUTATION MISMATCH]",
+  "[CONTENT MISMATCH]",
+  "[USER REPETITION",
+  "[PLAN RECONCILIATION]",
+  "[USER FRUSTRATION",
+];
+
+/**
+ * Walk messages backwards and collect the last N user-authored text
+ * messages. Skips:
+ *   - tool_result-only user messages
+ *   - system-injected reminders (phase 15/18/20/22/25, plan, etc.)
+ *   - empty strings
+ *
+ * Returns messages in chronological order (oldest first).
+ */
+export function collectRecentUserMessages(
+  messages: Message[],
+  limit = 5,
+): string[] {
+  const result: string[] = [];
+  for (let i = messages.length - 1; i >= 0 && result.length < limit; i--) {
+    const msg = messages[i];
+    if (!msg) continue;
+    if (msg.role !== "user") continue;
+    if (typeof msg.content !== "string") continue;
+    const t = msg.content.trim();
+    if (!t) continue;
+    if (SYSTEM_REMINDER_PREFIXES.some((p) => t.startsWith(p))) continue;
+    result.push(t);
+  }
+  return result.reverse();
+}
+
+// ─── Verdict ─────────────────────────────────────────────────────
+
+export interface UserRepetitionVerdict {
+  isRepeating: boolean;
+  /** Significant tokens that appeared in ≥3 recent user messages. */
+  sharedTopics: string[];
+  /** Frustration signal phrases detected (first match per message). */
+  frustrationSignals: string[];
+  /** The recent user messages that were scanned, oldest-first. */
+  recentMessages: string[];
+}
+
+/**
+ * Scan the recent user messages and decide whether the user is
+ * in a repetition+frustration pattern. Two gates:
+ *
+ *   1. ≥3 messages share at least one significant content token
+ *      (e.g. "grafica" / "chart" / "header")
+ *   2. ≥1 of the recent messages contains a frustration signal
+ *
+ * Both must fire — shared topics alone can be normal continuity,
+ * frustration alone can be unrelated to repetition.
+ */
+export function checkUserRepetition(
+  messages: Message[],
+  newUserMessage?: string,
+): UserRepetitionVerdict {
+  const historical = collectRecentUserMessages(messages, 5);
+  // Optionally fold in the CURRENT user message if the caller passes
+  // it — by the time checkUserRepetition runs in sendMessage, the
+  // new message hasn't been pushed to state.messages yet.
+  const recent =
+    newUserMessage !== undefined && newUserMessage.trim() !== ""
+      ? [...historical, newUserMessage.trim()].slice(-5)
+      : historical;
+
+  if (recent.length < 3) {
+    return {
+      isRepeating: false,
+      sharedTopics: [],
+      frustrationSignals: [],
+      recentMessages: recent,
+    };
+  }
+
+  // Gate 2 (cheaper): frustration signals must exist somewhere
+  const frustrationSignals: string[] = [];
+  for (const text of recent) {
+    for (const re of FRUSTRATION_PATTERNS) {
+      const m = text.match(re);
+      if (m) {
+        frustrationSignals.push(m[0].toLowerCase());
+        break;
+      }
+    }
+  }
+  if (frustrationSignals.length === 0) {
+    return {
+      isRepeating: false,
+      sharedTopics: [],
+      frustrationSignals: [],
+      recentMessages: recent,
+    };
+  }
+
+  // Gate 1: count token occurrences across messages
+  const tokenCounts = new Map<string, number>();
+  for (const text of recent) {
+    const tokens = significantTokens(text);
+    for (const t of tokens) {
+      tokenCounts.set(t, (tokenCounts.get(t) ?? 0) + 1);
+    }
+  }
+
+  const minShare = Math.min(3, recent.length);
+  const sharedTopics: string[] = [];
+  for (const [token, count] of tokenCounts) {
+    if (count >= minShare) sharedTopics.push(token);
+  }
+
+  return {
+    isRepeating: sharedTopics.length > 0,
+    sharedTopics,
+    frustrationSignals,
+    recentMessages: recent,
+  };
+}
+
+// ─── Reminder formatter ──────────────────────────────────────────
+
+export function buildUserRepetitionReminder(
+  verdict: UserRepetitionVerdict,
+  contextSaturation?: number,
+): string {
+  const lines: string[] = [];
+  lines.push("[USER REPETITION — SAME ISSUE REPEATED]");
+  lines.push("");
+  lines.push(
+    `The user has reported the same topic across ${verdict.recentMessages.length} ` +
+      `of their most recent messages. Shared keyword(s): ` +
+      verdict.sharedTopics
+        .slice(0, 5)
+        .map((t) => `"${t}"`)
+        .join(", "),
+  );
+  lines.push("");
+  lines.push("Recent user messages (oldest → newest):");
+  for (let i = 0; i < verdict.recentMessages.length; i++) {
+    const m = verdict.recentMessages[i];
+    if (!m) continue;
+    const truncated = m.length > 140 ? m.slice(0, 137) + "..." : m;
+    lines.push(`  ${i + 1}. "${truncated}"`);
+  }
+  lines.push("");
+  lines.push(
+    `Frustration signals detected: ${verdict.frustrationSignals.join(", ")}`,
+  );
+  lines.push("");
+  lines.push(
+    "This means your previous attempts did NOT fix the actual problem.",
+  );
+  lines.push("You are in a rut. Do NOT:");
+  lines.push("  - Propose the same fix approach again");
+  lines.push('  - Write another "✅ Aplicado" / "Fixed" / "Done" claim');
+  lines.push(
+    "  - Run more diagnostic Reads on the same file region you already checked",
+  );
+  lines.push(
+    "  - Emit a long AUDIT REPORT in prose without actually applying a mutation",
+  );
+  lines.push("");
+  lines.push("Instead you MUST do ONE of:");
+  lines.push(
+    "  a) Re-read the EXACT code path the user is pointing at, line by line,",
+  );
+  lines.push(
+    "     and propose a FUNDAMENTALLY DIFFERENT fix. Show your reasoning for",
+  );
+  lines.push("     why the previous attempts missed the mark.");
+  lines.push(
+    '  b) Admit "I do not know why this is happening" and ask the user for',
+  );
+  lines.push(
+    "     more info (browser console screenshot, devtools trace, exact repro",
+  );
+  lines.push(
+    "     steps). Honesty is better than yet another failed attempt.",
+  );
+
+  if (contextSaturation !== undefined && contextSaturation >= 0.85) {
+    lines.push("");
+    lines.push(
+      `⚠️ Context window is ~${Math.round(contextSaturation * 100)}% full.`,
+    );
+    lines.push(
+      "You have lost track of what you already tried. Before the next fix,",
+    );
+    lines.push(
+      "run /compact to free space and reset working memory, then approach the",
+    );
+    lines.push("problem with a clean slate.");
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

The v2.10.67 Orbital session exposed a failure mode none of phases 15/18/20 could catch. The user reported the Mars Surface Temperature chart bug **four times** in a row:

1. *"la grafica bien, pero no renderiza correctamente"*
2. *"la grafica de Mars Surface Temperature • Last 7 Sols (InSight) colapsa el scroll hasta el infinito y mas allá"*
3. *"el problema de la grafica sigue igual, audita el problema"*
4. (console-log paste with runtime errors)

The model diagnosed the root cause correctly every time (Chart.js `responsive: true` + `maintainAspectRatio: false` + hidden container + no fixed height → layout thrashing) and then wrote diff after diff in prose WITHOUT applying them to the real code path. Some Edits mechanically succeeded on wrong code paths, bypassing phase 15's zero-mutation trigger. Model eventually confessed:

> "My previous claims that these changes had already been made were incorrect — no successful mutation occurred in the last turn due to tool failures."

**2.6M tokens, \$5.39, 19 minutes** burned on a 2-line fix.

## Phase 25 detector

New module `src/core/user-repetition-check.ts`:

- **`collectRecentUserMessages(messages, limit)`** — returns last N non-system user text messages, chronological, skipping `[SYSTEM]`, `[REALITY CHECK]`, `[CLAIM/MUTATION MISMATCH]`, `[CONTENT MISMATCH]`, `[USER REPETITION...]`, `[PLAN RECONCILIATION]`, tool_result-only messages, and empty strings
- **`checkUserRepetition(messages, newMsg?)`** — fires when:
  - ≥3 recent user messages share at least one significant content token (length ≥5, accent-normalized, not a stopword), AND
  - ≥1 of them contains a frustration signal
- **`FRUSTRATION_PATTERNS`** — ES + EN: `sigue igual`, `todavía sigue`, `otra vez`, `no funciona`, `mismo problema`, `audita`, `still broken`, `still not working`, `same problem`, `not fixed`, `didn't work`, `try again`, `fix again`, etc.
- **`STOPWORDS`** excludes `sigue`, `problema`, `mismo`, `todavía`, `still`, `again`, `broken`, `problem`, `issue`, `error`, `working`, etc. so they don't count as shared topics
- **`buildUserRepetitionReminder`** — lists shared topics, recent messages verbatim, frustration signals, and two resolutions:
  - (a) try a fundamentally different fix approach
  - (b) honestly admit uncertainty and ask the user for more info
- When context window ≥85%, the reminder also suggests `/compact`

## Wiring

`conversation.sendMessage` calls the check right after the operator-mind probe and before any task-orchestrator branches. The new user message is passed explicitly so it can enter the 5-message window even though it hasn't been pushed to `state.messages` yet.

## Test plan

- [x] 28 tests in `user-repetition-check.test.ts`
  - Orbital pattern reproduction (3 chart mentions + frustration) fires
  - Accent normalization (`gráfica` vs `grafica`)
  - Negative: <3 messages
  - Negative: same topic but no frustration ("normal iterative work")
  - Negative: differing topics
  - Negative: stopword-only overlap
  - Negative: system reminders in history are skipped
  - 12 frustration-signal coverage tests (ES + EN)
  - `collectRecentUserMessages` ordering, limit, skip rules
  - Reminder content + `/compact` gating at 85% threshold
- [x] 28/28 pass in the file
- [x] Full regression running