### PR TITLE
feat(edit-location): phase 27 — edit wrong-code-path proactive warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.69",
+  "version": "2.10.70",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/edit-location-check.test.ts
+++ b/src/core/edit-location-check.test.ts
@@ -1,0 +1,359 @@
+// Tests for phase 27 — edit location mismatch detector.
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildLocationWarning,
+  checkEditLocationMismatch,
+  extractLocationHints,
+  findSymbolLine,
+} from "./edit-location-check";
+
+// ─── extractLocationHints ────────────────────────────────────────
+
+describe("extractLocationHints", () => {
+  test("extracts English line number", () => {
+    const hints = extractLocationHints(["fix the bug at line 800"]);
+    expect(hints.lineHints).toHaveLength(1);
+    expect(hints.lineHints[0]!.value).toBe("800");
+    expect(hints.lineHints[0]!.kind).toBe("line");
+  });
+
+  test("extracts line range", () => {
+    const hints = extractLocationHints(["check lines 100-120 for the issue"]);
+    expect(hints.lineHints).toHaveLength(1);
+    expect(hints.lineHints[0]!.kind).toBe("range");
+    expect(hints.lineHints[0]!.value).toBe("100");
+    expect(hints.lineHints[0]!.endValue).toBe("120");
+  });
+
+  test("extracts Spanish línea", () => {
+    const hints = extractLocationHints(["el bug está en la línea 420"]);
+    expect(hints.lineHints).toHaveLength(1);
+    expect(hints.lineHints[0]!.value).toBe("420");
+  });
+
+  test("extracts function/class symbols", () => {
+    const hints = extractLocationHints([
+      "el bug está en function renderMarsGallery",
+      "revisa la class Dashboard",
+    ]);
+    const names = hints.symbolHints.map((h) => h.value);
+    expect(names).toContain("renderMarsGallery");
+    expect(names).toContain("Dashboard");
+  });
+
+  test("extracts backtick-quoted identifiers", () => {
+    const hints = extractLocationHints([
+      "`updateMarsChartWithRealData` is broken",
+    ]);
+    const names = hints.symbolHints.map((h) => h.value);
+    expect(names).toContain("updateMarsChartWithRealData");
+  });
+
+  test("filters generic identifiers from quoted names", () => {
+    const hints = extractLocationHints([
+      "`data` is undefined",
+      "`error` should be null",
+    ]);
+    const names = hints.symbolHints.map((h) => h.value);
+    expect(names).not.toContain("data");
+    expect(names).not.toContain("error");
+  });
+
+  test("extracts file paths", () => {
+    const hints = extractLocationHints([
+      "check orbital.html and server.js for the bug",
+    ]);
+    expect(hints.fileHints).toContain("orbital.html");
+    expect(hints.fileHints).toContain("server.js");
+  });
+
+  test("respects lookback window", () => {
+    const texts = [
+      "first says line 10",
+      "second says line 20",
+      "third says line 30",
+      "fourth says line 40",
+      "fifth says line 50",
+    ];
+    // lookback=3 → only last 3 messages scanned
+    const hints = extractLocationHints(texts, 3);
+    const values = hints.lineHints.map((h) => h.value);
+    expect(values).toEqual(["30", "40", "50"]);
+  });
+
+  test("empty input returns empty hints", () => {
+    const hints = extractLocationHints([]);
+    expect(hints.lineHints).toEqual([]);
+    expect(hints.symbolHints).toEqual([]);
+    expect(hints.fileHints).toEqual([]);
+  });
+});
+
+// ─── findSymbolLine ──────────────────────────────────────────────
+
+describe("findSymbolLine", () => {
+  test("finds symbol on line 1", () => {
+    const content = "function renderMarsGallery() {\n  return 42;\n}";
+    expect(findSymbolLine(content, "renderMarsGallery")).toBe(1);
+  });
+
+  test("finds symbol on later line", () => {
+    const content = [
+      "// header",
+      "const x = 1;",
+      "function updateMarsChart() {",
+      "  return null;",
+      "}",
+    ].join("\n");
+    expect(findSymbolLine(content, "updateMarsChart")).toBe(3);
+  });
+
+  test("respects word boundaries", () => {
+    const content = "const renderingHat = 1;\nfunction render() {}";
+    // 'render' should match on line 2, not inside 'renderingHat' on line 1
+    expect(findSymbolLine(content, "render")).toBe(2);
+  });
+
+  test("returns -1 when symbol not present", () => {
+    expect(findSymbolLine("const foo = 1;", "bar")).toBe(-1);
+  });
+
+  test("escapes regex metacharacters in symbol name", () => {
+    // This would crash if we didn't escape — though unlikely input
+    const content = "const x = 1;";
+    expect(findSymbolLine(content, "foo.bar")).toBe(-1);
+  });
+});
+
+// ─── checkEditLocationMismatch ───────────────────────────────────
+
+describe("checkEditLocationMismatch — Orbital chart scenario", () => {
+  // The v2.10.67 Orbital session had the user repeat:
+  //   "la grafica de Mars Surface Temperature"
+  //   "la grafica sigue igual"
+  //   "el problema de la grafica, audita"
+  // while the model kept editing random CSS 500+ lines away.
+  // This is the canonical test case for phase 27.
+
+  const fileContent = [
+    "// lines 1-50: CSS styles",
+    ...Array.from({ length: 48 }, (_, i) => `  .rule${i} { color: red; }`),
+    "",
+    "// lines 51-200: header & navigation",
+    ...Array.from({ length: 149 }, (_, i) => `  <div class='nav-${i}'>text</div>`),
+    "",
+    "// line 200: function declaration",
+    "function updateMarsChartWithRealData() {",
+    "  const canvas = document.getElementById('marsTempChart');",
+    "  const ctx = canvas.getContext('2d');",
+    "  return new Chart(ctx, {});",
+    "}",
+  ].join("\n");
+
+  test("flags edit far from mentioned symbol", () => {
+    const hints = extractLocationHints([
+      "updateMarsChartWithRealData is broken",
+      "la grafica sigue igual",
+    ]);
+    const verdict = checkEditLocationMismatch(
+      hints,
+      5, // edit line 5 (in CSS) — far from the function at ~200
+      "/tmp/orbital.html",
+      fileContent,
+    );
+    expect(verdict.isMismatch).toBe(true);
+    expect(verdict.unmatchedSymbolHints.length).toBeGreaterThanOrEqual(1);
+    expect(verdict.reason).toContain("updateMarsChartWithRealData");
+  });
+
+  test("does NOT flag edit near mentioned symbol", () => {
+    const hints = extractLocationHints([
+      "updateMarsChartWithRealData is broken",
+    ]);
+    // Function is at line ~202, edit at line 205 — within 30-line window
+    const verdict = checkEditLocationMismatch(
+      hints,
+      205,
+      "/tmp/orbital.html",
+      fileContent,
+    );
+    expect(verdict.isMismatch).toBe(false);
+  });
+});
+
+describe("checkEditLocationMismatch — line number mismatches", () => {
+  test("flags edit far from mentioned line", () => {
+    const hints = extractLocationHints(["fix the bug at line 800"]);
+    const verdict = checkEditLocationMismatch(
+      hints,
+      50, // edit line 50, user said 800 → distance 750
+      "/tmp/app.ts",
+      "//".repeat(1000),
+    );
+    expect(verdict.isMismatch).toBe(true);
+    expect(verdict.reason).toContain("line 800");
+    expect(verdict.reason).toContain("750");
+  });
+
+  test("does NOT flag edit within proximity window (±50)", () => {
+    const hints = extractLocationHints(["fix the bug at line 800"]);
+    const verdict = checkEditLocationMismatch(
+      hints,
+      830, // distance 30, within window
+      "/tmp/app.ts",
+      "//".repeat(1000),
+    );
+    expect(verdict.isMismatch).toBe(false);
+  });
+
+  test("does NOT fire when at least one line hint is within proximity (lenient matching)", () => {
+    // When the user mentions multiple line ranges, landing near ONE
+    // of them is enough to satisfy the intent — we don't warn just
+    // because the other hints weren't targeted.
+    const hints = extractLocationHints([
+      "check lines 100 and line 500 for bugs",
+    ]);
+    const verdict = checkEditLocationMismatch(
+      hints,
+      105, // close to 100
+      "/tmp/app.ts",
+      "//".repeat(1000),
+    );
+    expect(verdict.isMismatch).toBe(false);
+  });
+
+  test("fires when edit is far from every mentioned line", () => {
+    const hints = extractLocationHints([
+      "the bug is at line 100 and line 500",
+    ]);
+    const verdict = checkEditLocationMismatch(
+      hints,
+      10, // 90+ away from both
+      "/tmp/app.ts",
+      "//".repeat(1000),
+    );
+    expect(verdict.isMismatch).toBe(true);
+  });
+});
+
+describe("checkEditLocationMismatch — file mismatches", () => {
+  test("flags single-file mismatch", () => {
+    const hints = extractLocationHints([
+      "the bug is in server.js line 42",
+    ]);
+    const verdict = checkEditLocationMismatch(
+      hints,
+      42,
+      "/tmp/orbital.html", // editing wrong file
+      "file content",
+    );
+    expect(verdict.isMismatch).toBe(true);
+    expect(verdict.fileMismatch).toBe("server.js");
+    expect(verdict.reason).toContain("server.js");
+    expect(verdict.reason).toContain("orbital.html");
+  });
+
+  test("does not flag when editing the mentioned file", () => {
+    const hints = extractLocationHints([
+      "check orbital.html line 42",
+    ]);
+    const verdict = checkEditLocationMismatch(
+      hints,
+      42,
+      "/tmp/orbital.html",
+      "//".repeat(100),
+    );
+    expect(verdict.isMismatch).toBe(false);
+  });
+
+  test("does not flag when user mentioned multiple files (ambiguous)", () => {
+    const hints = extractLocationHints([
+      "check orbital.html, server.js, and package.json",
+    ]);
+    const verdict = checkEditLocationMismatch(
+      hints,
+      42,
+      "/tmp/README.md", // none of the mentioned files
+      "//".repeat(100),
+    );
+    // Multiple file mentions → ambiguous → don't warn on file mismatch
+    expect(verdict.fileMismatch).toBeNull();
+  });
+});
+
+describe("checkEditLocationMismatch — negative cases", () => {
+  test("returns no mismatch when there are no hints at all", () => {
+    const hints = extractLocationHints(["fix the bug"]);
+    const verdict = checkEditLocationMismatch(
+      hints,
+      42,
+      "/tmp/app.ts",
+      "content",
+    );
+    expect(verdict.isMismatch).toBe(false);
+  });
+
+  test("returns no mismatch when symbol isn't in the file", () => {
+    const hints = extractLocationHints([
+      "broken in mysteriousUnknownFunction",
+    ]);
+    const verdict = checkEditLocationMismatch(
+      hints,
+      42,
+      "/tmp/app.ts",
+      "// no symbols here",
+    );
+    expect(verdict.isMismatch).toBe(false);
+  });
+});
+
+// ─── buildLocationWarning ────────────────────────────────────────
+
+describe("buildLocationWarning", () => {
+  test("contains the reason, mismatch label, and actionable guidance", () => {
+    const verdict = {
+      isMismatch: true,
+      editLine: 50,
+      unmatchedLineHints: [],
+      unmatchedSymbolHints: [
+        {
+          kind: "symbol" as const,
+          value: "updateMarsChartWithRealData",
+          phrase: "updateMarsChartWithRealData",
+          messageIndex: 0,
+          symbolLine: 200,
+        },
+      ],
+      fileMismatch: null,
+      reason:
+        'User mentioned "updateMarsChartWithRealData" (at line 200) but Edit is ~150 lines away (at line 50).',
+    };
+    const warning = buildLocationWarning(verdict);
+    expect(warning).toContain("EDIT LOCATION MISMATCH");
+    expect(warning).toContain("non-blocking");
+    expect(warning).toContain("updateMarsChartWithRealData");
+    expect(warning).toContain("line 200");
+    expect(warning).toContain("line 50");
+    expect(warning).toMatch(/re-read/i);
+    expect(warning).toContain("fixed");
+  });
+
+  test("lists additional unmatched symbols when present", () => {
+    const verdict = {
+      isMismatch: true,
+      editLine: 10,
+      unmatchedLineHints: [],
+      unmatchedSymbolHints: [
+        { kind: "symbol" as const, value: "first", phrase: "first", messageIndex: 0, symbolLine: 100 },
+        { kind: "symbol" as const, value: "second", phrase: "second", messageIndex: 0, symbolLine: 200 },
+        { kind: "symbol" as const, value: "third", phrase: "third", messageIndex: 0, symbolLine: 300 },
+      ],
+      fileMismatch: null,
+      reason: 'User mentioned "first" (at line 100) but Edit is ~90 lines away (at line 10).',
+    };
+    const warning = buildLocationWarning(verdict);
+    expect(warning).toContain("second@200");
+    expect(warning).toContain("third@300");
+  });
+});

