### PR TITLE
fix: model discovery works with OAuth sessions + v2.10.92

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.91",
+  "version": "2.10.92",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/model-discovery.test.ts
+++ b/src/core/model-discovery.test.ts
@@ -237,26 +237,46 @@ describe("discoverFromProvider", () => {
 // ─── collectProviderKeys ───────────────────────────────────────
 
 describe("collectProviderKeys", () => {
-  test("picks up standard env var names", () => {
+  test("picks up standard env var names", async () => {
     process.env.ANTHROPIC_API_KEY = "a-key";
     process.env.OPENAI_API_KEY = "o-key";
     process.env.GROQ_API_KEY = "g-key";
-    const keys = collectProviderKeys();
+    const keys = await collectProviderKeys();
     expect(keys.get("anthropic")).toBe("a-key");
     expect(keys.get("openai")).toBe("o-key");
     expect(keys.get("groq")).toBe("g-key");
   });
 
-  test("falls back to KCODE-prefixed names", () => {
+  test("falls back to KCODE-prefixed names", async () => {
     process.env.KCODE_ANTHROPIC_API_KEY = "k-a-key";
-    const keys = collectProviderKeys();
+    const keys = await collectProviderKeys();
     expect(keys.get("anthropic")).toBe("k-a-key");
   });
 
-  test("omits providers without a key", () => {
-    const keys = collectProviderKeys();
+  test("omits providers without a key", async () => {
+    const keys = await collectProviderKeys();
     expect(keys.has("anthropic")).toBe(false);
     expect(keys.has("openai")).toBe(false);
+  });
+});
+
+describe("Anthropic headers auto-switch on OAuth vs API key", () => {
+  test("sk-ant-oat01-* uses Authorization: Bearer + oauth-beta", () => {
+    const anthropic = ALL_PROVIDERS.find((p) => p.id === "anthropic")!;
+    const h = anthropic.headers("sk-ant-oat01-testtoken123");
+    expect(h.authorization).toBe("Bearer sk-ant-oat01-testtoken123");
+    expect(h["anthropic-beta"]).toBe("oauth-2025-04-20");
+    expect(h["anthropic-version"]).toBe("2023-06-01");
+    expect(h["x-api-key"]).toBeUndefined();
+  });
+
+  test("sk-ant-api03-* uses x-api-key (no OAuth beta)", () => {
+    const anthropic = ALL_PROVIDERS.find((p) => p.id === "anthropic")!;
+    const h = anthropic.headers("sk-ant-api03-testkey456");
+    expect(h["x-api-key"]).toBe("sk-ant-api03-testkey456");
+    expect(h.authorization).toBeUndefined();
+    expect(h["anthropic-beta"]).toBeUndefined();
+    expect(h["anthropic-version"]).toBe("2023-06-01");
   });
 });
 

--- a/src/core/model-discovery.ts
+++ b/src/core/model-discovery.ts
@@ -56,11 +56,26 @@ const ANTHROPIC: ProviderSpec = {
   id: "anthropic",
   label: "Anthropic",
   endpoint: "https://api.anthropic.com/v1/models",
-  headers: (apiKey) => ({
-    "x-api-key": apiKey,
-    "anthropic-version": "2023-06-01",
-    "content-type": "application/json",
-  }),
+  headers: (apiKey) => {
+    // OAuth access tokens (sk-ant-oat01-*) use Authorization: Bearer
+    // + the oauth beta header. Real API keys (sk-ant-api03-*) use
+    // x-api-key. Detecting by prefix matches what request-builder.ts
+    // does for the /v1/messages endpoint.
+    if (apiKey.startsWith("sk-ant-oat01-")) {
+      return {
+        authorization: `Bearer ${apiKey}`,
+        "anthropic-beta": "oauth-2025-04-20",
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+        "x-app": "cli",
+      };
+    }
+    return {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+    };
+  },
   parse: parseDataIdArray,
   provider: "anthropic",
   baseUrl: "https://api.anthropic.com",
@@ -260,14 +275,47 @@ export async function discoverFromProvider(
 }
 
 /**
- * Figure out which API key to use for each provider. Reads from
- * environment variables first (standard names), then falls back to
- * a generic KCODE_API_KEY. Returns a map of provider id → key.
- * Providers without a key are omitted from the map.
+ * Figure out which credential to use for each provider, in priority:
+ *   1. KCode OAuth session (keychain-stored access token)
+ *   2. Standard env var API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, ...)
+ *   3. KCODE_-prefixed env var fallback
+ *
+ * Returns a map of provider id → credential. Providers with no
+ * credential at all are omitted. The credential may be either an
+ * OAuth bearer token or an API key — the per-provider `headers`
+ * function in ProviderSpec handles the distinction.
  */
-export function collectProviderKeys(): Map<string, string> {
+export async function collectProviderKeys(): Promise<Map<string, string>> {
   const keys = new Map<string, string>();
+
+  // Try OAuth sessions first. If the user ran `/auth` to log in to
+  // Anthropic or OpenAI via browser, we have an access token in the
+  // keychain and don't need an API key.
+  try {
+    const { getAuthSessionManager } = await import("./auth/session.js");
+    const { resolveProviderConfig } = await import("./auth/oauth-flow.js");
+    const manager = getAuthSessionManager();
+    for (const oauthProvider of ["anthropic", "openai"]) {
+      try {
+        const cfg = resolveProviderConfig(oauthProvider);
+        const token = await manager.getAccessToken(
+          oauthProvider,
+          cfg ?? undefined,
+        );
+        if (token) {
+          keys.set(oauthProvider, token);
+          log.debug("model-discovery", `using OAuth token for ${oauthProvider}`);
+        }
+      } catch {
+        // Provider not configured for OAuth — fall through to env vars
+      }
+    }
+  } catch {
+    // Auth module not available — skip OAuth, use env vars only
+  }
+
   const pick = (id: string, envs: string[]): void => {
+    if (keys.has(id)) return; // OAuth already set it
     for (const env of envs) {
       const v = process.env[env];
       if (v && v.length > 0) {
@@ -293,7 +341,7 @@ export async function runModelDiscovery(opts?: {
   providerFilter?: string[];
   apiKeys?: Map<string, string>;
 }): Promise<DiscoveryResult[]> {
-  const keys = opts?.apiKeys ?? collectProviderKeys();
+  const keys = opts?.apiKeys ?? (await collectProviderKeys());
   const config = await loadModelsConfig();
   const results: DiscoveryResult[] = [];
   let anyAdded = false;


### PR DESCRIPTION
## Summary
\`kcode models discover\` only read credentials from env vars. Users logged in via \`/auth\` (OAuth PKCE, subscriber-tier) had no \`ANTHROPIC_API_KEY\` set and got \"no API key configured\" even with valid credentials.

## Fix
1. \`collectProviderKeys()\` is now async and checks OAuth sessions first (via \`getAuthSessionManager().getAccessToken()\`) before falling back to env vars.
2. Anthropic \`ProviderSpec.headers()\` auto-switches based on token prefix:
   - \`sk-ant-oat01-*\` (OAuth) → \`Authorization: Bearer\` + \`anthropic-beta: oauth-2025-04-20\`
   - \`sk-ant-api03-*\` (API key) → \`x-api-key\`

Mirrors the same auth pattern \`request-builder.ts\` uses for \`/v1/messages\`.

## Test plan
- [x] 25/25 tests (2 new header-switching tests + updated async collectProviderKeys)
- [x] v2.10.92 deployed

After pulling, OAuth users can run:
\`\`\`
kcode models discover --provider anthropic
\`\`\`
And Opus 4.7 (plus any future Anthropic model) will be registered automatically.

Co-Authored-By: Kulvex Code <contact@astrolexis.space>