### PR TITLE
fix(phase-35): fire after reconnaissance + boolean gate + v2.10.88

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.87",
+  "version": "2.10.88",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/conversation-post-turn.ts
+++ b/src/core/conversation-post-turn.ts
@@ -39,6 +39,8 @@ export interface PostTurnContext {
   emptyEndTurnCount: number;
   truncationRetries: number;
   lastEmptyType: "thinking_only" | "tools_only" | "thinking_and_tools" | "no_output" | undefined;
+  /** Phase 35: whether the action-defer nudge already fired this session. */
+  actionNudgeUsed: boolean;
 
   /** Debug tracer (optional) */
   debugTracer?: {
@@ -66,6 +68,7 @@ export interface PostTurnResult {
   lastEmptyType: "thinking_only" | "tools_only" | "thinking_and_tools" | "no_output" | undefined;
   previousTurnTail: string;
   turnsSinceLastExtraction: number;
+  actionNudgeUsed: boolean;
 }
 
 // ─── Main Post-Turn Handler ─────────────────────────────────────
@@ -81,6 +84,11 @@ export interface PostTurnResult {
 export async function handlePostTurn(ctx: PostTurnContext): Promise<PostTurnResult> {
   const events: StreamEvent[] = [];
   const injectMessages: Message[] = [];
+  // Phase 35 nudge flag — propagates the input value and only gets
+  // set to true in the nudge path. All other return paths inherit
+  // this value unchanged, avoiding the need to add actionNudgeUsed
+  // to every single return statement.
+  let actionNudgeUsed = ctx.actionNudgeUsed;
   let {
     maxTokensContinuations,
     emptyEndTurnCount,
@@ -89,6 +97,9 @@ export async function handlePostTurn(ctx: PostTurnContext): Promise<PostTurnResu
     previousTurnTail,
     turnsSinceLastExtraction,
   } = ctx;
+
+  // Compute text-output flag early — used by phase 35 and empty-response retry.
+  const hasTextOutput = ctx.textChunks.join("").trim().length > 0;
 
   // Auto-continue on max_tokens
   if (ctx.stopReason === "max_tokens" && maxTokensContinuations < 3) {
@@ -121,6 +132,7 @@ export async function handlePostTurn(ctx: PostTurnContext): Promise<PostTurnResu
       lastEmptyType,
       previousTurnTail,
       turnsSinceLastExtraction,
+      actionNudgeUsed,
     };
   }
 
@@ -149,6 +161,7 @@ export async function handlePostTurn(ctx: PostTurnContext): Promise<PostTurnResu
       lastEmptyType,
       previousTurnTail,
       turnsSinceLastExtraction,
+      actionNudgeUsed,
     };
   }
 
@@ -170,7 +183,7 @@ export async function handlePostTurn(ctx: PostTurnContext): Promise<PostTurnResu
   if (
     ctx.toolCalls.length === 0 &&
     ctx.stopReason === "end_turn" &&
-    ctx.turnCount === 0 &&
+    !ctx.actionNudgeUsed &&
     hasTextOutput
   ) {
     const fullText = ctx.textChunks.join("");
@@ -247,6 +260,7 @@ export async function handlePostTurn(ctx: PostTurnContext): Promise<PostTurnResu
         lastEmptyType,
         previousTurnTail,
         turnsSinceLastExtraction,
+        actionNudgeUsed: true,
       };
     }
   }
@@ -293,7 +307,7 @@ export async function handlePostTurn(ctx: PostTurnContext): Promise<PostTurnResu
   }
 
   // Safety net: classify empty responses and retry with context-aware prompts
-  const hasTextOutput = ctx.textChunks.join("").trim().length > 0;
+  // (hasTextOutput already computed at the top of the function)
   const hasThinkingOutput =
     ctx.thinkingChunks.length > 0 ||
     (ctx.messages.at(-1) as Record<string, unknown> | undefined)?.thinkingContent;
@@ -367,6 +381,7 @@ export async function handlePostTurn(ctx: PostTurnContext): Promise<PostTurnResu
       lastEmptyType,
       previousTurnTail,
       turnsSinceLastExtraction,
+      actionNudgeUsed,
     };
   }
 

--- a/src/core/conversation.ts
+++ b/src/core/conversation.ts
@@ -1171,6 +1171,7 @@ export class ConversationManager {
     // across loop iterations. A future refactor of runAgentLoop into smaller
     // functions should encapsulate this state (see L5 audit finding).
     let previousTurnTail = "";
+    let actionNudgeUsed = false; // Phase 35: fire once per session
 
     while (true) {
       // Hard break after force-stop allowed one final text turn
@@ -1658,6 +1659,7 @@ export class ConversationManager {
           lastEmptyType: guardState.lastEmptyType,
           debugTracer: this.debugTracer,
           collectSessionData: () => this.collectSessionData(),
+          actionNudgeUsed,
         });
 
         // Apply state updates from post-turn handler
@@ -1667,6 +1669,7 @@ export class ConversationManager {
         guardState.lastEmptyType = postTurnResult.lastEmptyType;
         previousTurnTail = postTurnResult.previousTurnTail;
         this.turnsSinceLastExtraction = postTurnResult.turnsSinceLastExtraction;
+        actionNudgeUsed = postTurnResult.actionNudgeUsed;
 
         // Emit events
         for (const evt of postTurnResult.events) yield evt;


### PR DESCRIPTION
Phase 35 still didn't fire on v2.10.87 because model called 2 recon tools on turn 0 then planned on turn 1. Fixed: \`turnCount === 0\` → \`actionNudgeUsed\` boolean, fires once per session on any turn. Also fixed \`hasTextOutput\` ordering bug (ReferenceError).

57/57 tests green. v2.10.88 deployed.

Co-Authored-By: Kulvex Code <contact@astrolexis.space>