### PR TITLE
feat(write-guards): declaration-loss detector (P4-lite) + MultiEdit location warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.70",
+  "version": "2.10.71",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/write-content-scanner.test.ts
+++ b/src/core/write-content-scanner.test.ts
@@ -3,8 +3,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildDebugWarning,
+  buildDeclarationLossWarning,
   buildSecretReport,
+  countDeclarations,
   detectDebugStatements,
+  detectDeclarationLoss,
   detectSecrets,
 } from "./write-content-scanner";
 
@@ -289,5 +292,187 @@ describe("buildDebugWarning", () => {
     expect(warning).toContain("debugger");
     expect(warning).toContain("non-blocking");
     expect(warning).toMatch(/tests,\s*examples/i);
+  });
+});
+
+// ─── Declaration loss (P4-lite) ──────────────────────────────────
+
+describe("countDeclarations", () => {
+  test("counts JS functions and classes", () => {
+    const code = `
+      function a() {}
+      function b() {}
+      class C {}
+      export function d() {}
+      export class E {}
+    `;
+    expect(countDeclarations(code, "/tmp/app.js")).toBe(5);
+  });
+
+  test("counts TS interfaces and types", () => {
+    const code = `
+      export interface Foo { x: number; }
+      export type Bar = string;
+      function baz() {}
+    `;
+    expect(countDeclarations(code, "/tmp/app.ts")).toBe(3);
+  });
+
+  test("counts Python defs and classes", () => {
+    const code = `
+      def foo():
+          pass
+      def bar():
+          pass
+      class Baz:
+          pass
+    `;
+    expect(countDeclarations(code, "/tmp/app.py")).toBe(3);
+  });
+
+  test("counts Rust fns and structs/enums/traits", () => {
+    const code = `
+      pub fn foo() {}
+      async fn bar() {}
+      struct Baz;
+      enum Qux { A, B }
+      trait Corge {}
+    `;
+    expect(countDeclarations(code, "/tmp/main.rs")).toBe(5);
+  });
+
+  test("counts Go funcs and types", () => {
+    const code = `
+      func foo() {}
+      func (r *Receiver) bar() {}
+      type Baz struct {}
+    `;
+    expect(countDeclarations(code, "/tmp/main.go")).toBe(3);
+  });
+
+  test("counts HTML-embedded script functions and arrow consts", () => {
+    const code = `
+<html><body>
+<script>
+function setup() {}
+const renderFoo = () => {};
+const handleBar = async () => {};
+</script>
+</body></html>
+    `;
+    expect(countDeclarations(code, "/tmp/app.html")).toBe(3);
+  });
+
+  test("returns 0 for unknown extension", () => {
+    expect(countDeclarations("anything", "/tmp/x.txt")).toBe(0);
+  });
+});
+
+describe("detectDeclarationLoss", () => {
+  test("fires on Orbital-style silent refactor (8 → 4 functions)", () => {
+    const oldContent = `
+<script>
+function renderMissionControl() {}
+function renderApod() {}
+function renderMars() {}
+function renderAsteroids() {}
+function renderEarth() {}
+function renderLaunches() {}
+function animateVoyager() {}
+function simulateIss() {}
+</script>
+    `;
+    // "Refactor" keeps the file similar size but drops half the render funcs
+    const newContent = `
+<script>
+function renderMissionControl() {}
+function renderMars() {}
+function animateVoyager() {}
+function simulateIss() {}
+// CSS refinements
+// ${"x".repeat(300)}
+</script>
+    `;
+    const v = detectDeclarationLoss(oldContent, newContent, "/tmp/orbital.html");
+    expect(v.hasLoss).toBe(true);
+    expect(v.oldCount).toBe(8);
+    expect(v.newCount).toBe(4);
+    expect(v.lost).toBe(4);
+    expect(v.lossRatio).toBe(0.5);
+  });
+
+  test("does NOT fire on small consolidation (drop 1-2 helpers)", () => {
+    const oldContent = `
+function a() {}
+function b() {}
+function c() {}
+function d() {}
+function e() {}
+function f() {}
+    `;
+    const newContent = `
+function a() {}
+function b() {}
+function c() {}
+function d() {}
+function merged() {}
+    `;
+    const v = detectDeclarationLoss(oldContent, newContent, "/tmp/app.js");
+    // Lost 1, below the 3-declaration minimum
+    expect(v.hasLoss).toBe(false);
+  });
+
+  test("does NOT fire on tiny files (<5 declarations total)", () => {
+    const oldContent = `function a() {} function b() {} function c() {}`;
+    const newContent = `function a() {}`;
+    const v = detectDeclarationLoss(oldContent, newContent, "/tmp/app.js");
+    // Old had 3, below the ≥5 minimum
+    expect(v.hasLoss).toBe(false);
+  });
+
+  test("does NOT fire when new file has MORE declarations", () => {
+    const oldContent = Array.from({ length: 10 }, (_, i) => `function a${i}() {}`).join("\n");
+    const newContent =
+      oldContent + "\n" + Array.from({ length: 5 }, (_, i) => `function b${i}() {}`).join("\n");
+    const v = detectDeclarationLoss(oldContent, newContent, "/tmp/app.js");
+    expect(v.hasLoss).toBe(false);
+  });
+
+  test("does NOT fire when loss ratio is below 30%", () => {
+    const oldContent = Array.from({ length: 20 }, (_, i) => `function a${i}() {}`).join("\n");
+    const newContent = Array.from({ length: 17 }, (_, i) => `function a${i}() {}`).join("\n");
+    const v = detectDeclarationLoss(oldContent, newContent, "/tmp/app.js");
+    // Lost 3 out of 20 = 15%, below threshold
+    expect(v.hasLoss).toBe(false);
+  });
+
+  test("fires when loss is ≥3 and ratio ≥30%", () => {
+    const oldContent = Array.from({ length: 10 }, (_, i) => `function a${i}() {}`).join("\n");
+    const newContent = Array.from({ length: 6 }, (_, i) => `function a${i}() {}`).join("\n");
+    const v = detectDeclarationLoss(oldContent, newContent, "/tmp/app.js");
+    // Lost 4 out of 10 = 40%
+    expect(v.hasLoss).toBe(true);
+  });
+});
+
+describe("buildDeclarationLossWarning", () => {
+  test("includes old/new counts, loss percentage, and guidance", () => {
+    const warning = buildDeclarationLossWarning({
+      hasLoss: true,
+      oldCount: 10,
+      newCount: 4,
+      lost: 6,
+      lossRatio: 0.6,
+    });
+    expect(warning).toContain("DECLARATION LOSS");
+    expect(warning).toContain("non-blocking");
+    expect(warning).toContain("10 top-level");
+    expect(warning).toContain("4");
+    expect(warning).toContain("dropped 6");
+    expect(warning).toContain("60%");
+    expect(warning).toContain("consolidation");
+    expect(warning).toMatch(/phase 19/i);
+    expect(warning).toMatch(/phase 17/i);
+    expect(warning).toMatch(/list every function|re-add/);
   });
 });

