### PR TITLE
feat(phase-32): semantic phantom-typo claim detector + v2.10.79

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.78",
+  "version": "2.10.79",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/agent-loop-guards.ts
+++ b/src/core/agent-loop-guards.ts
@@ -335,6 +335,23 @@ export class LoopGuardState {
     { reason: string; callIndex: number }
   >();
 
+  /**
+   * Phase 32: active phantom-typo claim detected in the current turn's
+   * assistant text. Set by the conversation loop right after the
+   * assistant finishes streaming, checked by the tool executor before
+   * any Edit/MultiEdit runs, and cleared at the end of the tool-result
+   * push so it doesn't leak across turns.
+   *
+   * Canonical trigger: NEXUS Telemetry mark6 wrote "setProperty en
+   * lugar de setProperty" in its reasoning, then tried to fix the
+   * "bug". Phase 31 caught the byte-identical Edit; phase 32 catches
+   * the semantic claim even when old_string / new_string differ.
+   *
+   * Stores just the offending phrase and repeated token — null when
+   * no phantom claim is active.
+   */
+  activePhantomClaim: { phrase: string; token: string } | null = null;
+
   // Pre-computed tool filter sets
   readonly managedDisallowedSet: Set<string>;
   readonly allowedToolsSet: Set<string> | null;

--- a/src/core/conversation.ts
+++ b/src/core/conversation.ts
@@ -1450,6 +1450,28 @@ export class ConversationManager {
         streamResult);
       const fullText = textChunks.join("");
 
+      // Phase 32 — scan the assistant's prose for phantom-typo claims
+      // ("X en lugar de X") and stash the result on guardState so the
+      // tool executor can block any Edit/MultiEdit that follows. Reset
+      // at the top of each turn below so claims from one turn don't
+      // leak into the next.
+      try {
+        const { detectPhantomTypoClaim } = await import("./phantom-typo-detector.js");
+        const phantomMatch = detectPhantomTypoClaim(fullText);
+        if (phantomMatch) {
+          guardState.activePhantomClaim = phantomMatch;
+          log.warn(
+            "phase-32",
+            `phantom-typo claim detected: "${phantomMatch.phrase.slice(0, 80)}" (token="${phantomMatch.token}")`,
+          );
+        } else {
+          guardState.activePhantomClaim = null;
+        }
+      } catch (err) {
+        log.debug("phase-32", `detector failed (non-fatal): ${err}`);
+        guardState.activePhantomClaim = null;
+      }
+
       // Store assistant message in conversation history
       this.state.messages.push({ role: "assistant", content: assistantContent });
 

--- a/src/core/phantom-typo-detector.test.ts
+++ b/src/core/phantom-typo-detector.test.ts
@@ -1,0 +1,173 @@
+// Phase 32 — phantom-typo detector unit tests
+//
+// The detector exists because NEXUS Telemetry mark6 (Gemma abliterated)
+// invented phantom typos like "setProperty en lugar de setProperty"
+// and rode them into failed Edits. These tests pin the regex behavior
+// so a future refactor can't silently break the detection and let the
+// failure mode back in.
+
+import { describe, expect, test } from "bun:test";
+import { detectPhantomTypoClaim } from "./phantom-typo-detector";
+
+describe("detectPhantomTypoClaim — true positives", () => {
+  test("Spanish: 'setProperty en lugar de setProperty' (exact mark6 case)", () => {
+    const text =
+      "He analizado el código. El error es setProperty en lugar de setProperty en la línea 394.";
+    const match = detectPhantomTypoClaim(text);
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("setProperty");
+    expect(match!.phrase).toContain("setProperty");
+    expect(match!.phrase).toContain("en lugar de");
+  });
+
+  test("Spanish: 'getContext en lugar de getContext'", () => {
+    const match = detectPhantomTypoClaim("debería ser getContext en lugar de getContext aquí");
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("getContext");
+  });
+
+  test("Spanish: 'en vez de' variant", () => {
+    const match = detectPhantomTypoClaim("usa parseInt en vez de parseInt para esto");
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("parseInt");
+  });
+
+  test("English: 'X instead of X'", () => {
+    const match = detectPhantomTypoClaim("you should use renderChart instead of renderChart");
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("renderChart");
+  });
+
+  test("English: 'rather than'", () => {
+    const match = detectPhantomTypoClaim("Math.PI rather than Math.PI is the correct identifier");
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("Math.PI");
+  });
+
+  test("English: 'in place of'", () => {
+    const match = detectPhantomTypoClaim("use foo in place of foo throughout");
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("foo");
+  });
+
+  test("strips backticks from tokens", () => {
+    const match = detectPhantomTypoClaim("use `setProperty` en lugar de `setProperty`");
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("setProperty");
+  });
+
+  test("strips trailing punctuation", () => {
+    const match = detectPhantomTypoClaim("cambio: getContext en lugar de getContext.");
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("getContext");
+  });
+
+  test("strips mixed quote styles", () => {
+    const match = detectPhantomTypoClaim(`use "reverse" en lugar de 'reverse'`);
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("reverse");
+  });
+
+  test("handles dot-notation identifiers", () => {
+    const match = detectPhantomTypoClaim("Math.PI instead of Math.PI is the bug");
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("Math.PI");
+  });
+
+  test("handles parens in identifier (parens stripped as boundary punct)", () => {
+    const match = detectPhantomTypoClaim("setProperty() en lugar de setProperty()");
+    expect(match).not.toBeNull();
+    // Parens are stripped as boundary punctuation, so the returned
+    // token is the bare identifier. The match still fires correctly
+    // because both sides strip to the same thing.
+    expect(match!.token).toBe("setProperty");
+  });
+});
+
+describe("detectPhantomTypoClaim — true negatives", () => {
+  test("returns null for legitimate replacement (different tokens)", () => {
+    expect(detectPhantomTypoClaim("use setProperty en lugar de getAttribute")).toBeNull();
+    expect(detectPhantomTypoClaim("use Math.PI instead of 3.14")).toBeNull();
+    expect(detectPhantomTypoClaim("renderChart rather than drawChart")).toBeNull();
+  });
+
+  test("returns null for empty or short input", () => {
+    expect(detectPhantomTypoClaim("")).toBeNull();
+    expect(detectPhantomTypoClaim("short")).toBeNull();
+    expect(detectPhantomTypoClaim("a en lugar de a")).toBeNull(); // too short token
+  });
+
+  test("returns null when the phrase is missing the replacement marker", () => {
+    expect(detectPhantomTypoClaim("use setProperty for this setProperty thing")).toBeNull();
+    expect(detectPhantomTypoClaim("setProperty setProperty setProperty")).toBeNull();
+  });
+
+  test("returns null when tokens differ by case (likely real fix)", () => {
+    // Math.Pi → Math.PI is a REAL fix in JavaScript. Phase 32 must not
+    // flag legitimate case-sensitive corrections as phantoms.
+    const match = detectPhantomTypoClaim("use Math.PI instead of Math.Pi — case matters");
+    expect(match).toBeNull();
+  });
+
+  test("returns null when left has punctuation that makes it semantically different", () => {
+    // "setProperty()" vs "setProperty" — one is a call, one is a
+    // reference. Different. Not a phantom.
+    const match = detectPhantomTypoClaim("setProperty() en lugar de setProperty");
+    // Both will be stripped of (), so they ARE equal after stripping.
+    // We accept this as a near-match: the detector prefers false
+    // positives here because the underlying claim IS suspicious
+    // (a fix that's just adding/removing parens is usually wrong).
+    // Document the decision: left === right after stripping -> flagged.
+    expect(match).not.toBeNull();
+  });
+
+  test("ignores unrelated English 'instead' phrasing", () => {
+    expect(
+      detectPhantomTypoClaim(
+        "I checked the file instead of guessing, and the bug is on line 12",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("detectPhantomTypoClaim — robustness", () => {
+  test("finds the first match when multiple phantom claims are present", () => {
+    const text =
+      "El bug es setProperty en lugar de setProperty. También getContext en lugar de getContext.";
+    const match = detectPhantomTypoClaim(text);
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("setProperty");
+  });
+
+  test("survives weird whitespace between marker words", () => {
+    const match = detectPhantomTypoClaim("renderChart     en    lugar    de     renderChart");
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("renderChart");
+  });
+
+  test("case-insensitive marker matching (Spanish)", () => {
+    const match = detectPhantomTypoClaim("renderChart En Lugar De renderChart");
+    expect(match).not.toBeNull();
+  });
+
+  test("does not confuse a phrase that spans the marker at a distance", () => {
+    // "X then Y en lugar de Y" — the regex should match (Y, Y), not (X, Y)
+    const match = detectPhantomTypoClaim("cambio renderChart: drawChart en lugar de drawChart");
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("drawChart");
+  });
+
+  test("handles multi-paragraph text", () => {
+    const text = `
+First paragraph about something else.
+
+Segundo párrafo con el análisis:
+El problema es getContext en lugar de getContext, claramente.
+
+Third paragraph wrapping up.
+    `;
+    const match = detectPhantomTypoClaim(text);
+    expect(match).not.toBeNull();
+    expect(match!.token).toBe("getContext");
+  });
+});

--- a/src/core/phantom-typo-detector.ts
+++ b/src/core/phantom-typo-detector.ts
@@ -1,0 +1,84 @@
+// Phase 32 — semantic phantom-typo detector
+//
+// Phase 31 caught the easy case: Edit with old_string === new_string
+// byte-identical. This module catches the harder case where the
+// assistant's own prose declares a fix like "X en lugar de X" /
+// "X instead of X" — where both halves name the same identifier,
+// meaning the "bug" is a hallucination even if the subsequent Edit's
+// old/new strings happen to differ byte-wise.
+//
+// Canonical trigger: NEXUS Telemetry mark6 session. The model's
+// text said "setProperty en lugar de setProperty", "getContext en
+// lugar de getContext", "reverse en lugar de reverse" — literally
+// X in place of X, the same identifier. Phase 31 caught the no-op
+// Edit that followed, but if the model had constructed an Edit with
+// slightly-different-but-still-wrong old/new (e.g. "setProperty;"
+// vs "setProperty;  " with trailing whitespace), phase 31 would
+// miss it. Phase 32 catches it at the prose level.
+//
+// Design goals:
+//   - Zero false positives on legitimate text ("use X instead of Y").
+//   - Catch both Spanish and English phrasings.
+//   - Robust to punctuation around the tokens: quotes, backticks,
+//     parens, periods, commas.
+//   - Return the offending phrase for error reporting.
+
+// Patterns that introduce a "replacement" claim. Each must capture
+// the LEFT identifier in group 1 and the RIGHT identifier in group 2.
+// \S+ captures any non-whitespace run so identifiers with dots and
+// parens (Math.PI, setProperty()) work.
+const PHANTOM_PATTERNS: RegExp[] = [
+  // Spanish — "X en lugar de X", "X en vez de X", "X en sustitución de X"
+  /(\S+)\s+(?:en\s+lugar\s+de|en\s+vez\s+de|en\s+sustituci[oó]n\s+de)\s+(\S+)/gi,
+  // English — "X instead of X", "X rather than X", "X in place of X"
+  /(\S+)\s+(?:instead\s+of|rather\s+than|in\s+place\s+of|in\s+lieu\s+of)\s+(\S+)/gi,
+];
+
+// Strip decorative/boundary punctuation from a token so
+// "`setProperty`," and "setProperty" compare equal.
+function stripBoundaryPunct(s: string): string {
+  return s
+    .replace(/^[\s`'".,;:()\[\]{}!?<>]+/, "")
+    .replace(/[\s`'".,;:()\[\]{}!?<>]+$/, "");
+}
+
+export interface PhantomTypoMatch {
+  /** The full offending phrase, e.g. "setProperty en lugar de setProperty". */
+  phrase: string;
+  /** The repeated identifier, e.g. "setProperty". */
+  token: string;
+}
+
+/**
+ * Scan free-form assistant text for phantom-typo claims. Returns the
+ * first match or null.
+ *
+ * A phantom-typo claim is defined as a phrase of the form
+ *   "X <replacement-marker> Y"
+ * where X and Y, after stripping boundary punctuation, are byte-
+ * identical and at least 2 characters long. Very short tokens are
+ * rejected to avoid false-positive hits on 1-char identifiers.
+ */
+export function detectPhantomTypoClaim(text: string): PhantomTypoMatch | null {
+  if (!text || text.length < 10) return null;
+
+  for (const pat of PHANTOM_PATTERNS) {
+    // Reset lastIndex since the regex has /g flag
+    pat.lastIndex = 0;
+    for (const match of text.matchAll(pat)) {
+      const leftRaw = match[1] ?? "";
+      const rightRaw = match[2] ?? "";
+      const left = stripBoundaryPunct(leftRaw);
+      const right = stripBoundaryPunct(rightRaw);
+      if (!left || !right) continue;
+      if (left.length < 2) continue; // too short to be meaningful
+      if (left === right) {
+        return {
+          phrase: match[0],
+          token: left,
+        };
+      }
+    }
+  }
+  return null;
+}

--- a/src/core/phase32-phantom-typo.test.ts
+++ b/src/core/phase32-phantom-typo.test.ts
@@ -1,0 +1,204 @@
+// Phase 32 — integration tests for the phantom-typo claim guard
+//
+// Tests the full flow the conversation loop + tool executor use:
+//   1. detectPhantomTypoClaim runs on assistant text
+//   2. If a match is found, guardState.activePhantomClaim is set
+//   3. tool-executor checks this field and blocks Edit/MultiEdit whose
+//      old_string or new_string contains the claimed token
+//   4. Unrelated Edits (different token) pass through
+//
+// We can't run the actual conversation.ts streaming path here (it
+// pulls in ConversationManager), so we simulate the state handoff
+// and assert the decision logic directly.
+
+import { describe, expect, test } from "bun:test";
+import { LoopGuardState } from "./agent-loop-guards";
+import { detectPhantomTypoClaim } from "./phantom-typo-detector";
+
+// Mirror of the block logic in tool-executor.ts — keeping this in
+// sync with the real implementation is important. If the production
+// code's block condition changes, update this too.
+function shouldBlockEditForPhantom(
+  guardState: LoopGuardState,
+  toolName: "Edit" | "MultiEdit" | "Write",
+  input: Record<string, unknown>,
+): boolean {
+  if (toolName !== "Edit" && toolName !== "MultiEdit") return false;
+  const claim = guardState.activePhantomClaim;
+  if (!claim) return false;
+
+  if (toolName === "Edit") {
+    const oldStr = String(input.old_string ?? "");
+    const newStr = String(input.new_string ?? "");
+    return oldStr.includes(claim.token) || newStr.includes(claim.token);
+  }
+
+  const edits = input.edits;
+  if (Array.isArray(edits)) {
+    for (const edit of edits) {
+      const e = edit as Record<string, unknown>;
+      const o = String(e.old_string ?? "");
+      const n = String(e.new_string ?? "");
+      if (o.includes(claim.token) || n.includes(claim.token)) return true;
+    }
+  }
+  return false;
+}
+
+describe("Phase 32 — conversation loop → tool executor handoff", () => {
+  test("phantom claim in assistant text blocks Edit touching the same token", () => {
+    const guardState = new LoopGuardState();
+
+    // Simulate the conversation loop path: assistant finishes
+    // streaming, text is scanned, claim is stashed on guardState.
+    const assistantText =
+      "He analizado el código. El error es setProperty en lugar de setProperty en la línea 394. Voy a corregirlo.";
+    guardState.activePhantomClaim = detectPhantomTypoClaim(assistantText);
+    expect(guardState.activePhantomClaim).not.toBeNull();
+    expect(guardState.activePhantomClaim!.token).toBe("setProperty");
+
+    // Model now tries an Edit that touches the phantom token.
+    // tool-executor's phase-32 block should fire.
+    const editInput = {
+      file_path: "/tmp/file.js",
+      old_string: "element.setProperty('color', 'red')",
+      new_string: "element.setProperty('color', 'red');", // trailing semicolon
+    };
+    expect(shouldBlockEditForPhantom(guardState, "Edit", editInput)).toBe(true);
+  });
+
+  test("phantom claim does NOT block an Edit on an unrelated token", () => {
+    const guardState = new LoopGuardState();
+    guardState.activePhantomClaim = detectPhantomTypoClaim(
+      "He visto getContext en lugar de getContext, pero el bug real es otro",
+    );
+    expect(guardState.activePhantomClaim).not.toBeNull();
+
+    // Edit touches a completely different area — should pass through
+    const editInput = {
+      file_path: "/tmp/file.js",
+      old_string: "const x = 1;",
+      new_string: "const x = 2;",
+    };
+    expect(shouldBlockEditForPhantom(guardState, "Edit", editInput)).toBe(false);
+  });
+
+  test("phantom claim blocks MultiEdit when any sub-edit touches the token", () => {
+    const guardState = new LoopGuardState();
+    guardState.activePhantomClaim = detectPhantomTypoClaim(
+      "Voy a cambiar renderChart en lugar de renderChart",
+    );
+    expect(guardState.activePhantomClaim).not.toBeNull();
+
+    const multiEditInput = {
+      file_path: "/tmp/file.js",
+      edits: [
+        { old_string: "const x = 1;", new_string: "const x = 2;" }, // unrelated
+        {
+          old_string: "this.renderChart(data)",
+          new_string: "this.renderChart(data);",
+        }, // touches phantom token
+      ],
+    };
+    expect(shouldBlockEditForPhantom(guardState, "MultiEdit", multiEditInput)).toBe(true);
+  });
+
+  test("phantom claim does NOT block MultiEdit when no sub-edit touches the token", () => {
+    const guardState = new LoopGuardState();
+    guardState.activePhantomClaim = detectPhantomTypoClaim(
+      "vi drawChart en lugar de drawChart pero voy a tocar otra cosa",
+    );
+    expect(guardState.activePhantomClaim).not.toBeNull();
+
+    const multiEditInput = {
+      file_path: "/tmp/file.js",
+      edits: [
+        { old_string: "const x = 1;", new_string: "const x = 2;" },
+        { old_string: "const y = 3;", new_string: "const y = 4;" },
+      ],
+    };
+    expect(shouldBlockEditForPhantom(guardState, "MultiEdit", multiEditInput)).toBe(false);
+  });
+
+  test("no claim means no block (happy path)", () => {
+    const guardState = new LoopGuardState();
+    // Assistant text has no phantom claim
+    guardState.activePhantomClaim = detectPhantomTypoClaim(
+      "He leído el archivo. El bug está en la línea 394, faltaba un punto y coma.",
+    );
+    expect(guardState.activePhantomClaim).toBeNull();
+
+    const editInput = {
+      file_path: "/tmp/file.js",
+      old_string: "const x = 1",
+      new_string: "const x = 1;",
+    };
+    expect(shouldBlockEditForPhantom(guardState, "Edit", editInput)).toBe(false);
+  });
+
+  test("Write is never blocked by phase 32 (phase 31 handles Write escapes)", () => {
+    const guardState = new LoopGuardState();
+    guardState.activePhantomClaim = detectPhantomTypoClaim(
+      "setProperty en lugar de setProperty",
+    );
+    expect(guardState.activePhantomClaim).not.toBeNull();
+
+    // Phase 32 targets Edit/MultiEdit only. Write is handled by phase
+    // 31's rewrite-escape guard.
+    const writeInput = {
+      file_path: "/tmp/file.js",
+      content: "whatever",
+    };
+    expect(shouldBlockEditForPhantom(guardState, "Write", writeInput)).toBe(false);
+  });
+
+  test("claim survives until the next scan overrides it", () => {
+    const guardState = new LoopGuardState();
+
+    // Turn 1 — phantom claim detected
+    guardState.activePhantomClaim = detectPhantomTypoClaim(
+      "reverse en lugar de reverse",
+    );
+    expect(guardState.activePhantomClaim).not.toBeNull();
+    expect(guardState.activePhantomClaim!.token).toBe("reverse");
+
+    // Turn 2 — clean assistant text → claim cleared
+    guardState.activePhantomClaim = detectPhantomTypoClaim(
+      "Ahora sí veo el problema real, voy a hacer el fix correcto.",
+    );
+    expect(guardState.activePhantomClaim).toBeNull();
+
+    // Subsequent Edit touching "reverse" should pass — stale claim gone
+    expect(
+      shouldBlockEditForPhantom(guardState, "Edit", {
+        old_string: "array.reverse()",
+        new_string: "array.reverse().map(x => x)",
+      }),
+    ).toBe(false);
+  });
+
+  test("NEXUS mark6 canonical failure sequence — all three phantoms", () => {
+    const guardState = new LoopGuardState();
+
+    // Assistant text from the actual mark6 log (~line 1165-1170):
+    const markSixText = `He analizado el código y he encontrado el problema. El servicio aparece como "caído" o no se inicia porque hay tres errores tipográficos críticos en el JavaScript que detienen la ejecución del script antes de que la aplicación pueda renderizarse.
+Los errores son:
+ 1. setProperty en lugar de setProperty (Línea 394).
+ 2. getContext en lugar de getContext (Líneas 653 y 669).
+ 3. reverse en lugar de reverse (Línea 750).
+Voy a corregir estos errores inmediatamente para que el sistema inicie correctamente.`;
+
+    guardState.activePhantomClaim = detectPhantomTypoClaim(markSixText);
+    expect(guardState.activePhantomClaim).not.toBeNull();
+    // Detector picks the FIRST phantom phrase in order — setProperty
+    expect(guardState.activePhantomClaim!.token).toBe("setProperty");
+
+    // The Edit mark6 actually tried — would now be blocked
+    const editInput = {
+      file_path: "/home/curly/projects/nexus_telemetry.html",
+      old_string: "setProperty('--nasa-blue', '#0B3D91')",
+      new_string: "setProperty('--nasa-blue', '#0B3D91');",
+    };
+    expect(shouldBlockEditForPhantom(guardState, "Edit", editInput)).toBe(true);
+  });
+});

--- a/src/core/tool-executor.ts
+++ b/src/core/tool-executor.ts
@@ -445,6 +445,86 @@ export async function* executeToolsSequential(
       }
     }
 
+    // Phase 32 — semantic phantom-typo claim block
+    //
+    // The conversation loop scanned the current turn's assistant text
+    // for "X en lugar de X" / "X instead of X" patterns and stored
+    // any hit on guardState.activePhantomClaim. If one is active AND
+    // the model is now trying an Edit/MultiEdit, the entire Edit is
+    // suspicious: the model declared a phantom bug in its own prose
+    // and is acting on it. Block the call and force the model to
+    // re-investigate.
+    //
+    // Precision guard: we only block when the claimed token actually
+    // appears in the Edit's old_string or new_string. An Edit on a
+    // completely different part of the file is allowed through —
+    // even if the prose happened to contain a phantom phrase, it's
+    // unrelated to this particular surgical change.
+    if (
+      (call.name === "Edit" || call.name === "MultiEdit") &&
+      guardState.activePhantomClaim
+    ) {
+      const claim = guardState.activePhantomClaim;
+      let editTouchesToken = false;
+
+      if (call.name === "Edit") {
+        const oldStr = String((effectiveInput as Record<string, unknown>).old_string ?? "");
+        const newStr = String((effectiveInput as Record<string, unknown>).new_string ?? "");
+        editTouchesToken = oldStr.includes(claim.token) || newStr.includes(claim.token);
+      } else {
+        // MultiEdit: scan every sub-edit
+        const edits = (effectiveInput as Record<string, unknown>).edits;
+        if (Array.isArray(edits)) {
+          for (const edit of edits) {
+            const e = edit as Record<string, unknown>;
+            const o = String(e.old_string ?? "");
+            const n = String(e.new_string ?? "");
+            if (o.includes(claim.token) || n.includes(claim.token)) {
+              editTouchesToken = true;
+              break;
+            }
+          }
+        }
+      }
+
+      if (editTouchesToken) {
+        if (ctx.debugTracer?.isEnabled()) {
+          ctx.debugTracer.traceGuard(
+            "phase-32-phantom-typo",
+            true,
+            `Blocked ${call.name} — phantom-typo claim "${claim.phrase.slice(0, 80)}" touches token "${claim.token}"`,
+          );
+        }
+        const blockedContent =
+          `PHANTOM_TYPO_CLAIM_BLOCKED: your reasoning contained the phrase "${claim.phrase}" — ` +
+          `a self-referential "X in place of X" claim where both sides of the replacement are the ` +
+          `same identifier ("${claim.token}"). This is a hallucinated bug; "${claim.token}" does NOT ` +
+          `need to be renamed to "${claim.token}". STOP. Do NOT retry this Edit. ` +
+          `If the user reported a runtime symptom (service down, chart broken, no funciona), the real ` +
+          `fix is visible in the actual runtime output (browser console, server log, test output) — ` +
+          `not in imagined typography. Re-read the file carefully or ask the user what they actually see. ` +
+          `Respond with text only until you have evidence of the real bug.`;
+        log.warn(
+          "tool",
+          `phase 32 blocked ${call.name} on phantom-typo claim (token="${claim.token}")`,
+        );
+        yield {
+          type: "tool_result",
+          name: call.name,
+          toolUseId: call.id,
+          result: blockedContent,
+          isError: true,
+        };
+        toolResultBlocks.push({
+          type: "tool_result",
+          tool_use_id: call.id,
+          content: blockedContent,
+          is_error: true,
+        });
+        continue;
+      }
+    }
+
     // Phase 31 — rewrite-after-failed-Edit escape block
     //
     // When a model's Edit fails (especially from the phantom-typo


### PR DESCRIPTION
## Summary
Phase 32 catches the failure mode phase 31 missed: assistant prose that **declares** a phantom fix like \"X en lugar de X\" / \"X instead of X\" and then constructs an Edit whose old/new strings differ byte-wise (so phase 31 doesn't fire) but where the change is still based on a hallucinated bug.

## The mark6 prose, verbatim
\`\`\`
He analizado el código. Los errores son:
 1. setProperty en lugar de setProperty (Línea 394).
 2. getContext en lugar de getContext (Líneas 653 y 669).
 3. reverse en lugar de reverse (Línea 750).
\`\`\`
Each phrase is \"X in place of X\" — same identifier on both sides. Phase 31 caught the byte-identical Edit that followed; phase 32 catches the **claim itself**, even when the model's Edit happens to differ in trailing whitespace or punctuation.

## Implementation

### 1. \`src/core/phantom-typo-detector.ts\` — pure detector
Two regex patterns (Spanish + English) covering: \`en lugar de\`, \`en vez de\`, \`en sustitución de\`, \`instead of\`, \`rather than\`, \`in place of\`, \`in lieu of\`. Captures both sides, strips boundary punctuation (backticks, quotes, parens, periods), returns the offending phrase + repeated token if both sides match and the token is ≥2 chars.

**Zero-FP design**: the only way to trigger is to literally write a self-referential replacement claim. Legitimate text like \"use Math.PI instead of 3.14\" or \"Math.PI instead of Math.Pi (case matters)\" does not match.

### 2. \`LoopGuardState.activePhantomClaim\` field
Stores the detected match between turns. Set by \`conversation.ts\` right after assistant text accumulates, cleared when the next turn's text comes back clean.

### 3. \`tool-executor.ts\` phase-32 block
Above phase 31. Only fires when:
- A claim is active **AND**
- The Edit/MultiEdit's old_string or new_string **contains the phantom token**

An unrelated Edit in the same turn passes through. Block message tells the model the claim is self-referential and points it at runtime output as the source of truth.

## Precision
Phase 32 only fires on Edit/MultiEdit (Write is handled by phase 31). False-positive surface is small because \"renderChart en lugar de renderChart\" rarely appears in normal text.

| Scenario | Phase 32 fires? |
|---|---|
| Prose has \"X en lugar de X\" + Edit touches X | ✅ blocked |
| Prose has \"X en lugar de X\" + Edit touches Y (unrelated) | ❌ allowed |
| Prose has \"use X instead of Y\" (different) | ❌ no claim detected |
| Prose has \"Math.PI instead of Math.Pi\" (real case fix) | ❌ no claim detected |
| Write call (any) | ❌ phase 31 territory |

## Test plan
- [x] \`bun test src/core/phantom-typo-detector.test.ts\` — **22/22** unit tests
- [x] \`bun test src/core/phase32-phantom-typo.test.ts\` — **8/8** integration tests including the verbatim mark6 prose
- [x] \`bun test src/core/tool-executor.test.ts src/core/conversation.test.ts src/tools/edit.test.ts src/tools/multi-edit.test.ts src/tools/write.test.ts src/core/message-converters.test.ts src/web/\` — **228/228** broader integration suite
- [x] \`bun run build\` — v2.10.79 binary deployed

Co-Authored-By: Kulvex Code <contact@astrolexis.space>