### PR TITLE
feat: auto-discover models at TUI startup (throttled) + v2.10.93

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.92",
+  "version": "2.10.93",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/model-discovery.test.ts
+++ b/src/core/model-discovery.test.ts
@@ -6,7 +6,7 @@
 // orchestrator.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -16,6 +16,7 @@ import {
   discoverFromProvider,
   fetchProviderModels,
   guessContextSize,
+  maybeAutoDiscover,
   runModelDiscovery,
 } from "./model-discovery";
 import { _setModelsPathForTest, type ModelsConfig } from "./models";
@@ -331,5 +332,88 @@ describe("runModelDiscovery", () => {
     });
     expect(results).toHaveLength(1);
     expect(results[0]!.provider).toBe("anthropic");
+  });
+});
+
+// ─── maybeAutoDiscover (throttle) ──────────────────────────────
+
+describe("maybeAutoDiscover throttle", () => {
+  test("skips when last run was recent (within interval)", async () => {
+    // Pre-seed the discovery-state file with a very recent timestamp
+    const statePath = join(testHome, "discovery-state.json");
+    writeFileSync(
+      statePath,
+      JSON.stringify({ lastRunAt: Date.now() - 1000 }), // 1s ago
+      "utf-8",
+    );
+    writeFileSync(testModelsPath, JSON.stringify({ models: [] }), "utf-8");
+
+    // Fetch should NOT be called since we're within the interval
+    let fetchCalls = 0;
+    globalThis.fetch = async () => {
+      fetchCalls++;
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    };
+
+    const added = await maybeAutoDiscover({ minIntervalMs: 60_000 });
+    expect(added).toEqual([]);
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("runs when no previous state exists", async () => {
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    writeFileSync(testModelsPath, JSON.stringify({ models: [] }), "utf-8");
+
+    globalThis.fetch = async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("anthropic.com")) {
+        return new Response(
+          JSON.stringify({ data: [{ id: "claude-opus-4-7" }] }),
+          { status: 200 },
+        );
+      }
+      return new Response("not mocked", { status: 404 });
+    };
+
+    const added = await maybeAutoDiscover();
+    expect(added).toContain("claude-opus-4-7");
+
+    // State file should have been created with a fresh timestamp
+    const statePath = join(testHome, "discovery-state.json");
+    expect(existsSync(statePath)).toBe(true);
+    const state = JSON.parse(readFileSync(statePath, "utf-8"));
+    expect(state.lastRunAt).toBeGreaterThan(Date.now() - 10_000);
+  });
+
+  test("force=true bypasses the throttle", async () => {
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    writeFileSync(testModelsPath, JSON.stringify({ models: [] }), "utf-8");
+    const statePath = join(testHome, "discovery-state.json");
+    writeFileSync(
+      statePath,
+      JSON.stringify({ lastRunAt: Date.now() - 1000 }), // 1s ago — would normally skip
+      "utf-8",
+    );
+
+    let fetchCalls = 0;
+    globalThis.fetch = async () => {
+      fetchCalls++;
+      return new Response(JSON.stringify({ data: [{ id: "fresh-model" }] }), { status: 200 });
+    };
+
+    const added = await maybeAutoDiscover({ force: true });
+    expect(fetchCalls).toBeGreaterThan(0); // at least one provider queried
+    expect(added).toContain("fresh-model");
+  });
+
+  test("network failure returns empty array instead of throwing", async () => {
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    writeFileSync(testModelsPath, JSON.stringify({ models: [] }), "utf-8");
+    globalThis.fetch = async () => {
+      throw new Error("network down");
+    };
+    // Should not throw
+    const added = await maybeAutoDiscover({ force: true });
+    expect(added).toEqual([]);
   });
 });

--- a/src/core/model-discovery.ts
+++ b/src/core/model-discovery.ts
@@ -21,9 +21,11 @@
 // TODO — Gemini uses https://generativelanguage.googleapis.com with
 // a ?key=KEY auth instead of bearer tokens.
 
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { log } from "./logger";
 import type { ModelEntry, ModelsConfig } from "./models";
 import { loadModelsConfig, saveModelsConfig } from "./models";
+import { kcodePath } from "./paths";
 
 // ─── Provider adapters ──────────────────────────────────────────
 
