### PR TITLE
fix: portInUse defense-in-depth (spawnSync) + v2.10.84

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.83",
+  "version": "2.10.84",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/auto-launch-dev-server.ts
+++ b/src/core/auto-launch-dev-server.ts
@@ -189,11 +189,19 @@ export function hasRunnableWriteInTurn(messages: Message[]): boolean {
  */
 function portInUse(port: number): boolean {
   try {
-    const { execSync } = require("node:child_process") as typeof import("node:child_process");
-    const out = execSync(`ss -tlnp state listening "( sport = :${port} )"`, {
-      timeout: 1000,
-      stdio: ["ignore", "pipe", "ignore"],
-    }).toString();
+    // Use spawnSync with args array instead of execSync with template
+    // string. Although `port` is always a validated number (1024-65535)
+    // so shell injection is impossible in practice, defense-in-depth
+    // says: never interpolate into a shell string if you can avoid it.
+    // Gemma 4 audit (v2.10.83) correctly flagged this pattern.
+    const { spawnSync } = require("node:child_process") as typeof import("node:child_process");
+    const result = spawnSync(
+      "ss",
+      ["-tlnp", "state", "listening", `( sport = :${port} )`],
+      { timeout: 1000, stdio: ["ignore", "pipe", "ignore"] },
+    );
+    if (result.status !== 0) return false;
+    const out = result.stdout?.toString() ?? "";
     return out.trim().split("\n").length > 1;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
Gemma 4 audit found \`portInUse\` using \`execSync\` with template string interpolation. Port is always a validated number so injection is impossible in practice, but \`spawnSync\` with args array is trivially safer.

Only finding across 3 audit rounds that **only Gemma 4 caught** — grok missed it in both of its audits. Gemma 4 had ~60% signal/noise ratio vs grok's ~25%.

## Test plan
- [x] \`bun run build\` — v2.10.84 deployed
- [x] Code review: \`spawnSync("ss", ["-tlnp", "state", "listening", ...])\` vs old \`execSync(\`ss ... \${port}\`)\`

Co-Authored-By: Kulvex Code <contact@astrolexis.space>