### PR TITLE
fix: resolve 5 audit findings + v2.10.76

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,13 +10,16 @@
         "ink": "^6.8.0",
         "ora": "^9.3.0",
         "react": "^19.2.4",
+        "react-dom": "^19.2.4",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
         "@types/bun": "latest",
         "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.2",
         "ink-testing-library": "^4.0.0",
         "react-devtools-core": "^7.0.1",
+        "vite": "^6.0.0",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -44,11 +47,117 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.10", "", { "os": "win32", "cpu": "x64" }, "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg=="],
 
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.1", "", { "os": "android", "cpu": "arm" }, "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.1", "", { "os": "android", "cpu": "arm64" }, "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.1", "", { "os": "linux", "cpu": "arm" }, "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.1", "", { "os": "linux", "cpu": "arm" }, "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.1", "", { "os": "linux", "cpu": "none" }, "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.1", "", { "os": "linux", "cpu": "x64" }, "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.1", "", { "os": "none", "cpu": "arm64" }, "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ=="],
+
     "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
@@ -84,7 +193,13 @@
 
     "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
 
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
@@ -108,19 +223,31 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "ora": ["ora@9.3.0", "", { "dependencies": { "chalk": "^5.6.2", "cli-cursor": "^5.0.0", "cli-spinners": "^3.2.0", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.1.0", "log-symbols": "^7.0.1", "stdin-discarder": "^0.3.1", "string-width": "^8.1.0" } }, "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw=="],
 
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
+
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
 
+    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
+
+    "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -129,6 +256,8 @@
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
 
@@ -142,11 +271,15 @@
 
     "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
 
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
     "type-fest": ["type-fest@5.4.4", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
 
     "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.75",
+  "version": "2.10.76",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",
@@ -58,8 +58,10 @@
     "@biomejs/biome": "^2.4.10",
     "@types/bun": "latest",
     "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.2",
     "ink-testing-library": "^4.0.0",
-    "react-devtools-core": "^7.0.1"
+    "react-devtools-core": "^7.0.1",
+    "vite": "^6.0.0"
   },
   "peerDependencies": {
     "typescript": "^5"
@@ -69,6 +71,7 @@
     "commander": "^14.0.3",
     "ink": "^6.8.0",
     "ora": "^9.3.0",
-    "react": "^19.2.4"
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
   }
 }

--- a/src/cli/commands/teach.ts
+++ b/src/cli/commands/teach.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { kcodePath } from "../../core/paths";
+import type { FineTuneConfig } from "../../core/training/fine-tuner";
 
 export function registerTeachCommand(program: Command): void {
   const teachCmd = program

--- a/src/web/api.test.ts
+++ b/src/web/api.test.ts
@@ -228,6 +228,29 @@ describe("API Endpoints", () => {
     expect(res.status).toBe(403);
   });
 
+  test("GET /api/v1/files/:path prevents sibling-directory bypass (prefix attack)", async () => {
+    // Regression: "/tmp/test-other/secret.txt" resolves outside
+    // "/tmp/test" but naive startsWith("/tmp/test") would pass.
+    // The fix requires cwd + path separator or exact equality.
+    bridge.setWorkingDirectory("/tmp/test");
+    const res = await handleApiRequest(
+      new Request("http://localhost/api/v1/files/..%2Ftest-other%2Fsecret.txt"),
+      "/api/v1/files/..%2Ftest-other%2Fsecret.txt",
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("GET /api/v1/files/:path still allows legitimate relative paths", async () => {
+    // Sanity check: the fix should not break normal file reads.
+    // We expect 404 (file doesn't exist), not 403 (denied).
+    bridge.setWorkingDirectory("/tmp/test");
+    const res = await handleApiRequest(
+      new Request("http://localhost/api/v1/files/subdir/file.txt"),
+      "/api/v1/files/subdir/file.txt",
+    );
+    expect(res.status).toBe(404);
+  });
+
   test("GET /api/v1/files/:path returns 404 for nonexistent file", async () => {
     bridge.setWorkingDirectory("/tmp/test");
     const res = await handleApiRequest(

--- a/src/web/api.ts
+++ b/src/web/api.ts
@@ -1,7 +1,7 @@
 // KCode - Web UI REST API
 // Endpoint handlers for /api/v1/* routes
 
-import { join, normalize, resolve } from "node:path";
+import { join, normalize, resolve, sep } from "node:path";
 import { log } from "../core/logger";
 import { getActiveModel, getConversationManager, getWorkingDirectory } from "./session-bridge";
 import type { ServerEvent } from "./types";
@@ -189,10 +189,17 @@ async function handleReadFile(encodedPath: string): Promise<Response> {
   const cwd = getWorkingDirectory();
   const requestedPath = decodeURIComponent(encodedPath);
 
-  // Resolve against cwd and ensure no path traversal
+  // Resolve against cwd and ensure no path traversal.
+  //
+  // Security fix: plain startsWith comparison is INSUFFICIENT because
+  // "/home/curly/KCode-other/secret.txt" startsWith "/home/curly/KCode"
+  // returns true and bypasses the check. The requested path must
+  // either equal the cwd exactly or be prefixed with cwd + path
+  // separator so sibling-directory traversal is impossible.
   const resolved = resolve(cwd, requestedPath);
-  const normalizedCwd = normalize(cwd);
-  if (!resolved.startsWith(normalizedCwd)) {
+  const normalizedCwd = normalize(cwd).replace(new RegExp(`${sep.replace(/[/\\]/g, "\\$&")}+$`), "");
+  const cwdWithSep = normalizedCwd + sep;
+  if (resolved !== normalizedCwd && !resolved.startsWith(cwdWithSep)) {
     return error("Path traversal denied", 403);
   }
 

--- a/src/web/client/main.tsx
+++ b/src/web/client/main.tsx
@@ -7,8 +7,14 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 
 // ─── Types ──────────────────────────────────────────────────────
+//
+// Protocol schema shared with the server — see src/web/types.ts
+// (ServerEvent type). Keep these in sync when server emits new
+// variants. The client handles the subset that's user-visible;
+// the rest are logged silently.
 
 interface Message {
+  id: string;
   role: "user" | "assistant";
   content: string;
   timestamp: number;
@@ -69,36 +75,124 @@ function App() {
   const wsUrl = `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/ws`;
   const { connected, events, send } = useWebSocket(wsUrl);
 
-  // Process WebSocket events
+  // Process WebSocket events.
+  //
+  // Protocol schema (mirrors src/web/types.ts ServerEvent):
+  //   - connected:       initial hello with sessionId + model
+  //   - model.changed:   active model switched mid-session
+  //   - message.new:     a whole new message block opened (user or assistant)
+  //   - message.delta:   streaming content appended to an existing message
+  //   - message.thinking: reasoning tokens (optional display)
+  //   - tool.start:      tool call started (inline in assistant message)
+  //   - tool.result:     tool call finished (inline)
+  //   - session.stats:   running usage counters
+  //   - error:           display as banner
+  //   - compact.start/compact.done: conversation compaction events
+  //
+  // The old handler was talking to a protocol that never existed on
+  // the server side (text_delta / message_end / status) — so the UI
+  // never updated regardless of what the server sent. Fixed.
   useEffect(() => {
     if (events.length === 0) return;
     const latest = events[events.length - 1]!;
 
     switch (latest.type) {
-      case "text_delta":
-        setStreaming(true);
+      case "connected": {
+        if (typeof latest.model === "string") setModel(latest.model);
+        break;
+      }
+
+      case "model.changed": {
+        if (typeof latest.model === "string") setModel(latest.model);
+        break;
+      }
+
+      case "message.new": {
+        const id = String(latest.id ?? "");
+        const role = (latest.role as "user" | "assistant") ?? "assistant";
+        const content = String(latest.content ?? "");
+        const timestamp = Number(latest.timestamp ?? Date.now());
+        setStreaming(role === "assistant");
         setMessages((prev) => {
-          const last = prev[prev.length - 1];
-          if (last?.role === "assistant") {
+          // Dedupe: if the same id already exists, replace it
+          const existing = prev.findIndex((m) => m.id === id);
+          if (existing >= 0) {
             return [
-              ...prev.slice(0, -1),
-              { ...last, content: last.content + (latest.text as string) },
+              ...prev.slice(0, existing),
+              { id, role, content, timestamp },
+              ...prev.slice(existing + 1),
             ];
           }
+          return [...prev, { id, role, content, timestamp }];
+        });
+        break;
+      }
+
+      case "message.delta": {
+        const id = String(latest.id ?? "");
+        const delta = String(latest.delta ?? "");
+        setStreaming(true);
+        setMessages((prev) => {
+          const existing = prev.findIndex((m) => m.id === id);
+          if (existing >= 0) {
+            const target = prev[existing]!;
+            return [
+              ...prev.slice(0, existing),
+              { ...target, content: target.content + delta },
+              ...prev.slice(existing + 1),
+            ];
+          }
+          // Unknown id — create the message as a new assistant block
           return [
             ...prev,
-            { role: "assistant", content: latest.text as string, timestamp: Date.now() },
+            { id, role: "assistant", content: delta, timestamp: Date.now() },
           ];
         });
         break;
+      }
 
-      case "message_end":
+      case "session.stats": {
+        if (typeof latest.model === "string") setModel(latest.model);
+        const input = Number(latest.inputTokens ?? 0);
+        const output = Number(latest.outputTokens ?? 0);
+        setTokenCount(input + output);
         setStreaming(false);
-        if (typeof latest.tokens === "number") setTokenCount((p) => p + (latest.tokens as number));
+        break;
+      }
+
+      case "error": {
+        // Surface the error as an assistant message so the user sees it
+        const message = String(latest.message ?? "Unknown error");
+        setStreaming(false);
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `err-${Date.now()}`,
+            role: "assistant",
+            content: `⚠️ ${message}`,
+            timestamp: Date.now(),
+          },
+        ]);
+        break;
+      }
+
+      case "message.thinking":
+      case "tool.start":
+      case "tool.result":
+      case "compact.start":
+      case "compact.done":
+      case "permission.request":
+      case "permission.resolved":
+        // Known events we don't currently display. Silently accepted
+        // so the switch exhaustiveness check at the bottom doesn't
+        // log a warning about them.
         break;
 
-      case "status":
-        if (typeof latest.model === "string") setModel(latest.model);
+      default:
+        // Unknown event type — log once for development
+        if (typeof console !== "undefined") {
+          console.debug("[kcode-web] unknown event type:", latest.type);
+        }
         break;
     }
   }, [events]);
@@ -112,7 +206,11 @@ function App() {
     const text = input.trim();
     if (!text || streaming) return;
 
-    setMessages((prev) => [...prev, { role: "user", content: text, timestamp: Date.now() }]);
+    const localId = `local-user-${Date.now()}`;
+    setMessages((prev) => [
+      ...prev,
+      { id: localId, role: "user", content: text, timestamp: Date.now() },
+    ]);
     send({ type: "message.send", content: text });
     setInput("");
   };
@@ -171,9 +269,9 @@ function App() {
             <p>Connected to your local KCode session. Type a message below to get started.</p>
           </div>
         )}
-        {messages.map((msg, i) => (
+        {messages.map((msg) => (
           <div
-            key={i}
+            key={msg.id}
             style={{
               margin: "8px 0",
               padding: "12px 16px",

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -4,17 +4,24 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { WebServer } from "./server";
 import type { WebServerConfig } from "./types";
 
-const TEST_PORT = 19399;
-
+// Port 0 lets the OS pick a free port at bind time. Each test reads
+// the actual assigned port via `server.port` after `start()` resolves.
+// This avoids the v2.10.74 EADDRINUSE flake where a hardcoded 19399
+// collided with parallel test runs and left 16 tests failing.
 function testConfig(overrides?: Partial<WebServerConfig>): Partial<WebServerConfig> {
   return {
-    port: TEST_PORT,
+    port: 0,
     host: "127.0.0.1",
     auth: { enabled: true, token: "test-token-12345" },
     cors: false,
     openBrowser: false,
     ...overrides,
   };
+}
+
+/** URL helper: returns the base URL for the currently-running server. */
+function base(server: WebServer): string {
+  return `http://127.0.0.1:${server.port}`;
 }
 
 describe("WebServer", () => {
@@ -32,7 +39,8 @@ describe("WebServer", () => {
 
   test("starts and stops", async () => {
     const result = await server.start();
-    expect(result.url).toContain(String(TEST_PORT));
+    expect(result.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(server.port).toBeGreaterThan(0);
     expect(result.token).toBe("test-token-12345");
     expect(server.isRunning).toBe(true);
 
@@ -47,7 +55,7 @@ describe("WebServer", () => {
 
   test("serves index.html for root path", async () => {
     await server.start();
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/?token=test-token-12345`);
+    const res = await fetch(`${base(server)}/?token=test-token-12345`);
     expect(res.status).toBe(200);
     const text = await res.text();
     expect(text).toContain("KCode Web UI");
@@ -56,14 +64,14 @@ describe("WebServer", () => {
 
   test("serves CSS with correct MIME type", async () => {
     await server.start();
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/styles.css?token=test-token-12345`);
+    const res = await fetch(`${base(server)}/styles.css?token=test-token-12345`);
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/css");
   });
 
   test("serves JS with correct MIME type", async () => {
     await server.start();
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/app.js?token=test-token-12345`);
+    const res = await fetch(`${base(server)}/app.js?token=test-token-12345`);
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("javascript");
   });
@@ -71,7 +79,7 @@ describe("WebServer", () => {
   test("returns 404 for nonexistent files", async () => {
     // SPA fallback means unknown paths return index.html
     await server.start();
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/nonexistent.xyz?token=test-token-12345`);
+    const res = await fetch(`${base(server)}/nonexistent.xyz?token=test-token-12345`);
     // Falls back to index.html due to SPA routing
     expect(res.status).toBe(200);
   });
@@ -79,7 +87,7 @@ describe("WebServer", () => {
   test("prevents path traversal in static files", async () => {
     await server.start();
     const res = await fetch(
-      `http://127.0.0.1:${TEST_PORT}/..%2F..%2Fetc%2Fpasswd?token=test-token-12345`,
+      `${base(server)}/..%2F..%2Fetc%2Fpasswd?token=test-token-12345`,
     );
     // Path traversal dots are stripped, so it won't escape static dir
     expect(res.status).not.toBe(500);
@@ -87,7 +95,7 @@ describe("WebServer", () => {
 
   test("rejects WebSocket upgrade without token", async () => {
     await server.start();
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/ws`, {
+    const res = await fetch(`${base(server)}/ws`, {
       headers: { Upgrade: "websocket" },
     });
     expect(res.status).toBe(401);
@@ -95,13 +103,13 @@ describe("WebServer", () => {
 
   test("rejects API requests without auth", async () => {
     await server.start();
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/api/v1/session`);
+    const res = await fetch(`${base(server)}/api/v1/session`);
     expect(res.status).toBe(401);
   });
 
   test("accepts API requests with Bearer token", async () => {
     await server.start();
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/api/v1/health`, {
+    const res = await fetch(`${base(server)}/api/v1/health`, {
       headers: { Authorization: "Bearer test-token-12345" },
     });
     expect(res.status).toBe(200);
@@ -111,7 +119,7 @@ describe("WebServer", () => {
 
   test("accepts API requests with query token", async () => {
     await server.start();
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/api/v1/health?token=test-token-12345`);
+    const res = await fetch(`${base(server)}/api/v1/health?token=test-token-12345`);
     expect(res.status).toBe(200);
   });
 
@@ -120,7 +128,7 @@ describe("WebServer", () => {
     server = new WebServer(testConfig({ cors: true }));
     await server.start();
 
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/api/v1/health?token=test-token-12345`);
+    const res = await fetch(`${base(server)}/api/v1/health?token=test-token-12345`);
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
   });
 
@@ -129,7 +137,7 @@ describe("WebServer", () => {
     server = new WebServer(testConfig({ cors: true }));
     await server.start();
 
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/api/v1/health`, {
+    const res = await fetch(`${base(server)}/api/v1/health`, {
       method: "OPTIONS",
     });
     expect(res.status).toBe(204);
@@ -140,7 +148,7 @@ describe("WebServer", () => {
     server = new WebServer(testConfig({ auth: { enabled: false, token: "" } }));
     await server.start();
 
-    const res = await fetch(`http://127.0.0.1:${TEST_PORT}/api/v1/health`);
+    const res = await fetch(`${base(server)}/api/v1/health`);
     expect(res.status).toBe(200);
   });
 
@@ -157,14 +165,16 @@ describe("WebServer", () => {
 
   test("getConfig returns config copy", () => {
     const config = server.getConfig();
-    expect(config.port).toBe(TEST_PORT);
+    // Config.port is 0 (requested), server.port holds the actual
+    // OS-assigned port only after start()
+    expect(config.port).toBe(0);
     expect(config.auth.token).toBe("test-token-12345");
   });
 
   test("WebSocket connects with valid token", async () => {
     await server.start();
 
-    const ws = new WebSocket(`ws://127.0.0.1:${TEST_PORT}/ws?token=test-token-12345`);
+    const ws = new WebSocket(`${base(server).replace("http","ws")}/ws?token=test-token-12345`);
 
     const connected = await new Promise<boolean>((resolve) => {
       ws.onopen = () => resolve(true);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -154,7 +154,11 @@ export class WebServer {
       },
     });
 
-    const baseUrl = `http://${config.host}:${config.port}`;
+    // Use the actual port Bun assigned (may differ from config.port
+    // when config.port === 0 for OS-assigned random ports, which the
+    // test suite relies on to run in parallel without EADDRINUSE).
+    const actualPort = this.server.port;
+    const baseUrl = `http://${config.host}:${actualPort}`;
     const uiUrl = `${baseUrl}?token=${config.auth.token}`;
 
     log.info("web", `Web UI server started at ${baseUrl}`);
@@ -166,6 +170,15 @@ export class WebServer {
     }
 
     return { url: baseUrl, token: config.auth.token };
+  }
+
+  /**
+   * Actual TCP port the server is listening on. Returns 0 when the
+   * server is stopped. Useful when config.port was 0 and Bun picked
+   * a random free port — tests use this to avoid hardcoded ports.
+   */
+  get port(): number {
+    return this.server?.port ?? 0;
   }
 
   /** Stop the server */


### PR DESCRIPTION
## Summary
Fixes 5 findings from the code audit — 2 high, 2 medium, 1 low.

- **HIGH** — Path traversal bypass in `src/web/api.ts`: `startsWith(cwd)` allowed sibling directories (e.g. `/home/curly/KCode-other/secret`) to escape the workspace. Now enforces exact-match or `cwd + sep` prefix. +2 regression tests.
- **HIGH** — SPA React protocol mismatch in `src/web/client/main.tsx`: client listened for `text_delta`/`message_end`/`status` events the server never emits, so the UI silently ignored everything. Rewrote the event dispatcher to the real `ServerEvent` schema (connected, model.changed, message.new/delta, session.stats, error, tool.*). Messages now have ids for dedupe against server echoes.
- **MEDIUM** — `FineTuneConfig` used in `teach.ts:136` without a top-level `import type`.
- **MEDIUM** — Missing deps: `react-dom`, `@types/react-dom`, `vite` added to package.json so `bun run build:web` and client typechecking work.
- **LOW** — `server.test.ts` used hardcoded port 19399 which caused EADDRINUSE flakes on parallel runs. Switched to `port: 0` with an OS-assigned port read via a new `server.port` getter.

Version bumped to **v2.10.76**.

## Test plan
- [x] `bun test src/web/` — 88/88 pass
- [x] `bun test src/cli/commands/` — 60/60 pass
- [x] `bun run build` — binary produced (107 MB, v2.10.76)
- [x] Manual audit of path-traversal regression tests (sibling dir → 403, legit path → 404)
- [x] Full batched suite green on retry (batch 9 flake unrelated)

Co-Authored-By: Kulvex Code <contact@astrolexis.space>