### PR TITLE
fix: discovery reads API keys from ~/.kcode/settings.json + v2.10.95

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.94",
+  "version": "2.10.95",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/model-discovery.test.ts
+++ b/src/core/model-discovery.test.ts
@@ -261,6 +261,32 @@ describe("collectProviderKeys", () => {
     expect(keys.has("anthropic")).toBe(false);
     expect(keys.has("openai")).toBe(false);
   });
+
+  test("falls back to settings.json keys (the /cloud flow stores them here)", async () => {
+    // Simulate a user who ran /cloud and has anthropicApiKey saved
+    // in ~/.kcode/settings.json but no env var exported.
+    writeFileSync(
+      join(testHome, "settings.json"),
+      JSON.stringify({
+        anthropicApiKey: "sk-ant-api03-from-settings",
+        xaiApiKey: "xai-some-key",
+      }),
+      "utf-8",
+    );
+    const keys = await collectProviderKeys();
+    expect(keys.get("anthropic")).toBe("sk-ant-api03-from-settings");
+  });
+
+  test("env var wins over settings.json when both are present", async () => {
+    process.env.ANTHROPIC_API_KEY = "env-wins";
+    writeFileSync(
+      join(testHome, "settings.json"),
+      JSON.stringify({ anthropicApiKey: "settings-loses" }),
+      "utf-8",
+    );
+    const keys = await collectProviderKeys();
+    expect(keys.get("anthropic")).toBe("env-wins");
+  });
 });
 
 describe("Anthropic headers auto-switch on OAuth vs API key", () => {

--- a/src/core/model-discovery.ts
+++ b/src/core/model-discovery.ts
@@ -331,6 +331,34 @@ export async function collectProviderKeys(): Promise<Map<string, string>> {
   pick("groq", ["GROQ_API_KEY", "KCODE_GROQ_API_KEY"]);
   pick("deepseek", ["DEEPSEEK_API_KEY", "KCODE_DEEPSEEK_API_KEY"]);
   pick("together", ["TOGETHER_API_KEY", "TOGETHER_AI_API_KEY", "KCODE_TOGETHER_API_KEY"]);
+
+  // Final fallback: keys stored in ~/.kcode/settings.json. The /cloud
+  // command saves API keys here (anthropicApiKey, xaiApiKey, etc.)
+  // instead of env vars, so users who configured via /cloud need this
+  // fallback or discovery will wrongly report "no API key configured".
+  try {
+    const settingsPath = kcodePath("settings.json");
+    if (existsSync(settingsPath)) {
+      const raw = readFileSync(settingsPath, "utf-8");
+      const settings = JSON.parse(raw);
+      const fallback = (id: string, field: string): void => {
+        if (keys.has(id)) return;
+        const v = settings[field];
+        if (typeof v === "string" && v.length > 0) {
+          keys.set(id, v);
+          log.debug("model-discovery", `using settings.${field} for ${id}`);
+        }
+      };
+      fallback("anthropic", "anthropicApiKey");
+      fallback("openai", "openaiApiKey");
+      fallback("groq", "groqApiKey");
+      fallback("deepseek", "deepseekApiKey");
+      fallback("together", "togetherApiKey");
+    }
+  } catch {
+    // settings.json unreadable or malformed — skip, not fatal
+  }
+
   return keys;
 }
 


### PR DESCRIPTION
## Root cause of Opus 4.7 not showing up
\`collectProviderKeys\` only checked OAuth sessions and env vars. Users who configured providers via \`/cloud\` had their keys saved in \`~/.kcode/settings.json\` under \`anthropicApiKey\`, etc. Discovery reported \"no API key configured\" despite the user being fully authenticated.

## Fix
Added a final fallback that reads \`~/.kcode/settings.json\` and picks up \`anthropicApiKey\` / \`openaiApiKey\` / \`groqApiKey\` / \`deepseekApiKey\` / \`togetherApiKey\` if no env var is set.

Priority chain:
1. KCode OAuth session (keychain, /auth flow)
2. Env var (ANTHROPIC_API_KEY, etc.)
3. **settings.json (NEW — /cloud flow)**

## Live verification
Tested on dev machine with Anthropic key in settings.json, no env var, no OAuth:
\`\`\`
$ kcode models discover --provider anthropic
  anthropic  — +8 new:
      claude-opus-4-7
      claude-opus-4-5-20251101
      claude-haiku-4-5-20251001
      claude-sonnet-4-5-20250929
      claude-opus-4-1-20250805
      claude-opus-4-20250514
      claude-sonnet-4-20250514
      claude-3-haiku-20240307
\`\`\`

## Test plan
- [x] 31/31 tests including 2 new (settings.json fallback + env-wins priority)
- [x] v2.10.95 deployed
- [x] Live run picked up Opus 4.7

Co-Authored-By: Kulvex Code <contact@astrolexis.space>