--- a/src/core/edit-location-check.ts
+++ b/src/core/edit-location-check.ts
@@ -1,0 +1,405 @@
+// KCode - Phase 27: Edit location mismatch warning
+//
+// Non-blocking proactive warning that fires when an Edit's target
+// line is far from where the user's recent messages said the bug
+// lives. Catches the Orbital chart-fix failure mode: the user
+// says "la gráfica" or "Mars Surface Temperature chart" and the
+// model edits random CSS 500 lines away from the real code.
+//
+// Design principles:
+//   - Non-blocking. Edits still apply. Warning is appended to the
+//     success message so the model sees it and can course-correct
+//     on the next turn (or the user can redirect).
+//   - Cheap. Regex + indexOf, no LLM calls.
+//   - Quiet when uncertain. If the user didn't mention any specific
+//     location, the detector returns null.
+//   - Lenient thresholds. Default ±50-line window, ±30-line window
+//     for symbol proximity. False positives are cheap; false
+//     negatives (missing a real mismatch) cost tokens.
+
+import { basename } from "node:path";
+
+// ─── Location hint extraction ────────────────────────────────────
+
+export interface LocationHint {
+  /** "line" for explicit line numbers, "range" for N-M, "symbol" for function/class/component names. */
+  kind: "line" | "range" | "symbol";
+  /** The line number or function/class name. */
+  value: string;
+  /** For ranges, the end line. */
+  endValue?: string;
+  /** The original phrase that matched, for the warning report. */
+  phrase: string;
+  /** Which user message this hint came from (newest = last). */
+  messageIndex: number;
+}
+
+export interface LocationHints {
+  lineHints: LocationHint[];
+  symbolHints: LocationHint[];
+  /** File paths mentioned (e.g., "orbital.html", "server.js"). */
+  fileHints: string[];
+}
+
+// Regexes for location mentions in user prose. LINE_RANGE_REGEX
+// already matches "line 800" via the `lines?` group — LINE_AT_REGEX
+// only exists to help English "at line 42" phrasing survive, but it
+// overlaps with LINE_RANGE on the same position. We dedupe line hints
+// by numeric value + messageIndex to avoid double-counting.
+const LINE_RANGE_REGEX = /\blines?\s+(\d{1,5})\s*(?:[-–—]\s*(\d{1,5}))?\b/gi;
+const LINE_AT_REGEX = /\bat\s+line\s+(\d{1,5})\b/gi;
+const SPANISH_LINE_REGEX = /\bl[ií]nea\s+(\d{1,5})\b/gi;
+// function foo / def bar / fn baz / const quux
+const SYMBOL_REGEX =
+  /\b(?:function|def|fn|class|const|let|var|method|component|m[oó]dulo|module)\s+([A-Za-z_$][A-Za-z0-9_$]{2,})/g;
+// Backtick-quoted or double-quoted identifiers: `renderMarsGallery` / "Dashboard"
+const QUOTED_ID_REGEX = /[`"']([A-Za-z_$][A-Za-z0-9_$]{4,})[`"']/g;
+// Bare long camelCase/PascalCase identifiers (≥14 chars). Catches
+// things like `updateMarsChartWithRealData is broken` where the
+// user didn't quote or prefix the name. 14+ chars avoids matching
+// ordinary English / Spanish words.
+const BARE_LONG_IDENT_REGEX =
+  /\b([a-z][a-zA-Z0-9_$]*[A-Z][a-zA-Z0-9_$]*|[A-Z][a-zA-Z0-9_$]*[A-Z][a-zA-Z0-9_$]*)\b/g;
+// File mentions with extensions: orbital.html, server.js, app.tsx
+const FILE_REGEX =
+  /\b([A-Za-z0-9_\-.]+\.(?:html|htm|js|jsx|ts|tsx|mjs|cjs|py|rs|go|java|rb|php|cs|swift|kt|scala|vue|svelte|astro|md|json|yml|yaml|toml|css|scss|sass|less))\b/g;
+
+/**
+ * Noise-filter: identifiers that are too generic to be useful
+ * location hints. If the user says "fix the component" we can't
+ * narrow the Edit location from that.
+ */
+const GENERIC_IDENTIFIERS = new Set([
+  "true",
+  "false",
+  "null",
+  "undefined",
+  "console",
+  "window",
+  "document",
+  "event",
+  "props",
+  "state",
+  "value",
+  "element",
+  "target",
+  "result",
+  "data",
+  "error",
+  "response",
+  "request",
+  "item",
+  "index",
+  "this",
+  "self",
+  "args",
+  "params",
+  "options",
+  "config",
+  "callback",
+  "handler",
+  "function",
+  "class",
+  "module",
+  "Component",
+  "Element",
+  "File",
+  "Directory",
+]);
+
+/**
+ * Extract location hints from the last N user messages. Looks for
+ * explicit line numbers, ranges, symbol names, and file paths.
+ */
+export function extractLocationHints(
+  userTexts: readonly string[],
+  lookback = 3,
+): LocationHints {
+  const window = userTexts.slice(-lookback);
+  const lineHints: LocationHint[] = [];
+  const symbolHints: LocationHint[] = [];
+  const fileHints = new Set<string>();
+
+  // Dedupe by "${value}@${messageIndex}" so two overlapping regexes
+  // matching the same position don't create duplicate hints.
+  const seenLineKey = new Set<string>();
+  const seenSymbolKey = new Set<string>();
+  const pushLine = (h: LocationHint) => {
+    const k = `${h.value}@${h.messageIndex}`;
+    if (seenLineKey.has(k)) return;
+    seenLineKey.add(k);
+    lineHints.push(h);
+  };
+  const pushSymbol = (h: LocationHint) => {
+    const k = `${h.value}@${h.messageIndex}`;
+    if (seenSymbolKey.has(k)) return;
+    seenSymbolKey.add(k);
+    symbolHints.push(h);
+  };
+
+  for (let idx = 0; idx < window.length; idx++) {
+    const text = window[idx];
+    if (!text) continue;
+
+    // Line numbers (English: "line 800", "lines 100-120", "at line 42")
+    LINE_RANGE_REGEX.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = LINE_RANGE_REGEX.exec(text)) !== null) {
+      const kind = m[2] ? "range" : "line";
+      pushLine({
+        kind,
+        value: m[1]!,
+        endValue: m[2],
+        phrase: m[0],
+        messageIndex: idx,
+      });
+    }
+
+    LINE_AT_REGEX.lastIndex = 0;
+    while ((m = LINE_AT_REGEX.exec(text)) !== null) {
+      pushLine({
+        kind: "line",
+        value: m[1]!,
+        phrase: m[0],
+        messageIndex: idx,
+      });
+    }
+
+    // Spanish línea
+    SPANISH_LINE_REGEX.lastIndex = 0;
+    while ((m = SPANISH_LINE_REGEX.exec(text)) !== null) {
+      pushLine({
+        kind: "line",
+        value: m[1]!,
+        phrase: m[0],
+        messageIndex: idx,
+      });
+    }
+
+    // Symbol names introduced by function/class/etc
+    SYMBOL_REGEX.lastIndex = 0;
+    while ((m = SYMBOL_REGEX.exec(text)) !== null) {
+      const name = m[1]!;
+      if (GENERIC_IDENTIFIERS.has(name)) continue;
+      pushSymbol({
+        kind: "symbol",
+        value: name,
+        phrase: m[0],
+        messageIndex: idx,
+      });
+    }
+
+    // Backtick / quoted identifiers
+    QUOTED_ID_REGEX.lastIndex = 0;
+    while ((m = QUOTED_ID_REGEX.exec(text)) !== null) {
+      const name = m[1]!;
+      if (GENERIC_IDENTIFIERS.has(name)) continue;
+      if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(name)) continue;
+      pushSymbol({
+        kind: "symbol",
+        value: name,
+        phrase: `"${name}"`,
+        messageIndex: idx,
+      });
+    }
+
+    // Bare long camelCase/PascalCase identifiers (≥14 chars): catches
+    // the "updateMarsChartWithRealData is broken" case where the user
+    // drops a function name in prose without quoting it.
+    BARE_LONG_IDENT_REGEX.lastIndex = 0;
+    while ((m = BARE_LONG_IDENT_REGEX.exec(text)) !== null) {
+      const name = m[1]!;
+      if (name.length < 14) continue;
+      if (GENERIC_IDENTIFIERS.has(name)) continue;
+      pushSymbol({
+        kind: "symbol",
+        value: name,
+        phrase: name,
+        messageIndex: idx,
+      });
+    }
+
+    // File paths
+    FILE_REGEX.lastIndex = 0;
+    while ((m = FILE_REGEX.exec(text)) !== null) {
+      fileHints.add(m[1]!);
+    }
+  }
+
+  return {
+    lineHints,
+    symbolHints,
+    fileHints: Array.from(fileHints),
+  };
+}
+
+// ─── Mismatch detection ──────────────────────────────────────────
+
+export interface LocationMismatchVerdict {
+  isMismatch: boolean;
+  /** The edit line. */
+  editLine: number;
+  /** Line hints the edit is far from. */
+  unmatchedLineHints: LocationHint[];
+  /** Symbol hints whose position (if found) is far from the edit. */
+  unmatchedSymbolHints: Array<LocationHint & { symbolLine: number }>;
+  /** File hints that don't match the target file path. */
+  fileMismatch: string | null;
+  /** Human-friendly summary of the mismatch for the warning. */
+  reason: string;
+}
+
+const LINE_PROXIMITY_WINDOW = 50;
+const SYMBOL_PROXIMITY_WINDOW = 30;
+
+/**
+ * Find the 1-based line number of the first occurrence of a symbol
+ * in the file content. Returns -1 if the symbol isn't found.
+ *
+ * Uses a word-boundary match so `render` doesn't match `renderingHat`.
+ */
+export function findSymbolLine(fileContent: string, symbol: string): number {
+  // Escape regex metacharacters
+  const escaped = symbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`\\b${escaped}\\b`);
+  const m = fileContent.match(re);
+  if (!m || m.index === undefined) return -1;
+  return fileContent.slice(0, m.index).split("\n").length;
+}
+
+/**
+ * Decide whether the Edit's target line is far from anywhere the
+ * user's recent messages pointed at. Returns isMismatch=false when
+ * there are no usable hints (no warning is better than a noisy one).
+ */
+export function checkEditLocationMismatch(
+  hints: LocationHints,
+  editLine: number,
+  filePath: string,
+  fileContent: string,
+): LocationMismatchVerdict {
+  const fileBase = basename(filePath);
+
+  // File-level mismatch: did the user mention a different file?
+  let fileMismatch: string | null = null;
+  if (hints.fileHints.length > 0) {
+    const exactHit = hints.fileHints.some(
+      (f) => basename(f) === fileBase,
+    );
+    if (!exactHit) {
+      // Only report if there's exactly one file hint — ambiguous
+      // cases (user mentioned 3 files, model picked one) are fine
+      if (hints.fileHints.length === 1) {
+        fileMismatch = hints.fileHints[0]!;
+      }
+    }
+  }
+
+  // Partition line hints into "near" vs "far" from the edit. If ANY
+  // line hint is near the edit, the user's intent is satisfied — we
+  // don't warn. Only emit a mismatch when every line hint is far.
+  const unmatchedLineHints: LocationHint[] = [];
+  let anyLineHintNear = false;
+  for (const h of hints.lineHints) {
+    const lineNum = parseInt(h.value, 10);
+    if (Number.isNaN(lineNum)) continue;
+    const endNum = h.endValue ? parseInt(h.endValue, 10) : lineNum;
+    const distance = Math.min(
+      Math.abs(editLine - lineNum),
+      Math.abs(editLine - endNum),
+    );
+    if (distance <= LINE_PROXIMITY_WINDOW) {
+      anyLineHintNear = true;
+    } else {
+      unmatchedLineHints.push(h);
+    }
+  }
+
+  // Same logic for symbols: if any mentioned symbol exists in the
+  // file AND is near the edit, we're probably on target.
+  const unmatchedSymbolHints: Array<LocationHint & { symbolLine: number }> = [];
+  let anySymbolNear = false;
+  let anySymbolFoundInFile = false;
+  for (const h of hints.symbolHints) {
+    const symbolLine = findSymbolLine(fileContent, h.value);
+    if (symbolLine === -1) continue; // symbol not in this file — ignore
+    anySymbolFoundInFile = true;
+    if (Math.abs(editLine - symbolLine) <= SYMBOL_PROXIMITY_WINDOW) {
+      anySymbolNear = true;
+    } else {
+      unmatchedSymbolHints.push({ ...h, symbolLine });
+    }
+  }
+
+  // Compute mismatch: fire ONLY if no hint category was satisfied.
+  // File mismatch still fires unconditionally when applicable.
+  const lineMismatch =
+    hints.lineHints.length > 0 && !anyLineHintNear && unmatchedLineHints.length > 0;
+  const symbolMismatch =
+    anySymbolFoundInFile && !anySymbolNear && unmatchedSymbolHints.length > 0;
+  const isMismatch = fileMismatch !== null || lineMismatch || symbolMismatch;
+
+  let reason = "";
+  if (fileMismatch) {
+    reason = `User mentioned "${fileMismatch}" but Edit targets "${fileBase}".`;
+  } else if (unmatchedLineHints.length > 0) {
+    const first = unmatchedLineHints[0]!;
+    const distance = Math.abs(editLine - parseInt(first.value, 10));
+    reason = `User said "${first.phrase}" but Edit is ~${distance} lines away (at line ${editLine}).`;
+  } else if (unmatchedSymbolHints.length > 0) {
+    const first = unmatchedSymbolHints[0]!;
+    const distance = Math.abs(editLine - first.symbolLine);
+    reason = `User mentioned "${first.value}" (at line ${first.symbolLine}) but Edit is ~${distance} lines away (at line ${editLine}).`;
+  }
+
+  return {
+    isMismatch,
+    editLine,
+    unmatchedLineHints,
+    unmatchedSymbolHints,
+    fileMismatch,
+    reason,
+  };
+}
+
+// ─── Warning formatter ───────────────────────────────────────────
+
+export function buildLocationWarning(verdict: LocationMismatchVerdict): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(`⚠️  EDIT LOCATION MISMATCH (non-blocking warning)`);
+  lines.push(`   ${verdict.reason}`);
+
+  if (verdict.unmatchedLineHints.length > 1) {
+    lines.push(
+      `   Additional line hints not near this edit: ${verdict.unmatchedLineHints
+        .slice(1, 4)
+        .map((h) => `"${h.phrase}"`)
+        .join(", ")}`,
+    );
+  }
+  if (verdict.unmatchedSymbolHints.length > 1) {
+    lines.push(
+      `   Additional symbols not near this edit: ${verdict.unmatchedSymbolHints
+        .slice(1, 4)
+        .map((h) => `${h.value}@${h.symbolLine}`)
+        .join(", ")}`,
+    );
+  }
+  lines.push("");
+  lines.push(
+    `   The Edit succeeded, but the target region doesn't match where`,
+  );
+  lines.push(
+    `   the user's recent messages pointed. If this Edit doesn't actually`,
+  );
+  lines.push(
+    `   fix the reported issue, re-read the code region the user referenced`,
+  );
+  lines.push(
+    `   before making another Edit. Do NOT claim "✅ fixed" on the next`,
+  );
+  lines.push(`   turn without verifying the user's actual bug is addressed.`);
+
+  return lines.join("\n");
+}

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -301,9 +301,35 @@ async function _executeEditInner(input: Record<string, unknown>): Promise<ToolRe
     const linesDelta =
       linesChanged > 0 ? `+${linesChanged}` : linesChanged === 0 ? "±0" : `${linesChanged}`;
 
