### PR TITLE
feat(phase-31): block rewrite-after-failed-Edit escape + v2.10.78

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.77",
+  "version": "2.10.78",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/agent-loop-guards.ts
+++ b/src/core/agent-loop-guards.ts
@@ -311,6 +311,30 @@ export class LoopGuardState {
   /** Set of "burned" fingerprints that should not be retried */
   readonly burnedFingerprints = new Set<string>();
 
+  /**
+   * Phase 31: track files with a recent failed Edit so we can block
+   * "rewrite the whole file" escape via Write.
+   *
+   * Canonical trigger: NEXUS Telemetry session v2.10.76, mark6 (Gemma
+   * abliterated local model). User reported "no se inicia el servicio,
+   * aparece como caído". Model invented three phantom typos ("setProperty
+   * en lugar de setProperty", "getContext en lugar de getContext",
+   * "reverse en lugar de reverse" — literally X instead of X), tried an
+   * Edit with old_string === new_string, kcode correctly blocked the
+   * no-op Edit, and the model escaped by rewriting the entire 850-line
+   * file as 627 lines via Write — strictly worse. The phase 31 guard
+   * blocks that escape path: Write on a file with a recent failed Edit
+   * requires the model to re-read and produce a surgical Edit instead.
+   *
+   * Key is the absolute file_path; value is the reason from the Edit
+   * failure + the tool call index so we can expire stale entries.
+   * Cleared by a subsequent successful Edit on the same file.
+   */
+  readonly recentEditFailures = new Map<
+    string,
+    { reason: string; callIndex: number }
+  >();
+
   // Pre-computed tool filter sets
   readonly managedDisallowedSet: Set<string>;
   readonly allowedToolsSet: Set<string> | null;
@@ -415,6 +439,52 @@ export class LoopGuardState {
       }
     }
     this.inlineWarningCount = 0;
+  }
+
+  /**
+   * Phase 31: record a failed Edit so a subsequent Write on the same
+   * file can be blocked (escape-by-rewrite prevention).
+   *
+   * `callIndex` is the current tool-call counter snapshot at record
+   * time — used to expire entries that are more than ~6 tool calls
+   * old so long sessions don't keep stale blocks forever.
+   */
+  recordEditFailure(filePath: string, reason: string, callIndex: number): void {
+    if (!filePath) return;
+    this.recentEditFailures.set(filePath, { reason, callIndex });
+    // Bound the map so pathological sessions can't eat memory
+    if (this.recentEditFailures.size > 50) {
+      const firstKey = this.recentEditFailures.keys().next().value;
+      if (firstKey) this.recentEditFailures.delete(firstKey);
+    }
+  }
+
+  /**
+   * Phase 31: check whether a Write on this file should be blocked
+   * as a "rewrite after failed Edit" escape. Returns the failure
+   * reason if blocked, null otherwise. Expires entries older than 6
+   * tool calls so the guard doesn't outlive its usefulness.
+   */
+  getRecentEditFailure(filePath: string, currentCallIndex: number): string | null {
+    if (!filePath) return null;
+    const entry = this.recentEditFailures.get(filePath);
+    if (!entry) return null;
+    // Expire if too many tool calls have passed — model may have
+    // legitimately investigated and decided to rewrite.
+    if (currentCallIndex - entry.callIndex > 6) {
+      this.recentEditFailures.delete(filePath);
+      return null;
+    }
+    return entry.reason;
+  }
+
+  /**
+   * Phase 31: clear a file's failed-Edit record after a successful
+   * Edit on it. Called from tool-executor after the Edit path succeeds.
+   */
+  clearEditFailure(filePath: string): void {
+    if (!filePath) return;
+    this.recentEditFailures.delete(filePath);
   }
 }
 