--- a/src/core/write-content-scanner.ts
+++ b/src/core/write-content-scanner.ts
@@ -362,3 +362,207 @@ export function buildDebugWarning(verdict: DebugVerdict): string {
   lines.push(`   are exempt from this check.`);
   return lines.join("\n");
 }
+
+// ─── Phase 27.5 (P4-lite): declaration loss detector ────────────
+//
+// Phase 19 (detectInPlaceShrinkage) catches ≥35% line-count drops.
+// Phase 17 (detectSkeletonContent) catches placeholder stubs. The
+// gap: a "refactor" that drops 5 functions but keeps the file size
+// via added CSS / comments. No placeholders, shrinkage ratio sits
+// above 65%, both existing guards stay silent while the model
+// silently removed features.
+//
+// This heuristic counts top-level declarations in both old and new
+// content. If the new content has ≥3 fewer declarations AND lost
+// ≥30% of what was there, append a non-blocking warning so the
+// model can retract or re-add.
+//
+// Non-blocking because:
+//   - merge/consolidation refactors are legitimate use cases
+//   - a pure regex is not authoritative about whether "fewer decls
+//     means less functionality"
+//   - warning + Edit retry is strictly better than incorrectly
+//     blocking a legit refactor
+
+interface DeclarationPattern {
+  name: string;
+  regex: RegExp;
+  extensions: string[];
+}
+
+const DECLARATION_PATTERNS: DeclarationPattern[] = [
+  // JavaScript / TypeScript
+  {
+    name: "js-function",
+    regex: /^\s*(?:export\s+(?:default\s+)?)?(?:async\s+)?function\s+[A-Za-z_$][A-Za-z0-9_$]*/gm,
+    extensions: [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"],
+  },
+  {
+    name: "js-class",
+    regex: /^\s*(?:export\s+(?:default\s+)?)?(?:abstract\s+)?class\s+[A-Za-z_$][A-Za-z0-9_$]*/gm,
+    extensions: [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"],
+  },
+  {
+    name: "ts-interface",
+    regex: /^\s*(?:export\s+)?interface\s+[A-Za-z_$][A-Za-z0-9_$]*/gm,
+    extensions: [".ts", ".tsx"],
+  },
+  {
+    name: "ts-type-alias",
+    regex: /^\s*(?:export\s+)?type\s+[A-Za-z_$][A-Za-z0-9_$]*\s*=/gm,
+    extensions: [".ts", ".tsx"],
+  },
+  // Inline HTML-embedded JS: function decls inside <script> tags.
+  // For HTML files we count the same JS patterns but also arrow
+  // function consts assigned at module level, since model-generated
+  // HTML often uses `const foo = () => {}` as top-level handlers.
+  {
+    name: "html-script-function",
+    regex: /^\s*(?:export\s+)?function\s+[A-Za-z_$][A-Za-z0-9_$]*/gm,
+    extensions: [".html", ".htm"],
+  },
+  {
+    name: "html-script-arrow",
+    regex:
+      /^\s*(?:const|let|var)\s+[A-Za-z_$][A-Za-z0-9_$]*\s*=\s*(?:async\s+)?(?:\([^)]*\)|[A-Za-z_$])\s*=>/gm,
+    extensions: [".html", ".htm", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"],
+  },
+  // Python
+  {
+    name: "py-def",
+    regex: /^\s*def\s+[A-Za-z_][A-Za-z0-9_]*/gm,
+    extensions: [".py"],
+  },
+  {
+    name: "py-class",
+    regex: /^\s*class\s+[A-Za-z_][A-Za-z0-9_]*/gm,
+    extensions: [".py"],
+  },
+  // Go
+  {
+    name: "go-func",
+    regex: /^\s*func\s+(?:\([^)]+\)\s+)?[A-Za-z_][A-Za-z0-9_]*/gm,
+    extensions: [".go"],
+  },
+  {
+    name: "go-type",
+    regex: /^\s*type\s+[A-Za-z_][A-Za-z0-9_]*/gm,
+    extensions: [".go"],
+  },
+  // Rust
+  {
+    name: "rust-fn",
+    regex: /^\s*(?:pub\s+(?:\([^)]+\)\s+)?)?(?:async\s+)?fn\s+[A-Za-z_][A-Za-z0-9_]*/gm,
+    extensions: [".rs"],
+  },
+  {
+    name: "rust-struct",
+    regex: /^\s*(?:pub\s+(?:\([^)]+\)\s+)?)?(?:struct|enum|trait)\s+[A-Za-z_][A-Za-z0-9_]*/gm,
+    extensions: [".rs"],
+  },
+];
+
+function getExt(filePath: string): string {
+  const i = filePath.lastIndexOf(".");
+  return i >= 0 ? filePath.slice(i).toLowerCase() : "";
+}
+
+/**
+ * Count top-level declarations (functions, classes, interfaces,
+ * types, structs, etc.) in the given content, based on the file
+ * extension. Returns 0 for unknown extensions so we don't warn
+ * on file types we can't parse cheaply.
+ */
+export function countDeclarations(
+  content: string,
+  filePath: string,
+): number {
+  const ext = getExt(filePath);
+  let total = 0;
+  for (const { regex, extensions } of DECLARATION_PATTERNS) {
+    if (!extensions.includes(ext)) continue;
+    const global = new RegExp(
+      regex.source,
+      regex.flags.includes("g") ? regex.flags : regex.flags + "g",
+    );
+    const matches = content.match(global);
+    if (matches) total += matches.length;
+  }
+  return total;
+}
+
+export interface DeclarationLossVerdict {
+  hasLoss: boolean;
+  oldCount: number;
+  newCount: number;
+  lost: number;
+  lossRatio: number;
+}
+
+/**
+ * Compare declaration counts between old and new content. Returns
+ * hasLoss=true when:
+ *   - old file had ≥5 declarations (skip tiny files)
+ *   - new file has ≥3 fewer declarations
+ *   - ratio lost/old ≥ 0.3 (dropped ≥30% of declarations)
+ *
+ * These thresholds are deliberately conservative — a pure
+ * rename/consolidation that drops 1-2 functions should NOT warn.
+ */
+export function detectDeclarationLoss(
+  oldContent: string,
+  newContent: string,
+  filePath: string,
+): DeclarationLossVerdict {
+  const oldCount = countDeclarations(oldContent, filePath);
+  const newCount = countDeclarations(newContent, filePath);
+  const lost = oldCount - newCount;
+  const lossRatio = oldCount > 0 ? lost / oldCount : 0;
+  const hasLoss = oldCount >= 5 && lost >= 3 && lossRatio >= 0.3;
+  return { hasLoss, oldCount, newCount, lost, lossRatio };
+}
+
+export function buildDeclarationLossWarning(
+  verdict: DeclarationLossVerdict,
+): string {
+  const lines: string[] = [];
+  const pct = Math.round(verdict.lossRatio * 100);
+  lines.push("");
+  lines.push(
+    `⚠️  DECLARATION LOSS (non-blocking warning)`,
+  );
+  lines.push(
+    `   Old file had ${verdict.oldCount} top-level declarations` +
+      ` (functions, classes, types, structs).`,
+  );
+  lines.push(
+    `   New file has ${verdict.newCount}. You dropped ${verdict.lost}` +
+      ` declarations (${pct}%).`,
+  );
+  lines.push("");
+  lines.push(
+    `   This could be a legitimate consolidation — merging 5 helpers`,
+  );
+  lines.push(
+    `   into 3 is fine if behavior is preserved. But it could also`,
+  );
+  lines.push(
+    `   mean silently dropped features. Phase 19 didn't fire because`,
+  );
+  lines.push(
+    `   line count is within range; phase 17 didn't fire because there`,
+  );
+  lines.push(`   are no placeholder stubs. That's the gap this warns about.`);
+  lines.push("");
+  lines.push(
+    `   Before claiming "refactor complete" or "behavior is identical",`,
+  );
+  lines.push(
+    `   either (a) list every function/class that was merged into a`,
+  );
+  lines.push(
+    `   replacement so the user can verify, or (b) re-add the dropped`,
+  );
+  lines.push(`   declarations.`);
+  return lines.join("\n");
+}