+    // Phase 27: edit location mismatch warning (non-blocking). If the
+    // user's recent messages mentioned a specific line range, symbol
+    // name, or different file, and the Edit target doesn't match, we
+    // append a warning to the success message so the model can
+    // course-correct before declaring "fixed". Catches the Orbital
+    // chart-fix scenario where Edits mechanically succeeded on random
+    // CSS while the real bug was in a function 500 lines away.
+    let locationWarning = "";
+    try {
+      const { getUserTexts } = await import("../core/session-tracker.js");
+      const { extractLocationHints, checkEditLocationMismatch, buildLocationWarning } =
+        await import("../core/edit-location-check.js");
+      const hints = extractLocationHints(getUserTexts());
+      const verdict = checkEditLocationMismatch(
+        hints,
+        lineNumber,
+        file_path,
+        content,
+      );
+      if (verdict.isMismatch) {
+        locationWarning = buildLocationWarning(verdict);
+      }
+    } catch {
+      /* non-fatal */
+    }
+
     return {
       tool_use_id: "",
-      content: `Edited ${file_path}:${lineNumber} (${replacements} replacement${replacements > 1 ? "s" : ""}, ${linesDelta} lines)\n${diff}`,
+      content: `Edited ${file_path}:${lineNumber} (${replacements} replacement${replacements > 1 ? "s" : ""}, ${linesDelta} lines)\n${diff}${locationWarning}`,
     };
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