--- a/src/core/phase31-rewrite-escape.test.ts
+++ b/src/core/phase31-rewrite-escape.test.ts
@@ -1,0 +1,157 @@
+// Phase 31 — rewrite-after-failed-Edit escape guard
+//
+// Canonical trigger: NEXUS Telemetry session v2.10.76, mnemo:mark6-31b
+// (Gemma 4 31B abliterated). User reported "no se inicia el servicio,
+// aparece como caído". Model invented three phantom typos ("setProperty
+// en lugar de setProperty" — literally X instead of X), tried an Edit
+// with old_string === new_string, kcode blocked the no-op Edit, and
+// the model escaped by rewriting the entire 850-line file as 627 lines
+// via Write — strictly worse. Phase 31 blocks that escape path.
+//
+// Covers two layers:
+//   1. LoopGuardState bookkeeping (record / get / clear / expire)
+//   2. Phase 31 decision logic: Write on a file with a recent failed
+//      Edit returns a block reason; unrelated Writes do not.
+
+import { describe, expect, test } from "bun:test";
+import { LoopGuardState } from "./agent-loop-guards";
+
+describe("LoopGuardState.recordEditFailure / getRecentEditFailure", () => {
+  test("returns null when no failure recorded", () => {
+    const g = new LoopGuardState();
+    expect(g.getRecentEditFailure("/tmp/foo.ts", 1)).toBeNull();
+  });
+
+  test("returns recorded reason when within expiration window", () => {
+    const g = new LoopGuardState();
+    g.recordEditFailure("/tmp/foo.ts", "PHANTOM_TYPO_BLOCKED", 5);
+    expect(g.getRecentEditFailure("/tmp/foo.ts", 6)).toBe("PHANTOM_TYPO_BLOCKED");
+    expect(g.getRecentEditFailure("/tmp/foo.ts", 10)).toBe("PHANTOM_TYPO_BLOCKED");
+    expect(g.getRecentEditFailure("/tmp/foo.ts", 11)).toBe("PHANTOM_TYPO_BLOCKED");
+  });
+
+  test("expires entries older than 6 tool calls", () => {
+    const g = new LoopGuardState();
+    g.recordEditFailure("/tmp/foo.ts", "old one", 1);
+    // 7 calls later → expired (7 - 1 = 6, cutoff is >6)
+    expect(g.getRecentEditFailure("/tmp/foo.ts", 8)).toBeNull();
+    // And the entry got cleaned up
+    expect(g.recentEditFailures.has("/tmp/foo.ts")).toBe(false);
+  });
+
+  test("does not confuse different files", () => {
+    const g = new LoopGuardState();
+    g.recordEditFailure("/tmp/a.ts", "reason A", 1);
+    g.recordEditFailure("/tmp/b.ts", "reason B", 2);
+    expect(g.getRecentEditFailure("/tmp/a.ts", 3)).toBe("reason A");
+    expect(g.getRecentEditFailure("/tmp/b.ts", 3)).toBe("reason B");
+    expect(g.getRecentEditFailure("/tmp/c.ts", 3)).toBeNull();
+  });
+
+  test("clearEditFailure removes the entry", () => {
+    const g = new LoopGuardState();
+    g.recordEditFailure("/tmp/foo.ts", "reason", 1);
+    g.clearEditFailure("/tmp/foo.ts");
+    expect(g.getRecentEditFailure("/tmp/foo.ts", 2)).toBeNull();
+  });
+
+  test("clearEditFailure on unknown path is a no-op (no throw)", () => {
+    const g = new LoopGuardState();
+    expect(() => g.clearEditFailure("/nonexistent")).not.toThrow();
+    expect(() => g.clearEditFailure("")).not.toThrow();
+  });
+
+  test("recordEditFailure ignores empty filePath", () => {
+    const g = new LoopGuardState();
+    g.recordEditFailure("", "reason", 1);
+    expect(g.recentEditFailures.size).toBe(0);
+  });
+
+  test("recordEditFailure overwrites previous failure on same file", () => {
+    const g = new LoopGuardState();
+    g.recordEditFailure("/tmp/foo.ts", "first", 1);
+    g.recordEditFailure("/tmp/foo.ts", "second", 2);
+    // Latest failure wins, and the call index is updated so expiration
+    // resets relative to the newer record.
+    expect(g.getRecentEditFailure("/tmp/foo.ts", 3)).toBe("second");
+    expect(g.getRecentEditFailure("/tmp/foo.ts", 8)).toBe("second");
+    expect(g.getRecentEditFailure("/tmp/foo.ts", 9)).toBeNull();
+  });
+
+  test("map is bounded to 50 entries (oldest evicted)", () => {
+    const g = new LoopGuardState();
+    for (let i = 0; i < 60; i++) {
+      g.recordEditFailure(`/tmp/f${i}.ts`, `r${i}`, i);
+    }
+    expect(g.recentEditFailures.size).toBeLessThanOrEqual(50);
+    // The very first entries should have been evicted
+    expect(g.getRecentEditFailure("/tmp/f0.ts", 60)).toBeNull();
+    // The most recent ones survive
+    expect(g.getRecentEditFailure("/tmp/f59.ts", 60)).toBe("r59");
+  });
+});
+
+// ─── Integration: the NEXUS Telemetry mark6 canonical sequence ───
+
+describe("Phase 31 — NEXUS Telemetry mark6 canonical sequence", () => {
+  test("Edit fails with phantom typo → Write on same file is blocked", () => {
+    const g = new LoopGuardState();
+    const path = "/home/user/nexus_telemetry.html";
+
+    // Step 1: Edit failed because old_string === new_string (phantom
+    // typo). The tool-executor integration records this with the
+    // PHANTOM_TYPO_BLOCKED reason verbatim from the Edit tool.
+    const editFailureReason =
+      "PHANTOM_TYPO_BLOCKED: old_string and new_string are byte-identical. " +
+      "This means the 'bug' you think you see in the file does NOT exist...";
+    g.recordEditFailure(path, editFailureReason, 3);
+
+    // Step 2: Model tries to escape by Write on the same file.
+    // The phase-31 guard in tool-executor.ts checks
+    // getRecentEditFailure before executing.
+    const blockReason = g.getRecentEditFailure(path, 4);
+    expect(blockReason).not.toBeNull();
+    expect(blockReason).toContain("PHANTOM_TYPO_BLOCKED");
+  });
+
+  test("successful Edit clears the failure — subsequent Write allowed", () => {
+    const g = new LoopGuardState();
+    const path = "/home/user/nexus_telemetry.html";
+
+    g.recordEditFailure(path, "first phantom", 3);
+    expect(g.getRecentEditFailure(path, 4)).not.toBeNull();
+
+    // Model re-reads, identifies the real bug, and does a valid Edit
+    // → tool-executor integration calls clearEditFailure.
+    g.clearEditFailure(path);
+
+    // Now Write on the same file is allowed.
+    expect(g.getRecentEditFailure(path, 5)).toBeNull();
+  });
+
+  test("Write on an unrelated file is never blocked by phase 31", () => {
+    const g = new LoopGuardState();
+    g.recordEditFailure("/home/user/failed.ts", "reason", 1);
+    // Write on a completely different path
+    expect(g.getRecentEditFailure("/home/user/new-file.ts", 2)).toBeNull();
+  });
+
+  test("Edit failure expires after 6 tool calls — model earned its Write", () => {
+    const g = new LoopGuardState();
+    const path = "/home/user/nexus_telemetry.html";
+    g.recordEditFailure(path, "phantom", 1);
+
+    // Within window: still blocked
+    expect(g.getRecentEditFailure(path, 5)).not.toBeNull();
+    expect(g.getRecentEditFailure(path, 7)).not.toBeNull();
+
+    // Past window: model has done enough work, let them rewrite
+    expect(g.getRecentEditFailure(path, 8)).toBeNull();
+  });
+
+  test("failed Edit on file A does not block Write on file B", () => {
+    const g = new LoopGuardState();
+    g.recordEditFailure("/home/user/a.ts", "reason", 1);
+    expect(g.getRecentEditFailure("/home/user/b.ts", 2)).toBeNull();
+  });
+});

