### PR TITLE
fix: /help lists /model and other built-in commands + v2.10.91

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.90",
+  "version": "2.10.91",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -393,9 +393,17 @@ export class SkillManager {
     this.load();
     const lines: string[] = ["\n  Commands"];
 
-    // Built-in non-skill commands
-    lines.push("  /exit, /quit   Exit KCode");
-    lines.push("  /status        Show conversation stats");
+    // Built-in non-skill commands. Must be kept in sync with the
+    // slashCompletions set in src/ui/App.tsx — otherwise a command
+    // works but doesn't show in /help (silent omission).
+    lines.push("  /exit, /quit                  Exit KCode");
+    lines.push("  /status                       Show conversation stats");
+    lines.push("  /model, /toggle, /switch      Switch between local and cloud models");
+    lines.push("  /cloud, /api-key, /provider   Configure cloud API providers");
+    lines.push("  /auth                         OAuth login/status/logout for cloud providers");
+    lines.push("  /plugin, /plugins             Install, list, or remove plugins");
+    lines.push("  /marketplace                  Browse and install plugins from the marketplace");
+    lines.push("  /hookify                      Manage dynamic hookify rules");
     lines.push("");
 
     // Skill commands


### PR DESCRIPTION
## Summary
\`/help\` didn't list \`/model\` (or \`/toggle\`, \`/cloud\`, \`/auth\`, \`/plugin\`, \`/marketplace\`, etc.) even though those commands work. The \`formatHelp()\` function only listed skills + \`/exit\`, \`/quit\`, \`/status\` — it ignored the built-in non-skill commands registered in \`slashCompletions\`.

## Fix
Expanded the built-in section of \`formatHelp()\` with every command in \`slashCompletions\` (App.tsx:60-83), grouped by function.

Commands work and show in autocomplete the same as before; this fix just makes them discoverable via \`/help\`.

## Test plan
- [x] \`bun run build\` — v2.10.91 deployed
- [x] Manual: \`kcode\` → type \`/help\` → verify \`/model\` now appears

Co-Authored-By: Kulvex Code <contact@astrolexis.space>