### PR TITLE
fix(edit-location): filter CDN library mentions to kill phase 27 false positives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.71",
+  "version": "2.10.72",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/edit-location-check.test.ts
+++ b/src/core/edit-location-check.test.ts
@@ -68,6 +68,62 @@ describe("extractLocationHints", () => {
     expect(hints.fileHints).toContain("server.js");
   });
 
+  // ─── Phase 27 audit fix: CDN library filter ───
+
+  test("ignores CDN library mentions (Chart.js via CDN)", () => {
+    const nexusPrompt =
+      "Crea una aplicación que use Chart.js vía CDN para los gráficos " +
+      "y Tailwind CSS vía CDN para el estilo. Genera orbital.html.";
+    const hints = extractLocationHints([nexusPrompt]);
+    // orbital.html is a real file mention, Chart.js is a library
+    expect(hints.fileHints).toContain("orbital.html");
+    expect(hints.fileHints).not.toContain("Chart.js");
+  });
+
+  test("ignores React.js, Vue.js, jQuery, etc. from blocklist", () => {
+    const hints = extractLocationHints([
+      "build it with react.js and jquery.js, avoid vue.js",
+    ]);
+    expect(hints.fileHints).not.toContain("react.js");
+    expect(hints.fileHints).not.toContain("jquery.js");
+    expect(hints.fileHints).not.toContain("vue.js");
+  });
+
+  test("ignores library mentions with 'via CDN' context even if not in blocklist", () => {
+    const hints = extractLocationHints([
+      "load some-obscure-lib.js via CDN from unpkg",
+    ]);
+    expect(hints.fileHints).not.toContain("some-obscure-lib.js");
+  });
+
+  test("DOES treat path-prefixed mentions as real files even if name matches a library", () => {
+    // `./chart.js` or `src/chart.js` are user's own files — not CDN
+    const hints = extractLocationHints([
+      "the bug is in src/chart.js line 42",
+    ]);
+    expect(hints.fileHints.some((f) => f.endsWith("chart.js"))).toBe(true);
+  });
+
+  test("Nexus Telemetry false-positive regression check", () => {
+    // This is the EXACT v2.10.71 failure: user prompt mentions Chart.js
+    // as a library; model edits nexus-telemetry.html; phase 27 should
+    // NOT fire a file mismatch warning.
+    const nexusPrompt =
+      "Tecnologías: HTML5 + Tailwind CSS (vía CDN), Chart.js vía CDN, " +
+      "Lucide icons vía CDN. Crea nexus-telemetry.html.";
+    const hints = extractLocationHints([nexusPrompt]);
+    expect(hints.fileHints).toContain("nexus-telemetry.html");
+    expect(hints.fileHints).not.toContain("Chart.js");
+    // Edit the real file → no file mismatch
+    const verdict = checkEditLocationMismatch(
+      hints,
+      500,
+      "/tmp/nexus-telemetry.html",
+      "//".repeat(2000),
+    );
+    expect(verdict.fileMismatch).toBeNull();
+  });
+
   test("respects lookback window", () => {
     const texts = [
       "first says line 10",

--- a/src/core/edit-location-check.ts
+++ b/src/core/edit-location-check.ts
@@ -60,9 +60,175 @@ const QUOTED_ID_REGEX = /[`"']([A-Za-z_$][A-Za-z0-9_$]{4,})[`"']/g;
 // ordinary English / Spanish words.
 const BARE_LONG_IDENT_REGEX =
   /\b([a-z][a-zA-Z0-9_$]*[A-Z][a-zA-Z0-9_$]*|[A-Z][a-zA-Z0-9_$]*[A-Z][a-zA-Z0-9_$]*)\b/g;
-// File mentions with extensions: orbital.html, server.js, app.tsx
+// File mentions with extensions. Matches bare filenames ("server.js")
+// and path-prefixed ones ("src/chart.js", "./app/page.tsx") so the
+// CDN filter can distinguish user-project files (has path) from
+// third-party dependencies (bare library name).
 const FILE_REGEX =
-  /\b([A-Za-z0-9_\-.]+\.(?:html|htm|js|jsx|ts|tsx|mjs|cjs|py|rs|go|java|rb|php|cs|swift|kt|scala|vue|svelte|astro|md|json|yml|yaml|toml|css|scss|sass|less))\b/g;
+  /(?:\b|\.{0,2}\/)([A-Za-z0-9_\-./\\]*[A-Za-z0-9_\-]+\.(?:html|htm|js|jsx|ts|tsx|mjs|cjs|py|rs|go|java|rb|php|cs|swift|kt|scala|vue|svelte|astro|md|json|yml|yaml|toml|css|scss|sass|less))\b/g;
+
+/**
+ * Extensions that can legitimately be CDN-delivered third-party
+ * libraries. HTML/Python/Rust/Go/etc. are ALWAYS project files —
+ * never subject to the CDN filter.
+ */
+const CDN_CAPABLE_EXTENSIONS = new Set([
+  "js",
+  "jsx",
+  "mjs",
+  "cjs",
+  "ts",
+  "tsx",
+  "css",
+  "scss",
+  "sass",
+  "less",
+]);
+
+/**
+ * CDN library / framework names that look like file paths but are
+ * actually third-party dependencies mentioned in user prompts
+ * ("uses Chart.js via CDN"). These must NOT be treated as file
+ * hints for the edit-location check.
+ *
+ * The v2.10.71 Nexus Telemetry session fired phase 27 false
+ * positives on every Edit because the initial prompt mentioned
+ * "Chart.js vía CDN" and the model was editing nexus-telemetry.html —
+ * the file-mismatch path treated Chart.js as the target file.
+ *
+ * Matching is case-insensitive against the full filename.
+ */
+const CDN_LIBRARY_BLOCKLIST = new Set<string>([
+  // Charting / visualization
+  "chart.js",
+  "chartjs.js",
+  "d3.js",
+  "d3.min.js",
+  "plotly.js",
+  "echarts.js",
+  "highcharts.js",
+  // Frontend frameworks
+  "react.js",
+  "react-dom.js",
+  "vue.js",
+  "angular.js",
+  "svelte.js",
+  "ember.js",
+  "backbone.js",
+  "preact.js",
+  "solid.js",
+  "alpine.js",
+  "htmx.js",
+  // Utility libraries
+  "jquery.js",
+  "jquery.min.js",
+  "lodash.js",
+  "underscore.js",
+  "moment.js",
+  "dayjs.js",
+  "axios.js",
+  "rxjs.js",
+  // CSS frameworks
+  "tailwind.css",
+  "tailwindcss.css",
+  "bootstrap.css",
+  "bootstrap.min.css",
+  "bulma.css",
+  "foundation.css",
+  // Animation / UI
+  "gsap.js",
+  "anime.js",
+  "three.js",
+  "threejs.js",
+  "p5.js",
+  "lottie.js",
+  "framer-motion.js",
+  // Icons
+  "lucide.js",
+  "lucide-react.js",
+  "heroicons.js",
+  "feather.js",
+  // Maps
+  "leaflet.js",
+  "mapbox-gl.js",
+  "cesium.js",
+  // Build tools mentioned in prose
+  "vite.js",
+  "webpack.js",
+  "rollup.js",
+  "esbuild.js",
+  "parcel.js",
+  "turbo.js",
+  "bun.js",
+  // Backend / Node
+  "express.js",
+  "fastify.js",
+  "koa.js",
+  "hapi.js",
+  "next.js",
+  "nuxt.js",
+  "remix.js",
+  "astro.js",
+  // Data / state
+  "redux.js",
+  "mobx.js",
+  "zustand.js",
+  "valtio.js",
+  "jotai.js",
+  // Testing
+  "jest.js",
+  "mocha.js",
+  "vitest.js",
+  "cypress.js",
+  "playwright.js",
+]);
+
+/**
+ * Heuristic: a file mention looks like a CDN library dependency
+ * rather than a user-referenced project file.
+ *
+ * Rules:
+ *   1. HTML / Python / Rust / Go / Java / etc. files are NEVER
+ *      CDN libraries — they're always project files. Skip the
+ *      filter entirely for non-JS/CSS extensions.
+ *   2. Path-prefixed mentions (`src/chart.js`, `./app.js`) are
+ *      always project files, even if the basename matches a
+ *      known library.
+ *   3. Exact blocklist match (case-insensitive): `chart.js`,
+ *      `react.js`, `tailwind.css`, etc. → CDN library, filter out.
+ *   4. If the filename is BARE (no path) AND the ±40-char
+ *      surrounding text contains CDN-indicator words, filter out.
+ *      Narrower window than before (was ±80) to avoid catching
+ *      ambient prose like "uses Chart.js vía CDN" tainting a
+ *      nearby `orbital.html` mention.
+ */
+function isCdnLibraryMention(file: string, context: string): boolean {
+  // Extract extension
+  const extMatch = file.match(/\.([a-z]+)$/i);
+  if (!extMatch) return false;
+  const ext = extMatch[1]!.toLowerCase();
+  // Rule 1: non-JS/CSS extensions are always real files
+  if (!CDN_CAPABLE_EXTENSIONS.has(ext)) return false;
+  // Rule 2: path-prefixed mentions are always real files
+  if (file.includes("/") || file.includes("\\")) return false;
+  // Rule 3: explicit blocklist (bare basename)
+  const lowered = file.toLowerCase();
+  if (CDN_LIBRARY_BLOCKLIST.has(lowered)) return true;
+  // Rule 4: narrow surround check (±40 chars, not ±80)
+  const idx = context.indexOf(file);
+  if (idx === -1) return false;
+  const before = context.slice(Math.max(0, idx - 40), idx).toLowerCase();
+  const after = context.slice(idx + file.length, idx + file.length + 40).toLowerCase();
+  const surround = before + " " + after;
+  if (
+    /\bcdn\b|\bcdnjs\b|\bunpkg\b|\bjsdelivr\b|\blibrary\b|\bframework\b/.test(
+      surround,
+    )
+  ) {
+    return true;
+  }
+  return false;
+}
 
 /**
  * Noise-filter: identifiers that are too generic to be useful
@@ -219,10 +385,14 @@ export function extractLocationHints(
       });
     }
 
-    // File paths
+    // File paths — skip CDN library mentions (Chart.js, React.js,
+    // tailwind.css, etc.) that look like filenames but are
+    // dependencies, not project files
     FILE_REGEX.lastIndex = 0;
     while ((m = FILE_REGEX.exec(text)) !== null) {
-      fileHints.add(m[1]!);
+      const fileName = m[1]!;
+      if (isCdnLibraryMention(fileName, text)) continue;
+      fileHints.add(fileName);
     }
   }
 


### PR DESCRIPTION
## Summary

The v2.10.71 Nexus Telemetry session fired phase 27 **four times in a row** with this identical warning:

```
⚠️ EDIT LOCATION MISMATCH (non-blocking warning)
   User mentioned "Chart.js" but Edit targets "nexus-telemetry.html".
```

**Pure false positive.** The user's initial prompt named `Chart.js vía CDN` as a technology dependency. My `FILE_REGEX` caught `Chart.js` as a file hint, then the file-mismatch check fired on every Edit to the real `nexus-telemetry.html` because `Chart.js` looked like a different target file.

Every web project that names a `.js` library in the prompt would have generated the same noise — React.js, Vue.js, jQuery, Tailwind, Three.js, Lodash, etc. Phase 27 was effectively useless for the vast majority of frontend projects.

## Fix: `isCdnLibraryMention` with 4 rules

1. **Extension whitelist**: HTML / Python / Rust / Go / Java / Swift / Ruby / PHP / Vue / Svelte / Astro / Markdown / JSON / YAML / TOML / etc. are **NEVER** CDN libraries. Skip the filter entirely for non-JS/CSS extensions. An HTML file is always a project file.

2. **Path-prefixed exception**: `src/chart.js` / `./app.js` are always project files, even when the basename matches a known library. `FILE_REGEX` now captures `src/chart.js` as a single path so the check sees the leading directory.

3. **`CDN_LIBRARY_BLOCKLIST`**: 70+ entries across charting (chart.js, d3.js, plotly), frontend frameworks (react/vue/angular/svelte/preact/alpine/htmx), utility libs (jquery/lodash/moment/axios), CSS frameworks (tailwind/bootstrap/bulma), animation (gsap/three/p5), icons (lucide/heroicons), maps (leaflet/mapbox), build tools (vite/webpack/parcel), backend (express/next/nuxt), state (redux/zustand), testing (jest/vitest/cypress/playwright).

4. **Narrow surround check**: `±40` chars (was `±80`, which polluted siblings like `orbital.html` with ambient "vía CDN" text from elsewhere in the prompt). Only applies to JS/CSS extensions after Rules 1-3.

## Regression safety

- [x] **orbital-guard-replay.ts** still green (15/15 scenarios, includes 9 real Orbital failure modes)
- [x] **edit-location-check.test.ts**: 32/32 pass (5 new CDN-filter tests + existing 27)
- [x] **Nexus Telemetry reproduction test** confirms phase 27 NO LONGER fires spurious file mismatch when the prompt mentions Chart.js
- [x] **Path-prefixed `src/chart.js`** still matches as a real file (not filtered out by library basename check)
- [x] Full regression running

## Test cases added

```ts
test("ignores CDN library mentions (Chart.js via CDN)")
test("ignores React.js, Vue.js, jQuery, etc. from blocklist")
test("ignores library mentions with 'via CDN' context even if not in blocklist")
test("DOES treat path-prefixed mentions as real files even if name matches a library")
test("Nexus Telemetry false-positive regression check")
```