--- a/src/core/tool-executor.ts
+++ b/src/core/tool-executor.ts
@@ -445,6 +445,61 @@ export async function* executeToolsSequential(
       }
     }
 
+    // Phase 31 — rewrite-after-failed-Edit escape block
+    //
+    // When a model's Edit fails (especially from the phantom-typo
+    // detector where old_string === new_string), the common failure
+    // mode is to escape by rewriting the whole file via Write. That
+    // wipes the 850 lines of already-working code and typically
+    // produces a strictly worse version (NEXUS Telemetry mark6 session,
+    // 850 → 627 lines). This guard catches a Write on a file that has
+    // a recent Edit failure recorded against it, blocks the call, and
+    // redirects the model to re-read and produce a surgical fix.
+    //
+    // Expires after ~6 tool calls (inside getRecentEditFailure) so the
+    // guard doesn't outlive its usefulness — if the model legitimately
+    // investigated and concluded that a rewrite is needed, they can
+    // still do it after some intervening tool activity.
+    if (call.name === "Write" && typeof effectiveInput.file_path === "string") {
+      const fp = effectiveInput.file_path as string;
+      const failureReason = guardState.getRecentEditFailure(fp, ctx.toolUseCount);
+      if (failureReason) {
+        if (ctx.debugTracer?.isEnabled()) {
+          ctx.debugTracer.traceGuard(
+            "phase-31-rewrite-escape",
+            true,
+            `Blocked Write on ${fp} — recent Edit failed: ${failureReason.slice(0, 80)}`,
+          );
+        }
+        const blockedContent =
+          `REWRITE_ESCAPE_BLOCKED: You just failed an Edit on ${fp} (reason: ${failureReason.slice(0, 200)}). ` +
+          `Do NOT escape by rewriting the whole file with Write — that destroys information and typically produces a strictly worse version. ` +
+          `Instead: (1) Read the current file state again, (2) identify the REAL problem based on observable behavior (not imagined typos), ` +
+          `(3) produce a surgical Edit targeting only the broken section. ` +
+          `If the user reported a runtime issue, open the ACTUAL runtime output (browser console, server log, test output) ` +
+          `before touching the source again. This block expires after ~6 more tool calls, but you should only proceed to Write ` +
+          `after you've genuinely investigated — not as an escape.`;
+        log.warn(
+          "tool",
+          `phase 31 blocked rewrite-after-failed-Edit on ${fp}`,
+        );
+        yield {
+          type: "tool_result",
+          name: call.name,
+          toolUseId: call.id,
+          result: blockedContent,
+          isError: true,
+        };
+        toolResultBlocks.push({
+          type: "tool_result",
+          tool_use_id: call.id,
+          content: blockedContent,
+          is_error: true,
+        });
+        continue;
+      }
+    }
+
     // 3a. Auto-checkpoint conversation state before file modifications
     // (checkpoint saving is handled by the caller — we just yield an event marker)
 
