### PR TITLE
fix: orphan tool_use sanitization + audit round 2 + v2.10.77

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.76",
+  "version": "2.10.77",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/message-converters.test.ts
+++ b/src/core/message-converters.test.ts
@@ -241,6 +241,126 @@ describe("convertToAnthropicMessages", () => {
     expect(result).toHaveLength(1);
     expect(result[0]!.role).toBe("user");
   });
+
+  // ─── Orphan tool_use sanitization ─────────────────────────────
+  //
+  // Regression tests for the v2.10.76 bug where phase-20 (pkill guard)
+  // blocked a bash call and some code path failed to emit the synthetic
+  // tool_result, sending the orphan to Anthropic and hitting
+  //   400 "tool_use ids were found without tool_result blocks
+  //        immediately after: toolu_..."
+  // Both claude-opus-4-6 and claude-sonnet-4-6 died on the same bug
+  // during the NEXUS Telemetry session. The sanitizer is a serialization-
+  // layer safety net that synthesizes a tool_result for any orphan.
+
+  test("synthesizes tool_result for orphan tool_use when next message is missing", () => {
+    const messages: Message[] = [
+      { role: "user", content: "run pkill" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "ok" },
+          { type: "tool_use", id: "toolu_orphan1", name: "Bash", input: { command: "pkill -9 node" } },
+        ],
+      },
+    ];
+    const result = convertToAnthropicMessages(messages);
+    // Should have inserted a user message with synthetic tool_result
+    expect(result).toHaveLength(3);
+    const injected = result[2]!;
+    expect(injected.role).toBe("user");
+    expect(Array.isArray(injected.content)).toBe(true);
+    const blocks = injected.content as Array<{ type: string; tool_use_id?: string; is_error?: boolean }>;
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.type).toBe("tool_result");
+    expect(blocks[0]!.tool_use_id).toBe("toolu_orphan1");
+    expect(blocks[0]!.is_error).toBe(true);
+  });
+
+  test("synthesizes tool_result when next message is plain user text (no tool_result)", () => {
+    const messages: Message[] = [
+      { role: "user", content: "first" },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "toolu_X", name: "Bash", input: { command: "ls" } }],
+      },
+      // User typed a follow-up before the tool result arrived — orphan
+      { role: "user", content: "wait, stop" },
+    ];
+    const result = convertToAnthropicMessages(messages);
+    // Sanitizer should inject synthetic tool_result BEFORE the user's
+    // follow-up text, keeping the assistant tool_use paired.
+    expect(result.length).toBeGreaterThanOrEqual(3);
+    // Find the message right after the assistant with tool_use
+    const assistantIdx = result.findIndex(
+      (m) => m.role === "assistant" && Array.isArray(m.content),
+    );
+    const next = result[assistantIdx + 1];
+    expect(next).toBeDefined();
+    expect(next!.role).toBe("user");
+    const blocks = next!.content as Array<{ type: string; tool_use_id?: string }>;
+    const toolResults = blocks.filter((b) => b.type === "tool_result");
+    expect(toolResults.length).toBeGreaterThanOrEqual(1);
+    expect(toolResults[0]!.tool_use_id).toBe("toolu_X");
+  });
+
+  test("appends missing tool_result when next message has partial pairing", () => {
+    const messages: Message[] = [
+      { role: "user", content: "do two things" },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "toolu_A", name: "Read", input: { file_path: "/a" } },
+          { type: "tool_use", id: "toolu_B", name: "Read", input: { file_path: "/b" } },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          // Only B has a result, A is an orphan
+          { type: "tool_result", tool_use_id: "toolu_B", content: "b data" },
+        ],
+      },
+    ];
+    const result = convertToAnthropicMessages(messages);
+    expect(result).toHaveLength(3);
+    const toolResultMsg = result[2]!;
+    const blocks = toolResultMsg.content as Array<{ type: string; tool_use_id?: string }>;
+    const ids = blocks
+      .filter((b) => b.type === "tool_result")
+      .map((b) => b.tool_use_id);
+    // Both A and B must be present; order is implementation-defined but
+    // the important invariant is both ids appear.
+    expect(ids).toContain("toolu_A");
+    expect(ids).toContain("toolu_B");
+  });
+
+  test("leaves correctly-paired tool_use/tool_result alone", () => {
+    const messages: Message[] = [
+      { role: "user", content: "read a file" },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "toolu_ok", name: "Read", input: { file_path: "/x" } },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "toolu_ok", content: "x contents" }],
+      },
+    ];
+    const before = JSON.stringify(convertToAnthropicMessages(messages));
+    // Re-running should not mutate — convertToAnthropicMessages must be idempotent
+    const after = JSON.stringify(convertToAnthropicMessages(messages));
+    expect(before).toBe(after);
+    // Structure should have exactly 3 messages, no synthetic injection
+    const result = convertToAnthropicMessages(messages);
+    expect(result).toHaveLength(3);
+    const tr = (result[2]!.content as Array<{ type: string }>).filter(
+      (b) => b.type === "tool_result",
+    );
+    expect(tr).toHaveLength(1);
+  });
 });
 
 // ─── Anthropic Tool Conversion ──────────────────────────────────

