### PR TITLE
fix(phase-35): intention-without-execution + accented \b fix + v2.10.87

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.86",
+  "version": "2.10.87",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/conversation-post-turn.ts
+++ b/src/core/conversation-post-turn.ts
@@ -177,12 +177,30 @@ export async function handlePostTurn(ctx: PostTurnContext): Promise<PostTurnResu
 
     // Deferral detection: model ends with a question asking the user
     // what to do next, instead of just doing it.
+    //
+    // v2.10.86 update: Gemma 4 doesn't always ask a question. It
+    // also produces "Próximos Pasos Inmediatos" / "Next Steps" lists
+    // with declarative intentions ("Leeré...", "Analizaré...") that
+    // it never executes. Added intention-without-execution patterns
+    // alongside the original question-based deferral patterns.
     const DEFERRAL_PATTERNS = [
       /\?[\s\n]*$/,                                          // ends with ?
       /¿(?:Deseas|Quieres|Prefieres|Cómo quieres|Te gustaría)\b/i,
       /\b(?:Would you like|Do you want|Shall I|Should I|How would you like)\b/i,
       /\b(?:¿(?:Empiezo|Procedo|Continúo|Inicio))\b/i,
       /\b(?:Let me know|Dime cómo|Dime si)\b/i,
+      // Intention-without-execution: model declares what it WILL do
+      // without actually calling any tools. These patterns fire only
+      // when toolCalls.length === 0 (already checked above), so a
+      // model that says "I'll read the file" AND then calls Read
+      // won't match this path.
+      /\b(?:Próximos\s+(?:Pasos|pasos)|Next\s+Steps)\b/i,
+      /\b(?:Voy\s+a\s+(?:proceder|realizar|ejecutar|analizar|leer|revisar))\b/i,
+      /\b(?:I(?:'ll| will)\s+(?:start|begin|proceed|analyze|read|review|examine))\b/i,
+      // No \b wrappers: accented chars (é) aren't \w in JS regex
+      // without the u flag, so \b breaks between r and é. These
+      // conjugations are distinctive enough to not need word boundaries.
+      /(?:Leeré|Analizaré|Revisaré|Evaluaré|Inspeccionaré)/i,
     ];
     const hasDeferral = DEFERRAL_PATTERNS.some((p) => p.test(fullText));
 

--- a/src/core/phase35-action-defer.test.ts
+++ b/src/core/phase35-action-defer.test.ts
@@ -19,6 +19,11 @@ const DEFERRAL_PATTERNS = [
   /\b(?:Would you like|Do you want|Shall I|Should I|How would you like)\b/i,
   /\b(?:¿(?:Empiezo|Procedo|Continúo|Inicio))\b/i,
   /\b(?:Let me know|Dime cómo|Dime si)\b/i,
+  // v2.10.86b: intention-without-execution patterns
+  /\b(?:Próximos\s+(?:Pasos|pasos)|Next\s+Steps)\b/i,
+  /\b(?:Voy\s+a\s+(?:proceder|realizar|ejecutar|analizar|leer|revisar))\b/i,
+  /\b(?:I(?:'ll| will)\s+(?:start|begin|proceed|analyze|read|review|examine))\b/i,
+  /(?:Leeré|Analizaré|Revisaré|Evaluaré|Inspeccionaré)/i,
 ];
 
 const ACTION_INTENT =
@@ -90,6 +95,28 @@ describe("Phase 35 — deferral detection", () => {
     expect(hasDeferral("The fix has been applied successfully.")).toBe(false);
     expect(hasDeferral("Done. All tests pass.")).toBe(false);
   });
+
+  // v2.10.86b: intention-without-execution patterns
+  test("detects Spanish intention declarations (Gemma 4 pattern)", () => {
+    expect(hasDeferral("Leeré src/core/permissions.ts para entender el modelo")).toBe(true);
+    expect(hasDeferral("Analizaré la jerarquía de configuración")).toBe(true);
+    expect(hasDeferral("Revisaré el flujo de datos")).toBe(true);
+    expect(hasDeferral("Voy a proceder con el análisis")).toBe(true);
+    expect(hasDeferral("Voy a realizar las siguientes acciones")).toBe(true);
+    expect(hasDeferral("Voy a leer los archivos principales")).toBe(true);
+  });
+
+  test("detects English intention declarations", () => {
+    expect(hasDeferral("I'll start by reading the core module")).toBe(true);
+    expect(hasDeferral("I will proceed with the security analysis")).toBe(true);
+    expect(hasDeferral("I'll analyze the permission system")).toBe(true);
+    expect(hasDeferral("I will review the configuration flow")).toBe(true);
+  });
+
+  test("detects 'Próximos Pasos' / 'Next Steps' headers", () => {
+    expect(hasDeferral("Próximos Pasos Inmediatos:\n1. Leer el código")).toBe(true);
+    expect(hasDeferral("Next Steps:\n- Read the source")).toBe(true);
+  });
 });
 
 describe("Phase 35 — combined (NEXUS mark6 canonical case)", () => {
@@ -109,11 +136,21 @@ Voy a proceder en fases:
     expect(hasDeferral(assistantText)).toBe(true);
   });
 
-  test("Model that acts immediately → should NOT trigger nudge", () => {
+  test("Model that declares intent with 0 tool calls IS a deferral", () => {
     const userMsg = "audita todo este proyecto";
     const assistantText = `Voy a leer los archivos principales del proyecto para comenzar la auditoría.`;
-    // This response doesn't defer — it's about to act. Phase 35
-    // should only fire on deferral questions, not action statements.
+    // If the model said "Voy a leer" but has ZERO tool calls, that's
+    // a plan-without-action — phase 35 should nudge. In the runtime,
+    // if the model actually called Read, toolCalls.length > 0 and
+    // phase 35 never enters this path.
+    expect(hasActionIntent(userMsg)).toBe(true);
+    expect(hasDeferral(assistantText)).toBe(true);
+  });
+
+  test("Model that produces findings → should NOT trigger nudge", () => {
+    const userMsg = "audita todo este proyecto";
+    const assistantText = `He analizado el código y encontré 3 vulnerabilidades:\n1. SQL injection en login.ts:45\n2. Path traversal en api.ts:92\n3. Missing auth check en admin.ts:12`;
+    // Actual findings text (no intention declarations, no questions)
     expect(hasActionIntent(userMsg)).toBe(true);
     expect(hasDeferral(assistantText)).toBe(false);
   });
@@ -124,6 +161,28 @@ Voy a proceder en fases:
     // User asked an informational question, so even though the model
     // deferred, the user didn't have action intent — no nudge.
     expect(hasActionIntent(userMsg)).toBe(false);
+    expect(hasDeferral(assistantText)).toBe(true);
+  });
+
+  test("Gemma 4 v2.10.86 canonical failure — plan + 'Próximos Pasos' no question", () => {
+    const userMsg = "audita todo este proyecto";
+    const assistantText = `Para realizar una auditoría exhaustiva de este proyecto...
+
+🛡️ 1. Auditoría de Seguridad (Security Audit)
+...
+⚙️ 2. Auditoría de Robustez y Estabilidad
+...
+
+🚀 Próximos Pasos Inmediatos
+Para empezar la ejecución, voy a realizar las siguientes acciones técnicas:
+ 1. Análisis de la herramienta Bash: Leeré src/tools/index.ts
+ 2. Revisión de Permisos: Analizaré src/core/permissions.ts
+ 3. Inspección de Configuración: Revisaré src/core/config.ts`;
+
+    expect(hasActionIntent(userMsg)).toBe(true);
+    // MUST trigger — this was the v2.10.86 failure where phase 35
+    // didn't fire because the model used intention declarations
+    // instead of question-based deferrals.
     expect(hasDeferral(assistantText)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
Phase 35 didn't fire on v2.10.86 Gemma 4 session because the model declared intentions (\"Leeré...\", \"Próximos Pasos\") instead of asking a question. Added intention-without-execution patterns + fixed JS regex \`\\b\` bug with accented characters.

## What changed
1. **New deferral patterns**: \"Próximos Pasos\", \"Voy a proceder/analizar/leer\", \"I'll start/proceed\", \"Leeré/Analizaré/Revisaré\"
2. **Regex fix**: removed \`\\b\` wrappers from accented patterns (\`é\` isn't \`\\w\` in JS without \`u\` flag)

## Test plan
- [x] 16/16 tests including the v2.10.86 canonical Gemma 4 failure
- [x] v2.10.87 binary deployed

Co-Authored-By: Kulvex Code <contact@astrolexis.space>