--- a/src/tools/multi-edit.ts
+++ b/src/tools/multi-edit.ts
@@ -255,6 +255,35 @@ async function _executeMultiEditInner(input: Record<string, unknown>): Promise<T
     for (const op of ops) {
       results.push(miniDiff(op.old_string, op.new_string));
     }
+
+    // Phase 27 for MultiEdit: run location-mismatch check against the
+    // FIRST edit in this file. If the first edit is far from user
+    // hints, subsequent edits are likely in the same region and the
+    // single warning covers them all. Non-blocking — appended to the
+    // results list so it shows up in the success message.
+    try {
+      const firstOp = ops[0];
+      if (firstOp) {
+        const firstEditLine =
+          plan.original.slice(0, plan.original.indexOf(firstOp.old_string))
+            .split("\n").length;
+        const { getUserTexts } = await import("../core/session-tracker.js");
+        const { extractLocationHints, checkEditLocationMismatch, buildLocationWarning } =
+          await import("../core/edit-location-check.js");
+        const hints = extractLocationHints(getUserTexts());
+        const verdict = checkEditLocationMismatch(
+          hints,
+          firstEditLine,
+          filePath,
+          plan.original,
+        );
+        if (verdict.isMismatch) {
+          results.push(buildLocationWarning(verdict));
+        }
+      }
+    } catch {
+      /* non-fatal */
+    }
   }
 
   return {

--- a/src/tools/write.ts
+++ b/src/tools/write.ts
@@ -543,6 +543,20 @@ async function _executeWriteInner(input: Record<string, unknown>): Promise<ToolR
       // File doesn't exist yet — safe to create
     }
 
