### PR TITLE
fix: audit P1+P2 — cross-session state reset + secrets/debug scanner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.68",
+  "version": "2.10.69",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/conversation.ts
+++ b/src/core/conversation.ts
@@ -176,6 +176,39 @@ export class ConversationManager {
     this.config = { ...config }; // shallow copy to avoid mutating caller's config
     this.tools = tools;
 
+    // Phase-stack session-state reset (P1 audit fix).
+    // Several modules maintain module-level mutable state that survives
+    // across ConversationManager instances in the same process (audit
+    // read tracker, file-edit retry history, auto-launch session flag,
+    // response-session tracker). Without resetting them here, starting
+    // a new conversation in a long-running kcode process (daemon, /clear,
+    // /resume, tmux splits) inherits state from the previous conversation
+    // and produces false positives in the phase-17/21/22 guards.
+    try {
+      const { resetReads } = require("./session-tracker") as typeof import("./session-tracker");
+      resetReads();
+    } catch {
+      /* module not loaded */
+    }
+    try {
+      const { clearEditHistory } = require("./file-edit-history") as typeof import("./file-edit-history");
+      clearEditHistory();
+    } catch {
+      /* module not loaded */
+    }
+    try {
+      const { resetAutoLaunchState } = require("./auto-launch-dev-server") as typeof import("./auto-launch-dev-server");
+      resetAutoLaunchState();
+    } catch {
+      /* module not loaded */
+    }
+    try {
+      const { resetSessionState } = require("./response-session") as typeof import("./response-session");
+      resetSessionState();
+    } catch {
+      /* module not loaded */
+    }
+
     // Apply model profile adjustments for small models
     try {
       const { getModelProfile } = require("./model-profile") as typeof import("./model-profile");

--- a/src/core/write-content-scanner.test.ts
+++ b/src/core/write-content-scanner.test.ts
@@ -1,0 +1,293 @@
+// Tests for phase 26 — write content scanner (secrets + debug).
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildDebugWarning,
+  buildSecretReport,
+  detectDebugStatements,
+  detectSecrets,
+} from "./write-content-scanner";
+
+// ─── Secret detection ────────────────────────────────────────────
+
+describe("detectSecrets — known key shapes", () => {
+  test("catches OpenAI sk- key", () => {
+    const code = `const client = new OpenAI({ apiKey: "sk-proj1234567890abcdefABCDEF1234567890XYZ" });`;
+    const v = detectSecrets("/tmp/app.ts", code);
+    expect(v.hasSecret).toBe(true);
+    expect(v.hits[0]!.name).toBe("openai-api-key");
+    expect(v.hits[0]!.line).toBe(1);
+  });
+
+  test("catches Anthropic sk-ant- key", () => {
+    const key = "sk-ant-" + "A".repeat(96);
+    const code = `const k = "${key}";`;
+    const v = detectSecrets("/tmp/app.ts", code);
+    expect(v.hasSecret).toBe(true);
+    expect(v.hits[0]!.name).toBe("anthropic-api-key");
+  });
+
+  test("catches xAI/Grok key (the real user key shape from the session logs)", () => {
+    // Shape from user's earlier logs: xai-EPv6hHa45Cqb... (80 alnum chars)
+    const key = "xai-" + "A".repeat(80);
+    const code = `const GROK_KEY = "${key}";`;
+    const v = detectSecrets("/tmp/config.js", code);
+    expect(v.hasSecret).toBe(true);
+    expect(v.hits[0]!.name).toBe("xai-api-key");
+  });
+
+  test("catches Google API key (AIza...)", () => {
+    const code = `export const GOOGLE_API_KEY = "AIza${"B".repeat(35)}";`;
+    const v = detectSecrets("/tmp/maps.ts", code);
+    expect(v.hasSecret).toBe(true);
+    expect(v.hits[0]!.name).toBe("google-api-key");
+  });
+
+  test("catches AWS access key ID (AKIA...)", () => {
+    const code = `const AWS_ACCESS = "AKIAIOSFODNN7EXAMPLE";`;
+    const v = detectSecrets("/tmp/aws.ts", code);
+    // "EXAMPLE" is a placeholder substring — should be ignored
+    expect(v.hasSecret).toBe(false);
+  });
+
+  test("catches real-looking AWS access key", () => {
+    const code = `const AWS_ACCESS = "AKIA" + "ABCDEFGHIJKLMNOP";`;
+    // The key literal itself must be one string; split expressions don't count
+    const realKey = `AKIA${"X".repeat(16)}`;
+    const realCode = `const AWS_ACCESS = "${realKey}";`;
+    const v = detectSecrets("/tmp/aws.ts", realCode);
+    // Note: the regex uses [0-9A-Z], and "X" fits but looksLikePlaceholder
+    // catches all-X patterns. Use a realistic mix:
+    const realMix = "AKIAIOSFODNN7AB1CD23";
+    expect(detectSecrets("/tmp/aws.ts", `const k = "${realMix}";`).hasSecret).toBe(true);
+  });
+
+  test("catches GitHub PAT (ghp_...)", () => {
+    // String is split at runtime so GitHub's own secret scanner
+    // doesn't flag this test file as containing a real PAT.
+    const fakeKey = "gh" + "p_" + "a".repeat(36);
+    const code = `const TOKEN = "${fakeKey}";`;
+    const v = detectSecrets("/tmp/app.ts", code);
+    expect(v.hasSecret).toBe(true);
+    expect(v.hits[0]!.name).toBe("github-pat");
+  });
+
+  test("catches Slack bot token (xoxb-...)", () => {
+    const fakeKey = "xo" + "xb-" + "1234567890-0987654321-abcdefghijklmnopqrst";
+    const code = `const SLACK = "${fakeKey}";`;
+    const v = detectSecrets("/tmp/slack.ts", code);
+    expect(v.hasSecret).toBe(true);
+    expect(v.hits[0]!.name).toBe("slack-bot-token");
+  });
+
+  test("catches Stripe live secret (sk_live_...)", () => {
+    // Split to avoid GitHub secret scanner false positive on test file.
+    const fakeKey = "sk" + "_live_" + "51abcdefghijklmnopqrstuvwx";
+    const code = `stripe = new Stripe("${fakeKey}");`;
+    const v = detectSecrets("/tmp/payment.ts", code);
+    expect(v.hasSecret).toBe(true);
+    expect(v.hits[0]!.name).toBe("stripe-secret");
+  });
+
+  test("catches generic api_key assignment", () => {
+    const code = `const config = { api_key: "9kZ3xP2mN4qR6tL1vW8aB5cD7eF0hJ9k" };`;
+    const v = detectSecrets("/tmp/config.js", code);
+    expect(v.hasSecret).toBe(true);
+    expect(v.hits[0]!.name).toBe("generic-api-key-assignment");
+  });
+
+  test("catches Bearer token literal", () => {
+    const code = `headers: { Authorization: "Bearer 1234567890abcdefghijABCDEFGHIJ" }`;
+    const v = detectSecrets("/tmp/api.ts", code);
+    expect(v.hasSecret).toBe(true);
+    expect(v.hits[0]!.name).toBe("bearer-token");
+  });
+});
+
+describe("detectSecrets — placeholder handling", () => {
+  test("skips YOUR_KEY_HERE placeholders", () => {
+    // These look like secrets structurally but contain placeholder substrings
+    const code = `
+      const OPENAI_KEY = "sk-YOUR_OPENAI_KEY_HERE_1234567890xxxxx";
+      const ANTHROPIC = "sk-ant-YOUR_ANTHROPIC_KEY_HERE${"_".repeat(80)}";
+      const API_KEY = "REPLACE_WITH_YOUR_ACTUAL_KEY_HERE_12345";
+    `;
+    const v = detectSecrets("/tmp/config.ts", code);
+    expect(v.hasSecret).toBe(false);
+  });
+
+  test("skips all-x placeholder shapes", () => {
+    const code = `const KEY = "sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";`;
+    const v = detectSecrets("/tmp/demo.ts", code);
+    expect(v.hasSecret).toBe(false);
+  });
+
+  test("skips EXAMPLE-suffixed AWS keys (documentation standard)", () => {
+    const code = `const AWS = "AKIAIOSFODNN7EXAMPLE";`;
+    const v = detectSecrets("/tmp/iam.ts", code);
+    expect(v.hasSecret).toBe(false);
+  });
+});
+
+describe("detectSecrets — path exemptions", () => {
+  test("allows .env.example with literal examples", () => {
+    const content = `OPENAI_API_KEY=sk-proj1234567890abcdefABCDEF1234567890XYZ`;
+    expect(detectSecrets("/tmp/.env.example", content).hasSecret).toBe(false);
+  });
+
+  test("allows .env.sample", () => {
+    const content = `GROK_KEY=xai-${"A".repeat(80)}`;
+    expect(detectSecrets("/tmp/.env.sample", content).hasSecret).toBe(false);
+  });
+
+  test("allows README.md to contain example keys", () => {
+    const content = `
+      # Setup
+      export OPENAI_API_KEY="sk-abc1234567890defABCDEF1234567890XYZ"
+    `;
+    expect(detectSecrets("/tmp/README.md", content).hasSecret).toBe(false);
+  });
+
+  test("does NOT allow secrets in .env (non-example)", () => {
+    const content = `OPENAI_API_KEY=sk-proj1234567890abcdefABCDEF1234567890XYZ`;
+    // Note: .env is already blocked by the older sensitive-file
+    // pattern in write.ts, but the scanner should still flag it
+    expect(detectSecrets("/tmp/.env", content).hasSecret).toBe(true);
+  });
+});
+
+describe("buildSecretReport", () => {
+  test("names the file, lists hits, offers three resolutions", () => {
+    const verdict = {
+      hasSecret: true,
+      hits: [
+        { name: "openai-api-key", line: 12, snippet: "sk-proj1234…XYZ" },
+        { name: "stripe-secret", line: 45, snippet: "sk_live_51abcd…" },
+      ],
+    };
+    const report = buildSecretReport("/tmp/app.ts", verdict);
+    expect(report).toContain("BLOCKED");
+    expect(report).toContain("app.ts");
+    expect(report).toContain("2 plausible credential");
+    expect(report).toContain("openai-api-key");
+    expect(report).toContain("line 12");
+    expect(report).toMatch(/a\)/);
+    expect(report).toMatch(/b\)/);
+    expect(report).toMatch(/c\)/);
+    expect(report).toContain("env-var");
+  });
+});
+
+// ─── Debug statement detection ────────────────────────────────────
+
+describe("detectDebugStatements", () => {
+  test("flags console.log in a .ts file", () => {
+    const code = `
+      function main() {
+        console.log("hello");
+        return 42;
+      }
+    `;
+    const v = detectDebugStatements("/tmp/app.ts", code);
+    expect(v.hasDebug).toBe(true);
+    expect(v.hits[0]!.name).toBe("console.log");
+  });
+
+  test("flags debugger statement", () => {
+    const code = `
+      function fn() {
+        debugger;
+      }
+    `;
+    const v = detectDebugStatements("/tmp/app.ts", code);
+    expect(v.hasDebug).toBe(true);
+    expect(v.hits.some((h) => h.name === "debugger")).toBe(true);
+  });
+
+  test("flags console.log inside an HTML file", () => {
+    const code = `<html><script>console.log('x');</script></html>`;
+    const v = detectDebugStatements("/tmp/orbital.html", code);
+    expect(v.hasDebug).toBe(true);
+  });
+
+  test("flags Python print() statements", () => {
+    const code = `
+      def main():
+          print("debug")
+          return 42
+    `;
+    const v = detectDebugStatements("/tmp/app.py", code);
+    expect(v.hasDebug).toBe(true);
+    expect(v.hits[0]!.name).toBe("print()");
+  });
+
+  test("flags Rust dbg! and println!", () => {
+    const code = `fn main() { dbg!(x); println!("y"); }`;
+    const v = detectDebugStatements("/tmp/main.rs", code);
+    expect(v.hasDebug).toBe(true);
+    expect(v.hits.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("exempts test files (.test.ts)", () => {
+    const code = `
+      test("foo", () => {
+        console.log("debug");
+        expect(1).toBe(1);
+      });
+    `;
+    const v = detectDebugStatements("/tmp/app.test.ts", code);
+    expect(v.hasDebug).toBe(false);
+  });
+
+  test("exempts __tests__ directory", () => {
+    const code = `console.log('in tests')`;
+    const v = detectDebugStatements("/tmp/__tests__/foo.ts", code);
+    expect(v.hasDebug).toBe(false);
+  });
+
+  test("exempts scripts/bin/ folder", () => {
+    const code = `console.log('running');`;
+    const v = detectDebugStatements("/tmp/scripts/deploy.ts", code);
+    expect(v.hasDebug).toBe(false);
+  });
+
+  test("exempts examples/ folder", () => {
+    const code = `print("example output")`;
+    const v = detectDebugStatements("/tmp/examples/hello.py", code);
+    expect(v.hasDebug).toBe(false);
+  });
+
+  test("does NOT flag Python code in a .ts file (wrong extension)", () => {
+    const code = `print("this is actually a JS-style string")`;
+    // print() only triggers for .py
+    const v = detectDebugStatements("/tmp/app.ts", code);
+    expect(v.hasDebug).toBe(false);
+  });
+
+  test("caps hits per pattern at 10", () => {
+    const code = Array.from({ length: 25 }, () => `console.log("x");`).join("\n");
+    const v = detectDebugStatements("/tmp/app.ts", code);
+    // Each pattern caps at 10
+    const consoleHits = v.hits.filter((h) => h.name === "console.log");
+    expect(consoleHits.length).toBe(10);
+  });
+});
+
+describe("buildDebugWarning", () => {
+  test("lists hits with line numbers and names the exemption note", () => {
+    const verdict = {
+      hasDebug: true,
+      hits: [
+        { name: "console.log", line: 5, snippet: "console.log('hi')" },
+        { name: "debugger", line: 12, snippet: "debugger;" },
+      ],
+    };
+    const warning = buildDebugWarning(verdict);
+    expect(warning).toContain("2 debug statement");
+    expect(warning).toContain("console.log");
+    expect(warning).toContain("line 5");
+    expect(warning).toContain("debugger");
+    expect(warning).toContain("non-blocking");
+    expect(warning).toMatch(/tests,\s*examples/i);
+  });
+});

--- a/src/core/write-content-scanner.ts
+++ b/src/core/write-content-scanner.ts
@@ -1,0 +1,364 @@
+// KCode - Phase 26: Write content scanner
+//
+// Two complementary scans run on every Write/Edit content:
+//
+//   1. Secrets detector — BLOCKS the write when the content contains a
+//      plausible API key, access token, password, or credential that
+//      looks real (not a placeholder). Catches the "model memorized a
+//      secret earlier in the session and dumped it into code" failure
+//      mode. False positives here are better than accidentally shipping
+//      a leaked key.
+//
+//   2. Debug-statement detector — WARNS (non-blocking) when the content
+//      contains leftover console.log / debugger / dbg! / fmt.Println
+//      debug statements. Appended to the write-success message so the
+//      model sees it and has the option to clean up. Blocking this
+//      would be too aggressive because many legitimate files have
+//      console.log (tests, CLI tools, demos).
+//
+// Secrets are blocking; debug is advisory. The scan runs only on
+// writes to non-test, non-example source files — a .env.example,
+// foo.test.ts, or README.md is allowed to contain literal examples.
+
+import { basename } from "node:path";
+
+// ─── Secret patterns ────────────────────────────────────────────
+
+interface SecretPattern {
+  name: string;
+  regex: RegExp;
+}
+
+/**
+ * Well-known credential shapes. Each pattern is anchored tightly
+ * enough that random base64-looking strings in comments or docs
+ * don't false-positive. All patterns require a minimum length that
+ * excludes placeholder tokens like "sk-YOUR_KEY_HERE".
+ */
+const SECRET_PATTERNS: SecretPattern[] = [
+  // OpenAI API key
+  { name: "openai-api-key", regex: /\bsk-[A-Za-z0-9]{32,}\b/ },
+  // Anthropic API key (note: Anthropic keys start with sk-ant-)
+  { name: "anthropic-api-key", regex: /\bsk-ant-[A-Za-z0-9\-_]{80,}\b/ },
+  // xAI / Grok API key (observed pattern: xai- followed by 64+ alnum)
+  { name: "xai-api-key", regex: /\bxai-[A-Za-z0-9]{64,}\b/ },
+  // Google API key
+  { name: "google-api-key", regex: /\bAIza[0-9A-Za-z\-_]{35}\b/ },
+  // AWS access key ID
+  { name: "aws-access-key-id", regex: /\bAKIA[0-9A-Z]{16}\b/ },
+  // GitHub personal access token (classic)
+  { name: "github-pat", regex: /\bghp_[A-Za-z0-9]{36}\b/ },
+  // GitHub fine-grained PAT
+  { name: "github-pat-fg", regex: /\bgithub_pat_[A-Za-z0-9_]{82}\b/ },
+  // Slack bot token
+  { name: "slack-bot-token", regex: /\bxoxb-[A-Za-z0-9\-]{40,}\b/ },
+  // Stripe live secret key
+  { name: "stripe-secret", regex: /\bsk_live_[A-Za-z0-9]{24,}\b/ },
+  // Google OAuth client secret (GOCSPX- prefix)
+  { name: "google-oauth-secret", regex: /\bGOCSPX-[A-Za-z0-9_\-]{28,}\b/ },
+  // Generic assignment of "api_key" / "apikey" / "access_token" /
+  // "auth_token" / "secret_key" followed by a string literal of
+  // ≥20 chars. Matches both camelCase and snake_case variants.
+  {
+    name: "generic-api-key-assignment",
+    regex:
+      /\b(?:api[_-]?key|apikey|access[_-]?token|auth[_-]?token|secret[_-]?key|client[_-]?secret)\s*[:=]\s*["']([A-Za-z0-9_\-+/=]{20,})["']/i,
+  },
+  // Bearer token in source (Authorization header literal)
+  { name: "bearer-token", regex: /\bBearer\s+[A-Za-z0-9\-._~+/]{20,}\b/ },
+];
+
+/**
+ * Placeholder tokens that match our key-shape regexes but are
+ * obviously examples. We strip these before scanning so legitimate
+ * docs like `sk-YOUR_KEY_HERE` don't trip the detector even if the
+ * length happens to match.
+ */
+const PLACEHOLDER_SUBSTRINGS = [
+  "YOUR_",
+  "REPLACE_",
+  "EXAMPLE", // matches both "EXAMPLE_" and trailing "EXAMPLE" (AWS convention AKIAIOSFODNN7EXAMPLE)
+  "DEMO_",
+  "DUMMY_",
+  "PLACEHOLDER",
+  "XXXXXX",
+  "xxxxxx",
+  "your-",
+  "example-",
+  "my-key",
+];
+
+function looksLikePlaceholder(match: string): boolean {
+  for (const p of PLACEHOLDER_SUBSTRINGS) {
+    if (match.includes(p)) return true;
+  }
+  // All-x / all-zero strings
+  if (/^(sk-|xai-|AKIA|ghp_)?x+$/i.test(match)) return true;
+  if (/^[0-]+$/.test(match)) return true;
+  return false;
+}
+
+/**
+ * Filenames / paths where literal example credentials are allowed.
+ * .env.example files frequently ship with fake but shape-correct
+ * placeholder keys to document the required variables.
+ */
+const SECRET_EXEMPT_PATTERNS: RegExp[] = [
+  /\.env\.(example|sample|template|dist)$/i,
+  /\.env-example$/i,
+  /\.env\.test$/i,
+  /secrets?\.sample\./i,
+  /credentials\.example/i,
+  // Docs and readmes are exempted too — we don't want to block a
+  // README that shows how to configure an API key
+  /README(\.\w+)?$/i,
+  /CHANGELOG(\.\w+)?$/i,
+  /\.md$/i,
+  /\.rst$/i,
+];
+
+function pathIsExempt(filePath: string): boolean {
+  const name = basename(filePath);
+  return SECRET_EXEMPT_PATTERNS.some((re) => re.test(name) || re.test(filePath));
+}
+
+export interface SecretHit {
+  name: string;
+  snippet: string;
+  line: number;
+}
+
+export interface SecretVerdict {
+  hasSecret: boolean;
+  hits: SecretHit[];
+}
+
+/**
+ * Scan file content for plausible secrets. Returns every distinct
+ * hit with a truncated snippet and 1-based line number.
+ */
+export function detectSecrets(
+  filePath: string,
+  content: string,
+): SecretVerdict {
+  if (pathIsExempt(filePath)) return { hasSecret: false, hits: [] };
+
+  const hits: SecretHit[] = [];
+  const seen = new Set<string>();
+
+  for (const { name, regex } of SECRET_PATTERNS) {
+    const globalRegex = new RegExp(regex.source, regex.flags.includes("g") ? regex.flags : regex.flags + "g");
+    let m: RegExpExecArray | null;
+    while ((m = globalRegex.exec(content)) !== null) {
+      const full = m[0];
+      if (looksLikePlaceholder(full)) continue;
+      // Dedup on the matched string itself
+      if (seen.has(full)) continue;
+      seen.add(full);
+      // Compute 1-based line number
+      const line = content.slice(0, m.index).split("\n").length;
+      const snippet =
+        full.length > 60 ? full.slice(0, 20) + "…" + full.slice(-12) : full;
+      hits.push({ name, snippet, line });
+      if (m.index === globalRegex.lastIndex) globalRegex.lastIndex++;
+    }
+  }
+
+  return { hasSecret: hits.length > 0, hits };
+}
+
+export function buildSecretReport(
+  filePath: string,
+  verdict: SecretVerdict,
+): string {
+  const lines: string[] = [];
+  lines.push(
+    `BLOCKED — FILE NOT CREATED: "${basename(filePath)}" contains ${verdict.hits.length} plausible credential(s).`,
+  );
+  lines.push("");
+  lines.push(`Detected secret(s):`);
+  for (const h of verdict.hits.slice(0, 6)) {
+    lines.push(`  [${h.name}] line ${h.line}: ${h.snippet}`);
+  }
+  if (verdict.hits.length > 6) {
+    lines.push(`  ...and ${verdict.hits.length - 6} more`);
+  }
+  lines.push("");
+  lines.push(
+    `Hardcoding credentials in source files is a production-grade`,
+  );
+  lines.push(
+    `security risk. The user's API keys belong in environment variables,`,
+  );
+  lines.push(
+    `not in HTML/JS/config files that might get committed to git or`,
+  );
+  lines.push(`shipped to clients.`);
+  lines.push("");
+  lines.push(`You MUST do ONE of:`);
+  lines.push(
+    `  a) Replace the literal credential with an env-var reference`,
+  );
+  lines.push(
+    `     (process.env.API_KEY, Deno.env.get("API_KEY"), import.meta.env.VAR,`,
+  );
+  lines.push(`     etc.) and retry the Write.`);
+  lines.push(
+    `  b) If this is an example/template file, rename it to`,
+  );
+  lines.push(
+    `     \`.env.example\` / \`config.sample.json\` / similar — those`,
+  );
+  lines.push(`     paths are exempt from the secret scanner.`);
+  lines.push(
+    `  c) If the "secret" is actually a public demo key (e.g. NASA`,
+  );
+  lines.push(
+    `     DEMO_KEY, Mapbox public token), replace it with a placeholder`,
+  );
+  lines.push(
+    `     like \`YOUR_API_KEY_HERE\` — placeholders are ignored by the`,
+  );
+  lines.push(`     scanner.`);
+  return lines.join("\n");
+}
+
+// ─── Debug statement detector (warning-only) ─────────────────────
+
+interface DebugPattern {
+  name: string;
+  regex: RegExp;
+  /** File extensions this pattern applies to; empty = all. */
+  extensions: string[];
+}
+
+const DEBUG_PATTERNS: DebugPattern[] = [
+  // JavaScript / TypeScript
+  {
+    name: "console.log",
+    regex: /\bconsole\.(?:log|debug|trace|dir)\s*\(/g,
+    extensions: [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".html", ".vue", ".svelte", ".astro"],
+  },
+  {
+    name: "debugger",
+    regex: /^\s*debugger\s*;?\s*$/gm,
+    extensions: [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".html", ".vue", ".svelte", ".astro"],
+  },
+  // Python
+  {
+    name: "print()",
+    regex: /^\s*print\s*\(/gm,
+    extensions: [".py"],
+  },
+  {
+    name: "breakpoint()",
+    regex: /\bbreakpoint\s*\(\s*\)/g,
+    extensions: [".py"],
+  },
+  // Rust
+  {
+    name: "dbg!",
+    regex: /\bdbg!\s*\(/g,
+    extensions: [".rs"],
+  },
+  {
+    name: "println!",
+    regex: /\bprintln!\s*\(/g,
+    extensions: [".rs"],
+  },
+];
+
+/** File patterns where debug statements are expected / acceptable. */
+const DEBUG_EXEMPT_PATTERNS: RegExp[] = [
+  /\.test\./,
+  /\.spec\./,
+  /__tests__/,
+  /\/tests?\//,
+  /\/examples?\//,
+  /\/demos?\//,
+  /\/fixtures?\//,
+  /\/scripts?\//,
+  /\/bin\//,
+];
+
+export interface DebugHit {
+  name: string;
+  line: number;
+  snippet: string;
+}
+
+export interface DebugVerdict {
+  hasDebug: boolean;
+  hits: DebugHit[];
+}
+
+function debugPathIsExempt(filePath: string): boolean {
+  return DEBUG_EXEMPT_PATTERNS.some((re) => re.test(filePath));
+}
+
+function fileExt(filePath: string): string {
+  const i = filePath.lastIndexOf(".");
+  return i >= 0 ? filePath.slice(i).toLowerCase() : "";
+}
+
+/**
+ * Scan file content for debug statements. Non-blocking — callers
+ * should append the result as a warning to a successful-write
+ * message, not use it as a rejection signal.
+ */
+export function detectDebugStatements(
+  filePath: string,
+  content: string,
+): DebugVerdict {
+  if (debugPathIsExempt(filePath)) return { hasDebug: false, hits: [] };
+
+  const ext = fileExt(filePath);
+  const hits: DebugHit[] = [];
+
+  for (const { name, regex, extensions } of DEBUG_PATTERNS) {
+    if (extensions.length > 0 && !extensions.includes(ext)) continue;
+    const globalRegex = new RegExp(
+      regex.source,
+      regex.flags.includes("g") ? regex.flags : regex.flags + "g",
+    );
+    let m: RegExpExecArray | null;
+    let count = 0;
+    while ((m = globalRegex.exec(content)) !== null) {
+      if (count >= 10) break; // cap reports per pattern
+      count++;
+      const line = content.slice(0, m.index).split("\n").length;
+      const lineText = content.split("\n")[line - 1]?.trim() ?? "";
+      const snippet = lineText.length > 80 ? lineText.slice(0, 77) + "…" : lineText;
+      hits.push({ name, line, snippet });
+      if (m.index === globalRegex.lastIndex) globalRegex.lastIndex++;
+    }
+  }
+
+  return { hasDebug: hits.length > 0, hits };
+}
+
+export function buildDebugWarning(verdict: DebugVerdict): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(
+    `⚠️  ${verdict.hits.length} debug statement(s) detected in the written content:`,
+  );
+  for (const h of verdict.hits.slice(0, 6)) {
+    lines.push(`   [${h.name}] line ${h.line}: ${h.snippet}`);
+  }
+  if (verdict.hits.length > 6) {
+    lines.push(`   ...and ${verdict.hits.length - 6} more`);
+  }
+  lines.push("");
+  lines.push(
+    `   These are non-blocking but usually leftover from development.`,
+  );
+  lines.push(
+    `   Before shipping this file, consider removing them or gating`,
+  );
+  lines.push(
+    `   behind a DEBUG flag. Tests, examples, and scripts/bin/ paths`,
+  );
+  lines.push(`   are exempt from this check.`);
+  return lines.join("\n");
+}

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -464,6 +464,26 @@ async function _executeWriteInner(input: Record<string, unknown>): Promise<ToolR
       }
       return { tool_use_id: "", content: report, is_error: true };
     }
+
+    // Phase 26: hardcoded secrets scan. Blocks the Write when the
+    // content contains a plausible API key / access token / bearer
+    // credential that isn't a known placeholder. Docs, .env.example,
+    // and README.md are exempt. See write-content-scanner.ts.
+    try {
+      const { detectSecrets, buildSecretReport } = await import(
+        "../core/write-content-scanner.js"
+      );
+      const secrets = detectSecrets(file_path, content);
+      if (secrets.hasSecret) {
+        return {
+          tool_use_id: "",
+          content: buildSecretReport(file_path, secrets),
+          is_error: true,
+        };
+      }
+    } catch {
+      /* non-fatal */
+    }
   }
 
   // Block writes to sensitive files
@@ -558,6 +578,21 @@ async function _executeWriteInner(input: Record<string, unknown>): Promise<ToolR
     if (hasInlineHTML) {
       warning =
         "\n⚠️ Warning: This file contains HTML inside TypeScript. Consider moving HTML/CSS/JS to separate files in public/ to avoid template literal issues.";
+    }
+
+    // Phase 26 (non-blocking): append a debug-statement warning if
+    // the file contains leftover console.log / debugger / print() /
+    // dbg! / println! outside of test/example/script paths.
+    try {
+      const { detectDebugStatements, buildDebugWarning } = await import(
+        "../core/write-content-scanner.js"
+      );
+      const debug = detectDebugStatements(file_path, content);
+      if (debug.hasDebug) {
+        warning += buildDebugWarning(debug);
+      }
+    } catch {
+      /* non-fatal */
     }
 
     // Include the complete file content with line numbers for professional display.


### PR DESCRIPTION
## Summary

Two-part fix from today's exhaustive audit of the 20+ PRs shipped over the last 24 hours.

## P1 — Cross-session state leak (real bug)

Four modules hold module-level mutable state with reset functions that are **defined but NEVER called** in production:

- `session-tracker.ts`: `_readFiles`, `_grepCount`, `_grepHitFiles`, `_userTexts`, `_auditIntent` — `resetReads()` never called
- `file-edit-history.ts`: `_attempts`, `_nextIndex` — `clearEditHistory()` never called
- `auto-launch-dev-server.ts`: `_sessionState` — `resetAutoLaunchState()` never called
- `response-session.ts`: `_activeSession`, `_sessionHistory` — `resetSessionState()` never called

**Evidence**: `grep "resetReads|clearEditHistory|resetAutoLaunchState|resetSessionState" src/ | grep -v test` returned only the definitions, zero callers.

**Impact**: in a long-running kcode process (daemon mode, `/clear`, `/resume`, tmux splits, CLI re-invocations via subprocess), each new `ConversationManager` inherits state from the previous conversation. Phase 4 retry detection gets poisoned, phase 21 doc allowance reads stale user texts, phase 22 auto-launch thinks "already launched", audit guards see stale grep-hit files.

**Fix**: call all four resets at the top of `ConversationManager`'s constructor.

## P2 — Phase 26: hardcoded secrets + debug statement detector

New module `src/core/write-content-scanner.ts`:

### `detectSecrets()` — BLOCKING

Scans for 12 credential shapes: OpenAI `sk-`, Anthropic `sk-ant-`, xAI `xai-`, Google `AIza`, AWS `AKIA`, GitHub classic + fine-grained PATs, Slack bot tokens, Stripe live secrets, Google OAuth client secrets, generic `api_key/access_token/secret_key` assignments, `Bearer` header literals.

**Placeholder suppression**: skips matches containing `YOUR_`, `REPLACE_`, `EXAMPLE`, `DEMO_`, `DUMMY_`, `PLACEHOLDER`, `XXXXXX`, `your-`, `example-`, `my-key`. AWS canonical `AKIAIOSFODNN7EXAMPLE` is ignored.

**Path exemptions**: `.env.example`, `.env.sample`, `.env.template`, `.env.dist`, `secrets.sample`, `credentials.example`, `*.md`, `*.rst`, `README`, `CHANGELOG`.

### `detectDebugStatements()` — NON-BLOCKING warning

Appended to write-success message. Scans `console.log/debug/trace/dir`, `debugger`, Python `print()` / `breakpoint()`, Rust `dbg!` / `println!`.

**Path exemptions**: `*.test.*`, `*.spec.*`, `__tests__`, `/tests/`, `/examples/`, `/demos/`, `/fixtures/`, `/scripts/`, `/bin/`.

## Test fixtures note

Test file constructs the fake credentials via runtime string concatenation (e.g. `"gh" + "p_" + "a".repeat(36)`) so GitHub's own secret scanner doesn't flag the test fixtures as real credentials at push time. Nice eat-your-own-dogfood moment — my detector regex matches the pattern GitHub also uses, so the first push attempt was rejected.

## Test plan

- [x] 31 new tests in `write-content-scanner.test.ts`, all pass
- [x] 44/44 pass in write.test.ts + write-guards.test.ts regression
- [x] 65/65 pass in combined scanner + write + audit-guards + session-tracker
- [x] Full regression running separately