--- a/src/core/message-converters.ts
+++ b/src/core/message-converters.ts
@@ -224,7 +224,85 @@ export function convertToAnthropicMessages(messages: Message[]): AnthropicMessag
     result.unshift({ role: "user", content: "Hello." });
   }
 
+  // Sanitize orphan tool_use blocks. Anthropic enforces that every tool_use
+  // in an assistant message must be immediately followed by a matching
+  // tool_result in the next user message — or the request 400s with
+  // "tool_use ids were found without tool_result blocks immediately after".
+  // This was catastrophic on the NEXUS Telemetry session where Opus 4.6 and
+  // Sonnet 4.6 both died after phase-20 blocked a pkill and some code path
+  // failed to emit the synthetic tool_result (either an early-return in the
+  // stop-condition handlers with updatedContent undefined, or a partial
+  // stream that crashed before the executor ran). Rather than track down
+  // every possible source of orphans, we sanitize at the serialization
+  // boundary: any orphan tool_use gets a synthetic "(execution not
+  // completed)" tool_result wedged in right after. Grok/OpenAI-compatible
+  // APIs are more lenient but running this for all providers keeps the
+  // invariant airtight.
+  sanitizeOrphanToolUses(result);
+
   return result;
+}
+
+/**
+ * Walk an Anthropic-format message array and ensure every assistant tool_use
+ * has a matching tool_result in the next user message. Mutates the array.
+ *
+ * Behavior:
+ * - If the next message is user + content-array, append synthetic tool_result
+ *   blocks for any missing tool_use_ids at the front (order-stable).
+ * - If the next message is missing, user+string, or assistant, insert a new
+ *   user message containing the synthetic tool_results right after.
+ * - Every injected block is_error=true with a short diagnostic so the model
+ *   sees why its tool didn't run.
+ */
+function sanitizeOrphanToolUses(messages: AnthropicMessage[]): void {
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i]!;
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+
+    const toolUseIds: string[] = [];
+    for (const block of msg.content as Array<{ type: string; id?: string }>) {
+      if (block.type === "tool_use" && typeof block.id === "string") {
+        toolUseIds.push(block.id);
+      }
+    }
+    if (toolUseIds.length === 0) continue;
+
+    const next = messages[i + 1];
+    const matched = new Set<string>();
+    if (next && next.role === "user" && Array.isArray(next.content)) {
+      for (const block of next.content as Array<{ type: string; tool_use_id?: string }>) {
+        if (block.type === "tool_result" && typeof block.tool_use_id === "string") {
+          matched.add(block.tool_use_id);
+        }
+      }
+    }
+
+    const orphans = toolUseIds.filter((id) => !matched.has(id));
+    if (orphans.length === 0) continue;
+
+    const synthetic = orphans.map((id) => ({
+      type: "tool_result" as const,
+      tool_use_id: id,
+      content: "(execution not completed: tool run was interrupted before a result could be produced)",
+      is_error: true,
+    }));
+
+    if (next && next.role === "user" && Array.isArray(next.content)) {
+      // Prepend so synthetic results come before any unrelated user text
+      // blocks — Anthropic only requires they be in the message, not first.
+      // Prepending keeps it visually clear what kcode injected.
+      (next.content as unknown[]).unshift(...synthetic);
+    } else {
+      messages.splice(i + 1, 0, {
+        role: "user",
+        content: synthetic as unknown as AnthropicContentBlock[],
+      });
+      // Don't advance past the inserted message — the outer for-loop
+      // increment will skip it naturally since the next assistant message
+      // is now at i+2.
+    }
+  }
 }
 
 /**

--- a/src/web/client/main.tsx
+++ b/src/web/client/main.tsx
@@ -206,11 +206,12 @@ function App() {
     const text = input.trim();
     if (!text || streaming) return;
 
-    const localId = `local-user-${Date.now()}`;
-    setMessages((prev) => [
-      ...prev,
-      { id: localId, role: "user", content: text, timestamp: Date.now() },
-    ]);
+    // Intentionally no optimistic push. The server echoes `message.new`
+    // with its own `msg-N` id within milliseconds; pushing a local
+    // `local-user-*` entry here meant dedupe-by-id never matched and the
+    // user saw their message twice. Letting the server be the single
+    // source of truth removes the duplicate without adding latency that
+    // matters in practice — the WebSocket round-trip is same-host.
     send({ type: "message.send", content: text });
     setInput("");
   };

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -25,7 +25,7 @@ function timingSafeTokenEqual(supplied: string | null | undefined, expected: str
 import { handleApiRequest } from "./api";
 import type { ServerEvent, WebServerConfig } from "./types";
 import { DEFAULT_WEB_CONFIG, MIME_TYPES } from "./types";
-import { handleClientMessage, setSessionContext } from "./ws-handler";
+import { handleClientMessage, setBroadcastFn, setSessionContext } from "./ws-handler";
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -58,6 +58,11 @@ export class WebServer {
 
     const self = this;
     const config = this.config;
+
+    // Register the broadcast callback so REST enqueue can drain the queue
+    // even when no WebSocket has connected yet. Without this the POST
+    // /api/v1/messages path would enqueue and hang forever.
+    setBroadcastFn((evt) => self.broadcast(evt));
 
     this.server = Bun.serve<WebSocketData>({
       port: config.port,

--- a/src/web/ws-handler.ts
+++ b/src/web/ws-handler.ts
@@ -24,6 +24,19 @@ const messageQueue: Array<{ content: string; id: string }> = [];
 // Broadcast callback (set by server.ts)
 type BroadcastFn = (event: ServerEvent) => void;
 
+// Module-level broadcast reference. Set the first time server.ts hands us
+// one (on WebSocket connect / first client message). enqueueMessage uses
+// this to drain the queue even when the REST endpoint fires before any
+// WebSocket has connected — otherwise POST /api/v1/messages would enqueue
+// and never process, because processQueue only ran from inside
+// handleMessageSend.finally().
+let storedBroadcast: BroadcastFn | null = null;
+
+/** Register the broadcast function so REST enqueue can drain the queue. */
+export function setBroadcastFn(fn: BroadcastFn): void {
+  storedBroadcast = fn;
+}
+
 // ─── Public API ─────────────────────────────────────────────────
 
 /** Initialize or return session context */
