### PR TITLE
fix: external server health check accepts 401/404 + v2.10.96

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.95",
+  "version": "2.10.96",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -546,7 +546,14 @@ async function runMain(
               const resp = await fetch(`${externalServerUrl}${endpoint}`, {
                 signal: AbortSignal.timeout(2000),
               });
-              if (resp.ok) {
+              // Any HTTP response means the server is reachable — even
+              // 401/403/404. Cloud providers (Anthropic, OpenAI) require
+              // auth on /v1/models so they return 401, and their root /
+              // returns 404. Only a true network failure (timeout,
+              // ECONNREFUSED) means "not reachable". The original
+              // resp.ok check flagged Anthropic as unreachable despite
+              // the API being perfectly up.
+              if (resp.status < 500) {
                 ready = true;
                 break;
               }


### PR DESCRIPTION
## Problem
Startup health check probed \`/ready\`, \`/health\`, \`/v1/models\` with \`resp.ok\` (200-299). Anthropic returns:
- /ready → 404
- /health → 404
- /v1/models → 401 (auth required)

All failed resp.ok despite the API being fully reachable. kcode aborted after 15s with \"External server not reachable\".

## Fix
Treat any \`status < 500\` as \"server reachable\". Only timeout/ECONNREFUSED/DNS failures are true unreachability.

Found while debugging Anthropic latency — \`kcode --print --model claude-opus-4-7\` was failing on fresh runs.

## Test plan
- [x] v2.10.96 deployed
- [x] \`kcode --print --model claude-opus-4-7 "hola"\` now reaches the API (no more \"not reachable\")

Co-Authored-By: Kulvex Code <contact@astrolexis.space>