Resolves **P3** from yesterday's audit triage list.

The Orbital chart-fix session had the user point at `updateMarsChartWithRealData` / `la gráfica Mars Surface Temperature` repeatedly while the model kept editing random CSS 500+ lines away from the real function. Each Edit succeeded mechanically (old_string was found), so phase 15's zero-mutation trigger never fired. Phase 25 eventually caught the user-repetition but only reactively, after 3+ frustration messages.

**Phase 27 is proactive**: non-blocking warning appended to the Edit success message when the target line is far from where the user's recent messages pointed.

## How it works

New module `src/core/edit-location-check.ts`:

### `extractLocationHints(userTexts, lookback=3)`

Scans the last N user messages for:

- English **"line 800"**, **"lines 100-120"**, **"at line 42"**
- Spanish **"línea 420"**
- **Prefixed symbols**: `function foo` / `def bar` / `class Baz` / `const quux` / `component Header`
- **Backtick/quoted identifiers**: `` `renderMarsGallery` ``
- **Bare long camelCase** (≥14 chars) — catches *"updateMarsChartWithRealData is broken"* where the user drops a function name in prose without quoting
- **File paths** — `orbital.html`, `server.js`, etc.

Generic identifiers (`data`, `error`, `value`, `callback`, etc.) are filtered out. Deduplicates by `value+messageIndex` so `LINE_RANGE_REGEX` and `LINE_AT_REGEX` don't double-count.

