### PR TITLE
fix: outside-cwd write denial gives imperative retry hint + v2.10.81

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.80",
+  "version": "2.10.81",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/safety-analysis.test.ts
+++ b/src/core/safety-analysis.test.ts
@@ -519,6 +519,23 @@ describe("validateFileWritePath", () => {
     expect(result.allowed).toBe(false);
   });
 
+  test("outside-cwd denial includes explicit RETRY hint with corrected path", () => {
+    // Regression for v2.10.80 NEXUS session where grok-code-fast-1
+    // tried to Write to /home/user/NEXUS_Telemetry.html and, on
+    // denial, asked the user for the correct path instead of
+    // auto-correcting with the obvious alternative. The denial
+    // message now names the exact cwd-relocated path and tells the
+    // model not to defer to the user.
+    const result = validateFileWritePath(
+      "/home/user/NEXUS_Telemetry.html",
+      "/home/curly/projects",
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("RETRY NOW");
+    expect(result.reason).toContain("/home/curly/projects/NEXUS_Telemetry.html");
+    expect(result.reason).toContain("Do NOT ask the user");
+  });
+
   test("denies protected .ssh directory", () => {
     const home = process.env.HOME ?? "/root";
     const result = validateFileWritePath(`${home}/.ssh/id_rsa`, cwd);

--- a/src/core/safety-analysis.ts
+++ b/src/core/safety-analysis.ts
@@ -553,9 +553,20 @@ export function validateFileWritePath(
   // Block writes outside the working directory (unless explicitly to /tmp or an additional dir)
   const inAdditionalDir = additionalDirs?.some((d) => resolved.startsWith(d)) ?? false;
   if (!resolved.startsWith(workingDirectory) && !resolved.startsWith("/tmp") && !inAdditionalDir) {
+    // Construct the corrected path (cwd + basename of the offending
+    // path) so the error message can tell the model EXACTLY what to
+    // retry with. Without this hint, grok-code-fast-1 (v2.10.80
+    // NEXUS session) treated the denial as "ask user" and gave up,
+    // passing the buck to the user instead of auto-correcting.
+    const offendingBase = resolved.split("/").pop() ?? "file";
+    const suggestedPath = `${workingDirectory}/${offendingBase}`;
     return {
       allowed: false,
-      reason: `Write blocked: path "${resolved}" is outside working directory "${workingDirectory}"`,
+      reason:
+        `Write blocked: path "${resolved}" is outside working directory "${workingDirectory}". ` +
+        `RETRY NOW with file_path="${suggestedPath}". Do NOT ask the user to specify the path — ` +
+        `you already have enough information to fix this yourself. Just call Write again with the ` +
+        `corrected file_path.`,
     };
   }
 


### PR DESCRIPTION
## Summary
grok-code-fast-1 on the v2.10.80 NEXUS session tried Write to \`/home/user/NEXUS_Telemetry.html\` — a placeholder username that doesn't exist on the host. kcode correctly denied the write, but grok treated the denial as \"need user input\" and asked the user to specify the path, despite already knowing what it should have been.

## Why this is a message bug, not a guard bug
Grok's actual reply included \`/home/curly/projects/NEXUS_Telemetry.html\` — so it had all the information to self-correct. It just read the passive \"path is outside working directory\" denial as \"ask the user\" rather than \"retry yourself\".

## Fix
The denial message now:
1. Constructs the corrected path (\`cwd + basename(offendingPath)\`)
2. Embeds it with an imperative \`RETRY NOW with file_path=\"...\"\`
3. Explicitly says \`Do NOT ask the user — you have enough info\`

Example new message:
\`\`\`
Write blocked: path \"/home/user/NEXUS_Telemetry.html\" is outside
working directory \"/home/curly/projects\". RETRY NOW with
file_path=\"/home/curly/projects/NEXUS_Telemetry.html\". Do NOT
ask the user to specify the path — you already have enough
information to fix this yourself. Just call Write again with the
corrected file_path.
\`\`\`

## Test plan
- [x] Existing substring tests still pass (\"outside working directory\" preserved verbatim)
- [x] New regression test in \`safety-analysis.test.ts\` uses the NEXUS session's exact path as input and asserts all three markers (\"RETRY NOW\", suggested path, \"Do NOT ask the user\")
- [x] 247/247 safety-analysis + permissions suite green
- [x] v2.10.81 binary deployed

Co-Authored-By: Kulvex Code <contact@astrolexis.space>