@@ -596,6 +651,45 @@ export async function* executeToolsSequential(
         }
       } catch (err) {
         log.debug("lsp", "Failed to get LSP diagnostics after file change: " + err);
+      }
+    }
+
+    // Phase 31 — track Edit failures and clear on success. Write on a
+    // file with a recent failed Edit is blocked upstream (rewrite-
+    // escape guard) but we can't catch phantom-typo Edits there
+    // because the failure happens inside the tool. Record it here and
+    // clear on a successful Edit/Write.
+    if (call.name === "Edit" && typeof effectiveInput.file_path === "string") {
+      const fp = effectiveInput.file_path as string;
+      if (result.is_error) {
+        // Record the failure with the actual error message so the
+        // block message can quote it back to the model.
+        guardState.recordEditFailure(fp, result.content, ctx.toolUseCount);
+      } else {
+        // Successful Edit — clear any prior failure on this file.
+        guardState.clearEditFailure(fp);
+      }
+    } else if (
+      call.name === "Write" &&
+      !result.is_error &&
+      typeof effectiveInput.file_path === "string"
+    ) {
+      // Successful Write also clears (model wrote something and it
+      // stuck, so the prior failure is no longer load-bearing).
+      guardState.clearEditFailure(effectiveInput.file_path as string);
+    } else if (call.name === "MultiEdit" && Array.isArray(effectiveInput.edits)) {
+      // Phase 31 extends to MultiEdit: on failure, every file in the
+      // edits array inherits the failure so a subsequent Write on any
+      // of them is still blocked. On success, all cleared.
+      const edits = effectiveInput.edits as Array<{ file_path?: string }>;
+      for (const edit of edits) {
+        const fp = edit.file_path;
+        if (typeof fp !== "string" || !fp) continue;
+        if (result.is_error) {
+          guardState.recordEditFailure(fp, result.content, ctx.toolUseCount);
+        } else {
+          guardState.clearEditFailure(fp);
+        }
       }
     }
 