### `checkEditLocationMismatch`

**Lenient matching**: returns `isMismatch=true` only when **ALL** line hints are >50 lines away AND **ALL** mentioned symbols (that exist in the file) are >30 lines away. If ANY hint is satisfied, the Edit is on-target and we stay silent.

**File mismatch**: fires when the user mentioned exactly one file and the Edit targets a different one. Multiple file mentions = ambiguous, don't warn.

### `buildLocationWarning`

Emits a `⚠️ EDIT LOCATION MISMATCH` note with the specific reason (`User said "line 800" but Edit is ~750 lines away`) and actionable guidance:

> The Edit succeeded, but the target region doesn't match where the user's recent messages pointed. If this Edit doesn't actually fix the reported issue, re-read the code region the user referenced before making another Edit. Do NOT claim "✅ fixed" on the next turn without verifying the user's actual bug is addressed.

## Wiring

`src/tools/edit.ts` after the successful write, just before constructing the success message. Pulls user history from `getUserTexts()` (phase 21 session-tracker). Warning is appended to the success content string — non-blocking, Edit still applies.

## Test plan

- [x] 27 new tests in `edit-location-check.test.ts`:
  - 8 hint extraction cases (English/Spanish/symbols/quoted/files/lookback)
  - 5 `findSymbolLine` cases including word boundaries and metachar escaping
  - 2 Orbital scenarios (symbol mismatch at line 200 while edit at line 5; correct placement near symbol)
  - 4 line-number proximity tests (far, near, multiple hints lenient, all-far)
  - 3 file mismatch cases (single file, match, ambiguous multi-file)
  - 2 negative cases (no hints, symbol absent from file)
  - 3 warning formatter content checks
- [x] 36/36 pass in `edit-location-check + edit` combined
- [x] Full regression running

## Still deferred from yesterday's audit

- **P4**: silent feature loss without placeholders (needs LLM-level analysis, not regex)
- **Phase 15/18/20 consolidation**: refactor, not a bug — efficiency win