@@ -54,7 +67,12 @@ export function handleClientMessage(
 export function enqueueMessage(content: string): string {
   const id = `msg-${++sessionContext.messageIdCounter}`;
   messageQueue.push({ content, id });
-  // Processing will be triggered when a broadcast function is available
+  // Drain immediately if we have a broadcast and nothing is running. Without
+  // this a POST /api/v1/messages made before any WebSocket has connected
+  // would queue the message and wait forever.
+  if (storedBroadcast && !isProcessing) {
+    processQueue(storedBroadcast);
+  }
   return id;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     // Environment setup & latest features
-    "lib": ["ESNext"],
+    // DOM lib is required because src/web/client/main.tsx targets the browser
+    // (window, document, WebSocket, HTMLDivElement, etc.). The rest of the
+    // codebase is Node/Bun and doesn't use DOM APIs, so including DOM here
+    // costs nothing for them and unblocks typecheck for the web client.
+    "lib": ["ESNext", "DOM"],
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
Round-2 audit + root-cause of the Opus/Sonnet deaths during the NEXUS Telemetry cross-model comparison session.

### Critical — orphan tool_use killed Anthropic sessions
The NEXUS log from \`~/Descargas/kcode.log\` showed both **claude-opus-4-6** and **claude-sonnet-4-6** dying with identical errors:
\`\`\`
400 Bad Request — messages.6: tool_use ids were found without tool_result blocks immediately after: toolu_...
\`\`\`
Trigger: phase 20 blocks \`pkill -9 node\`. Some code path (stop-condition early-return with \`updatedContent: undefined\`, partial stream, retry reshape, ...) failed to emit the synthetic tool_result, and the orphan \`tool_use\` went to Anthropic which enforces the invariant strictly. Grok and local models were lenient and survived, which hid the bug.

**Fix**: \`sanitizeOrphanToolUses()\` runs at the serialization boundary inside \`convertToAnthropicMessages\`. For every assistant \`tool_use\` without a matching \`tool_result\` in the next user message, it injects a synthetic \`{type: "tool_result", is_error: true, content: "(execution not completed)"}\` block. Works regardless of which upstream path dropped the result. **4 new regression tests.**

### Follow-ups on audit round 2
- **SPA duplicated user messages** — my v2.10.76 optimistic \`local-user-*\` id never matched the server's \`msg-N\` echo, so dedupe failed and every send rendered twice. Fix: drop optimistic push. Server is same-host; the echo arrives in ms.
- **REST \`POST /api/v1/messages\` enqueued forever** — \`enqueueMessage\` pushed to the queue but \`processQueue\` only ran from \`handleMessageSend.finally()\`. A REST call before any WebSocket connect hung indefinitely. Fix: module-level \`storedBroadcast\` via new \`setBroadcastFn\`, drain in \`enqueueMessage\` if \`!isProcessing\`.
- **tsconfig lib missing DOM** — \`src/web/client/main.tsx\` uses \`window\`/\`document\`/\`WebSocket\`/\`HTMLDivElement\` which all errored under \`lib: ["ESNext"]\`. Added \`"DOM"\`.

### Not fixed (not reproducible)
\`src/web/server.test.ts\` EADDRINUSE — I ran the auditor's exact command (\`bun test src/web/server.test.ts src/web/api.test.ts\`) and got 44/44 pass. Tests use \`port: 0\` which the OS assigns. Likely a stale \`kcode\` web process in the auditor's environment.

## Test plan
- [x] \`bun test src/core/message-converters.test.ts\` — 23/23 pass (4 new + 19 existing)
- [x] \`bun test src/web/\` — 88/88 pass
- [x] \`bun test src/core/conversation.test.ts src/core/tool-executor.test.ts src/web/ src/core/message-converters.test.ts\` — 187/187 pass
- [x] \`bun run build\` — v2.10.77 binary deployed
- [x] Manual review of NEXUS Telemetry kcode.log confirms the exact failure mode this addresses

Co-Authored-By: Kulvex Code <contact@astrolexis.space>