### PR TITLE
feat: auto-discover new cloud models + v2.10.90

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.89",
+  "version": "2.10.90",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/cli/commands/models.ts
+++ b/src/cli/commands/models.ts
@@ -276,4 +276,45 @@ export function registerModelsCommand(program: Command): void {
       console.log(`  Generation speed:           ${tokensPerSec.toFixed(1)} tokens/sec`);
       console.log(`  Total time:                 ${(totalMs / 1000).toFixed(2)} s`);
     });
+
+  modelsCmd
+    .command("discover")
+    .description("Query cloud provider /v1/models endpoints and register new models")
+    .option(
+      "--provider <ids>",
+      "Comma-separated provider IDs (anthropic,openai,groq,deepseek,together). Default: all with keys.",
+    )
+    .action(async (opts: { provider?: string }) => {
+      const { runModelDiscovery } = await import("../../core/model-discovery");
+      const providerFilter = opts.provider
+        ? opts.provider.split(",").map((s) => s.trim()).filter(Boolean)
+        : undefined;
+
+      console.log("Discovering models from cloud providers...\n");
+      const results = await runModelDiscovery({ providerFilter });
+
+      let totalAdded = 0;
+      for (const r of results) {
+        const label = r.provider.padEnd(10);
+        if (r.error) {
+          console.log(`  ${label} — skipped (${r.error})`);
+          continue;
+        }
+        if (r.added.length === 0) {
+          console.log(`  ${label} — up to date (${r.skipped.length} known)`);
+          continue;
+        }
+        totalAdded += r.added.length;
+        console.log(`  ${label} — \x1b[32m+${r.added.length} new\x1b[0m:`);
+        for (const id of r.added) {
+          console.log(`      ${id}`);
+        }
+      }
+
+      if (totalAdded === 0) {
+        console.log("\nNo new models to add.");
+      } else {
+        console.log(`\n\x1b[32m✓\x1b[0m Added ${totalAdded} new model(s) to the registry.`);
+      }
+    });
 }