@@ -372,4 +374,92 @@ export async function runModelDiscovery(opts?: {
   }
 
   return results;
+}
+
+// ─── Throttle state ─────────────────────────────────────────────
+//
+// Auto-discovery runs at TUI mount, but we don't want every single
+// `kcode` invocation hammering 5 provider APIs every time. Record
+// the last-run timestamp and skip if < MIN_INTERVAL_MS has passed.
+//
+// Storage: ~/.kcode/discovery-state.json — tiny JSON blob kept
+// separate from models.json so discovery bookkeeping doesn't clutter
+// the model registry shape.
+
+const DISCOVERY_STATE_FILE = "discovery-state.json";
+const DEFAULT_MIN_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+interface DiscoveryState {
+  lastRunAt: number;
+}
+
+function readDiscoveryState(): DiscoveryState | null {
+  try {
+    const path = kcodePath(DISCOVERY_STATE_FILE);
+    if (!existsSync(path)) return null;
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.lastRunAt === "number") return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeDiscoveryState(state: DiscoveryState): void {
+  try {
+    writeFileSync(
+      kcodePath(DISCOVERY_STATE_FILE),
+      JSON.stringify(state, null, 2),
+      "utf-8",
+    );
+  } catch {
+    // Non-fatal: next run will just re-run discovery.
+  }
+}
+
+/**
+ * Auto-discovery hook for the TUI. Fires in the background at mount.
+ * Skips the actual API calls if we ran discovery recently (default:
+ * within the last 6 hours) so opening kcode 20 times in one session
+ * doesn't make 100 API requests.
+ *
+ * Returns a promise that resolves with the list of newly-added model
+ * IDs (empty array if throttled or nothing new). Never throws — any
+ * failure is swallowed so the TUI can't be held up by network issues.
+ */
+export async function maybeAutoDiscover(opts?: {
+  /** Override the minimum interval between runs. Used by tests. */
+  minIntervalMs?: number;
+  /** Force-run ignoring the throttle. */
+  force?: boolean;
+}): Promise<string[]> {
+  const minInterval = opts?.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
+  try {
+    if (!opts?.force) {
+      const state = readDiscoveryState();
+      if (state && Date.now() - state.lastRunAt < minInterval) {
+        log.debug(
+          "model-discovery",
+          `skipped (last run ${Math.round((Date.now() - state.lastRunAt) / 60000)}m ago)`,
+        );
+        return [];
+      }
+    }
+
+    const results = await runModelDiscovery();
+    writeDiscoveryState({ lastRunAt: Date.now() });
+
+    const added = results.flatMap((r) => r.added);
+    if (added.length > 0) {
+      log.info(
+        "model-discovery",
+        `auto-discovered ${added.length} new model(s): ${added.slice(0, 5).join(", ")}${added.length > 5 ? ", ..." : ""}`,
+      );
+    }
+    return added;
+  } catch (err) {
+    log.debug("model-discovery", `auto-discovery failed: ${err}`);
+    return [];
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,30 +383,10 @@ registerDashboardCommand(program);
 registerTemplateCommand(program);
 registerWebCommand(program);
 
-// ─── Optional background model discovery ────────────────────────
-//
-// Opt-in via KCODE_AUTO_DISCOVER_MODELS=1. Runs discovery in the
-// background so it can't slow startup — failures and results just
-// get logged. Useful for "Opus 4.7 just shipped, I want it without
-// running `kcode models discover` every time."
-if (process.env.KCODE_AUTO_DISCOVER_MODELS === "1") {
-  void (async () => {
-    try {
-      const { runModelDiscovery } = await import("./core/model-discovery");
-      const results = await runModelDiscovery();
-      const added = results.flatMap((r) => r.added);
-      if (added.length > 0) {
-        const { log } = await import("./core/logger");
-        log.info(
-          "model-discovery",
-          `auto-discovered ${added.length} new model(s): ${added.slice(0, 5).join(", ")}${added.length > 5 ? ", ..." : ""}`,
-        );
-      }
-    } catch {
-      // Best-effort — never break startup.
-    }
-  })();
-}
+// Note: model auto-discovery now lives in src/ui/App.tsx (fires at
+// TUI mount with a throttle) instead of here, so non-TUI CLI
+// subcommands (kcode build, kcode status, etc.) don't make API
+// calls they don't need.
 
 // ─── Parse ──────────────────────────────────────────────────────
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -55,6 +55,23 @@ export default function App({ config, conversationManager, tools, initialSession
     return sm;
   });
 
+  // Auto-discover new cloud models on TUI startup. Fires in the
+  // background so it never blocks the UI mount — a 6-hour throttle
+  // inside maybeAutoDiscover prevents hammering provider APIs across
+  // back-to-back kcode launches. New models (e.g. Opus 4.7 the day it
+  // ships) land in ~/.kcode/models.json and become available in the
+  // `/model` switcher after the next kcode restart.
+  useEffect(() => {
+    void (async () => {
+      try {
+        const { maybeAutoDiscover } = await import("../core/model-discovery.js");
+        await maybeAutoDiscover();
+      } catch {
+        // Best-effort: never surface discovery failures to the user.
+      }
+    })();
+  }, []);
+
   // Build completions list from skills (slash commands + aliases)
   // Uses a Set to guarantee no duplicates regardless of source
   const [slashCompletions] = useState(() => {


### PR DESCRIPTION
## Summary
Auto-discovery now fires every time the TUI starts, with a 6-hour throttle so back-to-back kcode launches don't spam provider APIs. When Opus 4.7 (or any future cloud model) ships, kcode picks it up automatically — no manual command, no env var opt-in.

## Changes
1. **\`maybeAutoDiscover()\`** in \`model-discovery.ts\`: reads \`~/.kcode/discovery-state.json\` for last-run timestamp, skips if within 6h, otherwise runs discovery and updates state. Never throws — network failures swallowed.
2. **\`App.tsx\` useEffect at mount**: fire-and-forget call. No blocking, no spinner.
3. **Removed** \`KCODE_AUTO_DISCOVER_MODELS=1\` opt-in from \`src/index.ts\`. Non-TUI subcommands (\`kcode build\`, etc.) no longer hit APIs they don't need.

## User flow
- User runs \`kcode\` → TUI mounts → background discovery fires (if throttle allows)
- New models land in \`~/.kcode/models.json\`
- User sees them after next restart (useState initializers are frozen at mount — mid-session additions not shown, acceptable since users restart frequently)
- \`kcode models discover\` still works for manual force-refresh

## Test plan
- [x] 29/29 tests including throttle skip/run/force/network-failure cases
- [x] v2.10.93 binary deployed

Co-Authored-By: Kulvex Code <contact@astrolexis.space>