+    // Phase 27.5 (P4-lite): snapshot old content for declaration-loss
+    // comparison AFTER the write. Read here so we capture the pre-write
+    // state; the comparison itself runs in the success path.
+    let oldContentForDeclCheck: string | null = null;
+    if (existsSync(file_path)) {
+      try {
+        const { readFileSync } =
+          require("node:fs") as typeof import("node:fs");
+        oldContentForDeclCheck = readFileSync(file_path, "utf-8");
+      } catch {
+        /* can't read — skip declaration loss check */
+      }
+    }
+
     mkdirSync(dirname(file_path), { recursive: true });
 
     // Atomic TOCTOU-safe write: O_NOFOLLOW rejects symlinks at kernel level,
@@ -583,13 +597,33 @@ async function _executeWriteInner(input: Record<string, unknown>): Promise<ToolR
     // Phase 26 (non-blocking): append a debug-statement warning if
     // the file contains leftover console.log / debugger / print() /
     // dbg! / println! outside of test/example/script paths.
+    //
+    // Phase 27.5 (non-blocking): append a declaration-loss warning
+    // when the Write replaces an existing file with significantly
+    // fewer top-level declarations (functions, classes, types). Fills
+    // the gap between phase 19 (line shrinkage) and phase 17 (skeleton
+    // stubs): a silent refactor that drops 4 of 10 functions but
+    // keeps the file size via added comments/CSS doesn't trip either.
     try {
-      const { detectDebugStatements, buildDebugWarning } = await import(
-        "../core/write-content-scanner.js"
-      );
+      const {
+        detectDebugStatements,
+        buildDebugWarning,
+        detectDeclarationLoss,
+        buildDeclarationLossWarning,
+      } = await import("../core/write-content-scanner.js");
       const debug = detectDebugStatements(file_path, content);
       if (debug.hasDebug) {
         warning += buildDebugWarning(debug);
+      }
+      if (oldContentForDeclCheck !== null) {
+        const decl = detectDeclarationLoss(
+          oldContentForDeclCheck,
+          content,
+          file_path,
+        );
+        if (decl.hasLoss) {
+          warning += buildDeclarationLossWarning(decl);
+        }
       }
     } catch {
       /* non-fatal */


### PR DESCRIPTION
## Summary

Two non-blocking additions to complete the audit follow-up from the P3/P4 triage list.

## P4-lite — Declaration-loss detector in Write

**Gap**: phase 19 catches line-count shrinkage (≥35% drop on files >300 lines). Phase 17 catches placeholder stubs (`{/* ... */}`, `<!-- condensed -->`). Neither catches the subtle failure mode where a refactor drops 4 of 10 functions but keeps the file size by adding comments / CSS / whitespace. No placeholders, shrinkage ratio above threshold, both existing guards stay silent.

**New helpers in `write-content-scanner.ts`**:

- **`countDeclarations(content, filePath)`** — language-specific regexes for:
  - JS/TS: `function`, `class`, `interface`, `type alias`
  - HTML `<script>`: function + arrow `const|let|var = (...) =>`
  - Python: `def`, `class`
  - Go: `func`, `type`
  - Rust: `fn`, `struct`, `enum`, `trait`
  - Returns 0 for unknown extensions (no false positives on binary/data files)

- **`detectDeclarationLoss(old, new, path)`** — fires when:
  - Old file had ≥5 declarations (skip tiny files)
  - New has ≥3 fewer declarations
  - `lost/old` ratio ≥ 0.3 (dropped ≥30%)
  - Thresholds deliberately conservative to avoid flagging legit consolidation dropping 1-2 helpers

- **`buildDeclarationLossWarning`** — non-blocking, includes counts, loss percentage, explicit references to phases 17/19 explaining why they stayed silent, and actionable guidance.

**Wiring** in `src/tools/write.ts`:
1. Before the atomic write, snapshot old content via `readFileSync` if the file existed
2. In the success path, call `detectDeclarationLoss` alongside the existing debug-statement check
3. Append warning to the `Created` success message — Write still applies

## Phase 27 — MultiEdit coverage

Phase 27 was wired into `edit.ts` yesterday but `multi-edit.ts` was not covered. The model can issue a MultiEdit with 5 sub-edits, all in a section 500 lines away from the user's mentioned symbol, and get a clean success message.

**Fix**: after each file's successful multi-write, compute the line of the FIRST sub-edit's `old_string` in the original content and run `checkEditLocationMismatch` against the extracted user hints. If the first edit is far from hints, append the same location warning to the per-file results block. First edit as proxy is sufficient — subsequent edits in a MultiEdit call are usually in the same region.

Lenient matching unchanged: if any hint is satisfied by the first edit, silent.

## Test plan

- [x] 14 new tests in `write-content-scanner.test.ts`:
  - `countDeclarations` × 7 (JS/TS/Py/Rust/Go/HTML/unknown-ext)
  - `detectDeclarationLoss` × 6 (Orbital reproduction, small consolidation, tiny file skip, additions, below-30%, exactly-at-threshold)
  - Warning formatter × 1
- [x] 98 tests pass in combined `write + edit + multi-edit + scanner + location-check`
- [x] Full regression running separately