--- a/src/core/model-discovery.test.ts
+++ b/src/core/model-discovery.test.ts
@@ -1,0 +1,315 @@
+// Model discovery tests.
+//
+// Covers: guessContextSize heuristic, provider adapters (parseDataIdArray,
+// headers factory), discoverFromProvider with a mocked fetch, merge
+// behavior (never overwrites existing), and the runModelDiscovery
+// orchestrator.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ALL_PROVIDERS,
+  type DiscoveryResult,
+  collectProviderKeys,
+  discoverFromProvider,
+  fetchProviderModels,
+  guessContextSize,
+  runModelDiscovery,
+} from "./model-discovery";
+import { _setModelsPathForTest, type ModelsConfig } from "./models";
+
+// Test isolation
+let testHome: string;
+let testModelsPath: string;
+let originalFetch: typeof globalThis.fetch;
+let originalKcodeHome: string | undefined;
+
+beforeEach(() => {
+  originalKcodeHome = process.env.KCODE_HOME;
+  originalFetch = globalThis.fetch;
+  testHome = join(tmpdir(), `kcode-discovery-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(testHome, { recursive: true });
+  process.env.KCODE_HOME = testHome;
+  testModelsPath = join(testHome, "models.json");
+  _setModelsPathForTest(testModelsPath);
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  _setModelsPathForTest(undefined);
+  if (originalKcodeHome === undefined) {
+    delete process.env.KCODE_HOME;
+  } else {
+    process.env.KCODE_HOME = originalKcodeHome;
+  }
+  if (existsSync(testHome)) {
+    rmSync(testHome, { recursive: true, force: true });
+  }
+  // Clean provider keys from env so they don't leak between tests
+  for (const env of [
+    "ANTHROPIC_API_KEY", "KCODE_ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY", "KCODE_OPENAI_API_KEY",
+    "GROQ_API_KEY", "KCODE_GROQ_API_KEY",
+    "DEEPSEEK_API_KEY", "KCODE_DEEPSEEK_API_KEY",
+    "TOGETHER_API_KEY", "TOGETHER_AI_API_KEY", "KCODE_TOGETHER_API_KEY",
+  ]) {
+    delete process.env[env];
+  }
+});
+
+// ─── guessContextSize ──────────────────────────────────────────
+
+describe("guessContextSize", () => {
+  test("Claude models map to 200K", () => {
+    expect(guessContextSize("claude-opus-4-7")).toBe(200_000);
+    expect(guessContextSize("claude-opus-4-6")).toBe(200_000);
+    expect(guessContextSize("claude-sonnet-4-6")).toBe(200_000);
+    expect(guessContextSize("claude-haiku-4-5")).toBe(200_000);
+    expect(guessContextSize("claude-3-5-sonnet-20241022")).toBe(200_000);
+  });
+
+  test("Claude 1M beta maps to 1M", () => {
+    expect(guessContextSize("claude-sonnet-4-6-1m")).toBe(1_000_000);
+  });
+
+  test("OpenAI modern models map correctly", () => {
+    expect(guessContextSize("gpt-4o")).toBe(128_000);
+    expect(guessContextSize("gpt-4o-mini")).toBe(128_000);
+    expect(guessContextSize("gpt-4-turbo-preview")).toBe(128_000);
+    expect(guessContextSize("gpt-4.1")).toBe(1_000_000);
+    expect(guessContextSize("o1-preview")).toBe(200_000);
+    expect(guessContextSize("o3-mini")).toBe(200_000);
+  });
+
+  test("old GPT-4 is 8K", () => {
+    expect(guessContextSize("gpt-4")).toBe(8_192);
+  });
+
+  test("Llama 3.x 70B/8B are 128K", () => {
+    expect(guessContextSize("llama-3.1-70b-versatile")).toBe(128_000);
+    expect(guessContextSize("llama-3.3-70b-versatile")).toBe(128_000);
+  });
+
+  test("DeepSeek R1/V3/coder maps to 128K", () => {
+    expect(guessContextSize("deepseek-r1")).toBe(128_000);
+    expect(guessContextSize("deepseek-v3")).toBe(128_000);
+    expect(guessContextSize("deepseek-coder-v2")).toBe(128_000);
+  });
+
+  test("unknown model defaults to 128K", () => {
+    expect(guessContextSize("some-new-model-2026")).toBe(128_000);
+  });
+});
+
+// ─── Provider adapters ─────────────────────────────────────────
+
+describe("Provider spec parse", () => {
+  test("Anthropic adapter parses OpenAI-compat { data: [] } shape", () => {
+    const anthropic = ALL_PROVIDERS.find((p) => p.id === "anthropic")!;
+    const ids = anthropic.parse({
+      data: [
+        { id: "claude-opus-4-7", type: "model" },
+        { id: "claude-sonnet-4-6", type: "model" },
+      ],
+    });
+    expect(ids).toEqual(["claude-opus-4-7", "claude-sonnet-4-6"]);
+  });
+
+  test("OpenAI adapter parses the same shape", () => {
+    const openai = ALL_PROVIDERS.find((p) => p.id === "openai")!;
+    const ids = openai.parse({
+      data: [
+        { id: "gpt-4o", object: "model" },
+        { id: "o3-mini", object: "model" },
+      ],
+    });
+    expect(ids).toEqual(["gpt-4o", "o3-mini"]);
+  });
+
+  test("parse handles missing/malformed body", () => {
+    const openai = ALL_PROVIDERS.find((p) => p.id === "openai")!;
+    expect(openai.parse(null)).toEqual([]);
+    expect(openai.parse({})).toEqual([]);
+    expect(openai.parse({ data: "not an array" })).toEqual([]);
+    expect(openai.parse({ data: [{ foo: "bar" }] })).toEqual([]);
+  });
+
+  test("Anthropic headers include x-api-key and anthropic-version", () => {
+    const anthropic = ALL_PROVIDERS.find((p) => p.id === "anthropic")!;
+    const h = anthropic.headers("test-key");
+    expect(h["x-api-key"]).toBe("test-key");
+    expect(h["anthropic-version"]).toBeTruthy();
+    expect(h["authorization"]).toBeUndefined();
+  });
+
+  test("OpenAI-compat providers use Bearer auth", () => {
+    for (const id of ["openai", "groq", "deepseek", "together"]) {
+      const spec = ALL_PROVIDERS.find((p) => p.id === id)!;
+      const h = spec.headers("test-key");
+      expect(h.authorization).toBe("Bearer test-key");
+    }
+  });
+});
+
+// ─── fetchProviderModels ───────────────────────────────────────
+
+describe("fetchProviderModels (with mocked fetch)", () => {
+  test("returns IDs on a 200 response", async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({ data: [{ id: "claude-opus-4-7" }, { id: "claude-sonnet-4-6" }] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    const anthropic = ALL_PROVIDERS.find((p) => p.id === "anthropic")!;
+    const ids = await fetchProviderModels(anthropic, "test-key");
+    expect(ids).toEqual(["claude-opus-4-7", "claude-sonnet-4-6"]);
+  });
+
+  test("throws on non-200 response", async () => {
+    globalThis.fetch = async () =>
+      new Response("unauthorized", { status: 401 });
+    const openai = ALL_PROVIDERS.find((p) => p.id === "openai")!;
+    await expect(fetchProviderModels(openai, "bad-key")).rejects.toThrow(/HTTP 401/);
+  });
+});
+
+// ─── discoverFromProvider ──────────────────────────────────────
+
+describe("discoverFromProvider", () => {
+  test("adds new models to an empty config", async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({ data: [{ id: "claude-opus-4-7" }, { id: "claude-sonnet-4-6" }] }),
+        { status: 200 },
+      );
+    const config: ModelsConfig = { models: [] };
+    const anthropic = ALL_PROVIDERS.find((p) => p.id === "anthropic")!;
+    const r = await discoverFromProvider(anthropic, "test-key", config);
+    expect(r.added).toEqual(["claude-opus-4-7", "claude-sonnet-4-6"]);
+    expect(r.skipped).toEqual([]);
+    expect(config.models).toHaveLength(2);
+    expect(config.models[0]!.provider).toBe("anthropic");
+    expect(config.models[0]!.contextSize).toBe(200_000);
+    expect(config.models[0]!.baseUrl).toBe("https://api.anthropic.com");
+  });
+
+  test("never overwrites existing entries (user customization preserved)", async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({ data: [{ id: "claude-opus-4-7" }] }),
+        { status: 200 },
+      );
+    const config: ModelsConfig = {
+      models: [
+        {
+          name: "claude-opus-4-7",
+          baseUrl: "https://custom.example.com",
+          contextSize: 99_999,
+          description: "User's custom config",
+          provider: "anthropic",
+        },
+      ],
+    };
+    const anthropic = ALL_PROVIDERS.find((p) => p.id === "anthropic")!;
+    const r = await discoverFromProvider(anthropic, "test-key", config);
+    expect(r.added).toEqual([]);
+    expect(r.skipped).toEqual(["claude-opus-4-7"]);
+    expect(config.models).toHaveLength(1);
+    expect(config.models[0]!.baseUrl).toBe("https://custom.example.com");
+    expect(config.models[0]!.contextSize).toBe(99_999);
+    expect(config.models[0]!.description).toBe("User's custom config");
+  });
+
+  test("records the error and returns empty added on fetch failure", async () => {
+    globalThis.fetch = async () =>
+      new Response("server error", { status: 500 });
+    const config: ModelsConfig = { models: [] };
+    const openai = ALL_PROVIDERS.find((p) => p.id === "openai")!;
+    const r = await discoverFromProvider(openai, "test-key", config);
+    expect(r.added).toEqual([]);
+    expect(r.error).toMatch(/HTTP 500/);
+    expect(config.models).toHaveLength(0);
+  });
+});
+
+// ─── collectProviderKeys ───────────────────────────────────────
+
+describe("collectProviderKeys", () => {
+  test("picks up standard env var names", () => {
+    process.env.ANTHROPIC_API_KEY = "a-key";
+    process.env.OPENAI_API_KEY = "o-key";
+    process.env.GROQ_API_KEY = "g-key";
+    const keys = collectProviderKeys();
+    expect(keys.get("anthropic")).toBe("a-key");
+    expect(keys.get("openai")).toBe("o-key");
+    expect(keys.get("groq")).toBe("g-key");
+  });
+
+  test("falls back to KCODE-prefixed names", () => {
+    process.env.KCODE_ANTHROPIC_API_KEY = "k-a-key";
+    const keys = collectProviderKeys();
+    expect(keys.get("anthropic")).toBe("k-a-key");
+  });
+
+  test("omits providers without a key", () => {
+    const keys = collectProviderKeys();
+    expect(keys.has("anthropic")).toBe(false);
+    expect(keys.has("openai")).toBe(false);
+  });
+});
+
+// ─── runModelDiscovery ─────────────────────────────────────────
+
+describe("runModelDiscovery", () => {
+  test("discovers from all providers with keys", async () => {
+    writeFileSync(testModelsPath, JSON.stringify({ models: [] }), "utf-8");
+    globalThis.fetch = async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("anthropic.com")) {
+        return new Response(JSON.stringify({ data: [{ id: "claude-opus-4-7" }] }), { status: 200 });
+      }
+      if (url.includes("openai.com")) {
+        return new Response(JSON.stringify({ data: [{ id: "gpt-4o-2026-preview" }] }), { status: 200 });
+      }
+      return new Response("not mocked", { status: 404 });
+    };
+    const keys = new Map([
+      ["anthropic", "a"],
+      ["openai", "o"],
+    ]);
+    const results = await runModelDiscovery({ apiKeys: keys, providerFilter: ["anthropic", "openai"] });
+    const added = results.flatMap((r) => r.added);
+    expect(added).toContain("claude-opus-4-7");
+    expect(added).toContain("gpt-4o-2026-preview");
+  });
+
+  test("skips providers without keys and records error", async () => {
+    writeFileSync(testModelsPath, JSON.stringify({ models: [] }), "utf-8");
+    const results: DiscoveryResult[] = await runModelDiscovery({
+      apiKeys: new Map(), // no keys
+      providerFilter: ["anthropic"],
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]!.error).toMatch(/no API key/);
+    expect(results[0]!.added).toEqual([]);
+  });
+
+  test("providerFilter limits which providers are queried", async () => {
+    writeFileSync(testModelsPath, JSON.stringify({ models: [] }), "utf-8");
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ data: [{ id: "some-model" }] }), { status: 200 });
+    const keys = new Map([
+      ["anthropic", "a"],
+      ["openai", "o"],
+      ["groq", "g"],
+    ]);
+    const results = await runModelDiscovery({
+      apiKeys: keys,
+      providerFilter: ["anthropic"], // only anthropic
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]!.provider).toBe("anthropic");
+  });
+});

--- a/src/core/model-discovery.ts
+++ b/src/core/model-discovery.ts
@@ -1,0 +1,327 @@
+// KCode — Model Discovery
+//
+// Queries cloud provider /v1/models endpoints and merges any newly-
+// released models into ~/.kcode/models.json. Solves the "Opus 4.7
+// just came out but kcode doesn't know about it" friction — the user
+// no longer has to manually `kcode models add` when Anthropic/OpenAI/
+// Groq/etc. ship a new model.
+//
+// Invoked via `kcode models discover` (manual) or at startup when
+// KCODE_AUTO_DISCOVER_MODELS=1 is set (opt-in to avoid surprise API
+// calls on every kcode launch).
+//
+// Providers supported today:
+//   - Anthropic     (GET https://api.anthropic.com/v1/models)
+//   - OpenAI        (GET https://api.openai.com/v1/models)
+//   - Groq          (GET https://api.groq.com/openai/v1/models)
+//   - DeepSeek      (GET https://api.deepseek.com/v1/models)
+//   - Together AI   (GET https://api.together.xyz/v1/models)
+//
+// Not yet supported (different schema): Google Gemini. Added as a
+// TODO — Gemini uses https://generativelanguage.googleapis.com with
+// a ?key=KEY auth instead of bearer tokens.
+
+import { log } from "./logger";
+import type { ModelEntry, ModelsConfig } from "./models";
+import { loadModelsConfig, saveModelsConfig } from "./models";
+
+// ─── Provider adapters ──────────────────────────────────────────
+
+export interface ProviderSpec {
+  id: string;
+  /** Human-readable name for logs/output. */
+  label: string;
+  /** Endpoint URL — usually {baseUrl}/v1/models. */
+  endpoint: string;
+  /**
+   * Headers factory. Given the API key, returns the auth headers.
+   * Split from endpoint because Anthropic uses x-api-key + version
+   * while OpenAI-compat uses Authorization: Bearer.
+   */
+  headers: (apiKey: string) => Record<string, string>;
+  /**
+   * How to parse the response body into a list of model IDs.
+   * Providers return slightly different shapes:
+   *   OpenAI-compat: { data: [{ id: "gpt-4o", ... }, ...] }
+   *   Anthropic:     { data: [{ id: "claude-opus-4-7", ... }, ...] } (same)
+   */
+  parse: (body: unknown) => string[];
+  /** Internal provider type used when writing to models.json. */
+  provider: "openai" | "anthropic";
+  /** The baseUrl we store on the entry (/v1 stripped — models.ts appends). */
+  baseUrl: string;
+}
+
+const ANTHROPIC: ProviderSpec = {
+  id: "anthropic",
+  label: "Anthropic",
+  endpoint: "https://api.anthropic.com/v1/models",
+  headers: (apiKey) => ({
+    "x-api-key": apiKey,
+    "anthropic-version": "2023-06-01",
+    "content-type": "application/json",
+  }),
+  parse: parseDataIdArray,
+  provider: "anthropic",
+  baseUrl: "https://api.anthropic.com",
+};
+
+const OPENAI: ProviderSpec = {
+  id: "openai",
+  label: "OpenAI",
+  endpoint: "https://api.openai.com/v1/models",
+  headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
+  parse: parseDataIdArray,
+  provider: "openai",
+  baseUrl: "https://api.openai.com",
+};
+
+const GROQ: ProviderSpec = {
+  id: "groq",
+  label: "Groq",
+  endpoint: "https://api.groq.com/openai/v1/models",
+  headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
+  parse: parseDataIdArray,
+  provider: "openai",
+  baseUrl: "https://api.groq.com/openai",
+};
+
+const DEEPSEEK: ProviderSpec = {
+  id: "deepseek",
+  label: "DeepSeek",
+  endpoint: "https://api.deepseek.com/v1/models",
+  headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
+  parse: parseDataIdArray,
+  provider: "openai",
+  baseUrl: "https://api.deepseek.com",
+};
+
+const TOGETHER: ProviderSpec = {
+  id: "together",
+  label: "Together AI",
+  endpoint: "https://api.together.xyz/v1/models",
+  headers: (apiKey) => ({ authorization: `Bearer ${apiKey}` }),
+  parse: parseDataIdArray,
+  provider: "openai",
+  baseUrl: "https://api.together.xyz",
+};
+
+export const ALL_PROVIDERS: ProviderSpec[] = [
+  ANTHROPIC,
+  OPENAI,
+  GROQ,
+  DEEPSEEK,
+  TOGETHER,
+];
+
+/**
+ * Parser for the common { data: [{ id: string }, ...] } shape used
+ * by OpenAI-compatible APIs and Anthropic. Rejects entries without a
+ * string id.
+ */
+function parseDataIdArray(body: unknown): string[] {
+  if (!body || typeof body !== "object") return [];
+  const b = body as Record<string, unknown>;
+  if (!Array.isArray(b.data)) return [];
+  const ids: string[] = [];
+  for (const entry of b.data) {
+    if (entry && typeof entry === "object") {
+      const id = (entry as Record<string, unknown>).id;
+      if (typeof id === "string" && id.length > 0) ids.push(id);
+    }
+  }
+  return ids;
+}
+
+// ─── Context size heuristic ─────────────────────────────────────
+
+/**
+ * Guess the context window size from a model ID. Used when we
+ * discover a model we've never seen before — we need SOME context
+ * size to store in the registry, and the ID is the only signal we
+ * have. Falls back to 128K as a safe default for modern models.
+ *
+ * Keep this conservative: if we guess too high, the model may 400
+ * on requests that exceed its real context. Too low just means
+ * kcode compacts earlier than necessary (no broken behavior).
+ */
+export function guessContextSize(modelId: string): number {
+  const id = modelId.toLowerCase();
+
+  // Anthropic Claude family — check 1M variant FIRST (more specific)
+  if (/claude.*1m/.test(id)) return 1_000_000;
+  if (/claude-(?:opus|sonnet|haiku)-[34]/.test(id)) return 200_000;
+  if (/claude-3-(?:5|7)/.test(id)) return 200_000;
+  if (/claude-(?:opus|sonnet|haiku)-4/.test(id)) return 200_000;
+
+  // OpenAI
+  if (/gpt-4-turbo/.test(id)) return 128_000;
+  if (/gpt-4o/.test(id)) return 128_000;
+  if (/gpt-4\.1/.test(id)) return 1_000_000;
+  if (/gpt-4/.test(id)) return 8_192;
+  if (/gpt-3\.5/.test(id)) return 16_385;
+  if (/^o[13]/.test(id) || /^o1/.test(id) || /^o3/.test(id)) return 200_000;
+
+  // Groq / Together common llama variants
+  if (/llama-3\.[1-3]-70b/.test(id)) return 128_000;
+  if (/llama-3\.[1-3]-8b/.test(id)) return 128_000;
+  if (/llama-3-/.test(id)) return 8_192;
+  if (/mixtral/.test(id)) return 32_768;
+  if (/qwen-?2/.test(id)) return 128_000;
+
+  // DeepSeek
+  if (/deepseek-(?:r1|v3|coder)/.test(id)) return 128_000;
+
+  // Default for unknown modern models
+  return 128_000;
+}
+
+// ─── Discovery ──────────────────────────────────────────────────
+
+export interface DiscoveryResult {
+  provider: string;
+  added: string[];
+  skipped: string[];
+  error?: string;
+}
+
+/** Fetch the model list from a single provider. Returns IDs or throws. */
+export async function fetchProviderModels(
+  spec: ProviderSpec,
+  apiKey: string,
+  opts?: { timeoutMs?: number },
+): Promise<string[]> {
+  const timeoutMs = opts?.timeoutMs ?? 10_000;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(spec.endpoint, {
+      method: "GET",
+      headers: spec.headers(apiKey),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      throw new Error(`${spec.label} /v1/models returned HTTP ${res.status}`);
+    }
+    const body = await res.json();
+    const ids = spec.parse(body);
+    log.debug("model-discovery", `${spec.label}: ${ids.length} models listed`);
+    return ids;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Discover models from one provider and merge new ones into the
+ * supplied config. Returns what changed so the caller can log it.
+ *
+ * Existing entries in the config are NEVER overwritten — if the user
+ * manually tuned contextSize or description for an entry, we leave
+ * it alone. We only ADD entries for IDs we've never seen.
+ */
+export async function discoverFromProvider(
+  spec: ProviderSpec,
+  apiKey: string,
+  config: ModelsConfig,
+): Promise<DiscoveryResult> {
+  const result: DiscoveryResult = {
+    provider: spec.id,
+    added: [],
+    skipped: [],
+  };
+
+  let ids: string[];
+  try {
+    ids = await fetchProviderModels(spec, apiKey);
+  } catch (err) {
+    result.error = err instanceof Error ? err.message : String(err);
+    return result;
+  }
+
+  const existingNames = new Set(config.models.map((m) => m.name));
+  for (const id of ids) {
+    if (existingNames.has(id)) {
+      result.skipped.push(id);
+      continue;
+    }
+    const entry: ModelEntry = {
+      name: id,
+      baseUrl: spec.baseUrl,
+      contextSize: guessContextSize(id),
+      provider: spec.provider,
+      description: `Auto-discovered from ${spec.label} on ${new Date().toISOString().slice(0, 10)}`,
+    };
+    config.models.push(entry);
+    result.added.push(id);
+  }
+
+  return result;
+}
+
+/**
+ * Figure out which API key to use for each provider. Reads from
+ * environment variables first (standard names), then falls back to
+ * a generic KCODE_API_KEY. Returns a map of provider id → key.
+ * Providers without a key are omitted from the map.
+ */
+export function collectProviderKeys(): Map<string, string> {
+  const keys = new Map<string, string>();
+  const pick = (id: string, envs: string[]): void => {
+    for (const env of envs) {
+      const v = process.env[env];
+      if (v && v.length > 0) {
+        keys.set(id, v);
+        return;
+      }
+    }
+  };
+  pick("anthropic", ["ANTHROPIC_API_KEY", "KCODE_ANTHROPIC_API_KEY"]);
+  pick("openai", ["OPENAI_API_KEY", "KCODE_OPENAI_API_KEY"]);
+  pick("groq", ["GROQ_API_KEY", "KCODE_GROQ_API_KEY"]);
+  pick("deepseek", ["DEEPSEEK_API_KEY", "KCODE_DEEPSEEK_API_KEY"]);
+  pick("together", ["TOGETHER_API_KEY", "TOGETHER_AI_API_KEY", "KCODE_TOGETHER_API_KEY"]);
+  return keys;
+}
+
+/**
+ * Run discovery across every provider we have a key for. Loads the
+ * current registry, appends new entries, saves atomically. Returns
+ * the per-provider results for the caller to print.
+ */
+export async function runModelDiscovery(opts?: {
+  providerFilter?: string[];
+  apiKeys?: Map<string, string>;
+}): Promise<DiscoveryResult[]> {
+  const keys = opts?.apiKeys ?? collectProviderKeys();
+  const config = await loadModelsConfig();
+  const results: DiscoveryResult[] = [];
+  let anyAdded = false;
+
+  for (const spec of ALL_PROVIDERS) {
+    if (opts?.providerFilter && !opts.providerFilter.includes(spec.id)) continue;
+    const apiKey = keys.get(spec.id);
+    if (!apiKey) {
+      results.push({
+        provider: spec.id,
+        added: [],
+        skipped: [],
+        error: "no API key configured",
+      });
+      continue;
+    }
+    const r = await discoverFromProvider(spec, apiKey, config);
+    if (r.added.length > 0) anyAdded = true;
+    results.push(r);
+  }
+
+  if (anyAdded) {
+    await saveModelsConfig(config);
+    log.info(
+      "model-discovery",
+      `saved ${config.models.length} total models to registry`,
+    );
+  }
+
+  return results;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,6 +383,31 @@ registerDashboardCommand(program);
 registerTemplateCommand(program);
 registerWebCommand(program);
 
+// ─── Optional background model discovery ────────────────────────
+//
+// Opt-in via KCODE_AUTO_DISCOVER_MODELS=1. Runs discovery in the
+// background so it can't slow startup — failures and results just
+// get logged. Useful for "Opus 4.7 just shipped, I want it without
+// running `kcode models discover` every time."
+if (process.env.KCODE_AUTO_DISCOVER_MODELS === "1") {
+  void (async () => {
+    try {
+      const { runModelDiscovery } = await import("./core/model-discovery");
+      const results = await runModelDiscovery();
+      const added = results.flatMap((r) => r.added);
+      if (added.length > 0) {
+        const { log } = await import("./core/logger");
+        log.info(
+          "model-discovery",
+          `auto-discovered ${added.length} new model(s): ${added.slice(0, 5).join(", ")}${added.length > 5 ? ", ..." : ""}`,
+        );
+      }
+    } catch {
+      // Best-effort — never break startup.
+    }
+  })();
+}
+
 // ─── Parse ──────────────────────────────────────────────────────
 
 profileCheckpoint("cli_defined");


### PR DESCRIPTION
## Summary
Opus 4.7 shipped today. Previously required manual \`kcode models add\`. New \`kcode models discover\` queries provider \`/v1/models\` endpoints and registers new IDs automatically.

## Providers (v1)
Anthropic, OpenAI, Groq, DeepSeek, Together AI. Gemini deferred (different schema).

## Invocation
- **Manual**: \`kcode models discover\` (or \`--provider anthropic,openai\`)
- **Auto on startup**: opt-in via \`KCODE_AUTO_DISCOVER_MODELS=1\`, runs in background

## Design
- Never overwrites existing entries (user's custom config preserved)
- Context size guessed from ID naming pattern; 1M-beta variants checked first to not be masked by generic Claude pattern
- Per-provider failure isolation — one provider 401 doesn't break the others
- API keys from standard env vars with KCODE_-prefixed fallbacks

## Test plan
- [x] 23 tests covering heuristic, adapters, fetch (200 + 401), merge behavior, orchestrator
- [x] v2.10.90 binary deployed

Run \`kcode models discover\` after merge to pick up Opus 4.7.

Co-Authored-By: Kulvex Code <contact@astrolexis.space>