--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -244,7 +244,7 @@ async function _executeEditInner(input: Record<string, unknown>): Promise<ToolRe
       return {
         tool_use_id: "",
         content:
-          "Error: old_string and new_string are identical. STOP: Do NOT retry this Edit. If the file already contains the desired content, no edit is needed. Move on to the next task.",
+          "PHANTOM_TYPO_BLOCKED: old_string and new_string are byte-identical. This means the 'bug' you think you see in the file does NOT exist — your diagnosis was a hallucinated typo. STOP guessing at code. If the user reported a runtime problem (\"service is down\", \"chart doesn't render\", \"no funciona\"), the fix is NOT in the source — it's visible in the runtime output. Do one of: (1) open the browser console / server log / test output to see the ACTUAL error, (2) Read the file again carefully and diff against expected behavior, (3) ask the user what they see. Do NOT retry this Edit and do NOT rewrite the whole file with Write as an escape — that will destroy information.",
         is_error: true,
       };
     }


### PR DESCRIPTION
## Summary
Phase 31 — blocks the "rewrite the whole file after a failed Edit" escape pattern. Canonical trigger: **NEXUS Telemetry mark6 session** from the cross-model comparison.

## What happened with mark6
1. User reported \"no se inicia el servicio, aparece como caído\" (service down).
2. Model invented **3 phantom typos** in the generated file: \"setProperty en lugar de setProperty\", \"getContext en lugar de getContext\", \"reverse en lugar de reverse\" — literally X in place of X (same identifier, so the supposed fix is a no-op).
3. Tried \`Edit\` with \`old_string === new_string\` → kcode correctly blocked the no-op Edit.
4. **Escaped** by rewriting the whole 850-line file via \`Write\`, producing a strictly worse 627-line version that lost working code.

## What phase 31 does
Two parts:

### 1. Stronger phantom-typo Edit message
\`src/tools/edit.ts\` now returns \`PHANTOM_TYPO_BLOCKED\` instead of a generic \"identical\" message. It:
- Names the failure mode explicitly (\"the 'bug' you think you see does NOT exist\")
- Points the model at runtime output as the source of truth (browser console / server log / test output)
- Explicitly tells it **not** to rewrite the whole file with Write as an escape

### 2. Rewrite-escape guard in tool-executor
\`src/core/tool-executor.ts\` blocks any \`Write\` on a file with a recent failed Edit. State lives in \`LoopGuardState\` via new methods:
- \`recordEditFailure(filePath, reason, callIndex)\`
- \`getRecentEditFailure(filePath, currentCallIndex)\` — auto-expires after 6 tool calls
- \`clearEditFailure(filePath)\` — called on successful Edit/Write

### Reset conditions (allowed paths)
| Sequence | Outcome |
|---|---|
| Failed Edit → Read → successful Edit → Write | ✅ allowed |
| Failed Edit → 7+ unrelated tool calls → Write | ✅ allowed (expired) |
| Failed Edit on file A → Write on file B | ✅ allowed |
| Write on a file with no prior failure | ✅ allowed |
| Failed Edit → Write on same file (within window) | ❌ blocked |

MultiEdit also participates: failures record against every file in the \`edits\` array.

## Not addressed in this phase (future work)
Proactive phantom-typo detection on the Edit input itself. Currently we only catch phantom typos when \`old_string === new_string\` byte-matches. Semantic phantom typos like \`Math.Pi → Math.PI\` that ARE different strings would still go through. A future phase could inspect the surrounding assistant text for \"X en lugar de X\" patterns.

## Test plan
- [x] \`bun test src/core/phase31-rewrite-escape.test.ts\` — **14/14** new tests
- [x] \`bun test src/core/tool-executor.test.ts src/core/tool-executor-e2e.test.ts src/tools/edit.test.ts src/tools/multi-edit.test.ts src/tools/write.test.ts\` — **90/90** integration tests
- [x] \`bun run build\` — v2.10.78 binary deployed
- [x] Existing \`edit.test.ts\` \"error when old_string and new_string are identical\" test still passes (it matches on \"identical\" substring which survives in the new message)

Co-Authored-By: Kulvex Code <contact@astrolexis.space>