### PR TITLE
feat: cloud-first setup for weak hardware + v2.10.97

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.96",
+  "version": "2.10.97",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/cloud-setup.ts
+++ b/src/core/cloud-setup.ts
@@ -1,0 +1,339 @@
+// KCode — Cloud-First Setup Flow
+//
+// Invoked by the setup wizard when hardware tier is weak/unusable.
+// Detects any existing cloud credentials (settings.json, env vars,
+// OAuth sessions) and either confirms them or walks the user through
+// picking a provider.
+//
+// Design: this is a plain-text CLI flow (readline), not a TUI — the
+// setup wizard runs outside the Ink renderer.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { createInterface } from "node:readline";
+import { log } from "./logger";
+import { kcodePath } from "./paths";
+
+// ─── Provider catalog ───────────────────────────────────────────
+
+interface CloudProviderOption {
+  id: string;
+  label: string;
+  /** Where to get an API key — a URL the user can visit. */
+  signupUrl: string;
+  /** Field name in ~/.kcode/settings.json for the API key. */
+  settingsField: string;
+  /** Environment variable alternative. */
+  envVar: string;
+  /** Short cost note shown to the user. */
+  costNote: string;
+  /** Whether this provider supports OAuth via /auth. */
+  supportsOAuth: boolean;
+  /** Suggested default model IDs for this provider. */
+  suggestedModels: string[];
+}
+
+const PROVIDERS: CloudProviderOption[] = [
+  {
+    id: "anthropic",
+    label: "Anthropic (Claude — highest quality, subscriber flat-rate or pay-per-token)",
+    signupUrl: "https://console.anthropic.com/settings/keys",
+    settingsField: "anthropicApiKey",
+    envVar: "ANTHROPIC_API_KEY",
+    costNote: "$3/MTok in, $15/MTok out for Sonnet; $15/$75 for Opus. Or $20/mo Pro for 5× usage.",
+    supportsOAuth: true,
+    suggestedModels: ["claude-sonnet-4-6", "claude-opus-4-7", "claude-haiku-4-5"],
+  },
+  {
+    id: "openai",
+    label: "OpenAI (GPT-4o, o3 — strong reasoning)",
+    signupUrl: "https://platform.openai.com/api-keys",
+    settingsField: "openaiApiKey",
+    envVar: "OPENAI_API_KEY",
+    costNote: "$2.50/MTok in, $10/MTok out for GPT-4o. o3 is ~3× pricier.",
+    supportsOAuth: true,
+    suggestedModels: ["gpt-4o", "o3-mini"],
+  },
+  {
+    id: "groq",
+    label: "Groq (fastest inference, Llama/Qwen models — very cheap)",
+    signupUrl: "https://console.groq.com/keys",
+    settingsField: "groqApiKey",
+    envVar: "GROQ_API_KEY",
+    costNote: "$0.59-$0.79/MTok. Fastest tokens/sec in the industry (~500 tok/s).",
+    supportsOAuth: false,
+    suggestedModels: ["llama-3.3-70b-versatile", "llama-3.1-70b-versatile"],
+  },
+  {
+    id: "deepseek",
+    label: "DeepSeek (strong coding, very cheap)",
+    signupUrl: "https://platform.deepseek.com/api_keys",
+    settingsField: "deepseekApiKey",
+    envVar: "DEEPSEEK_API_KEY",
+    costNote: "$0.14/MTok in, $0.28/MTok out. Best price/perf for coding.",
+    supportsOAuth: false,
+    suggestedModels: ["deepseek-r1", "deepseek-v3", "deepseek-coder-v2"],
+  },
+  {
+    id: "together",
+    label: "Together AI (many open models, competitive pricing)",
+    signupUrl: "https://api.together.xyz/settings/api-keys",
+    settingsField: "togetherApiKey",
+    envVar: "TOGETHER_API_KEY",
+    costNote: "Varies by model. Most 70B models at ~$0.88/MTok.",
+    supportsOAuth: false,
+    suggestedModels: ["meta-llama/Llama-3.3-70B-Instruct-Turbo"],
+  },
+];
+
+// ─── Credential detection ───────────────────────────────────────
+
+export interface DetectedCredential {
+  providerId: string;
+  source: "settings" | "env" | "oauth";
+  /** Brief description shown to the user; never the key itself. */
+  summary: string;
+}
+
+/**
+ * Look in all the usual places for pre-configured credentials.
+ * Returns every provider that has at least one usable credential so
+ * the wizard can ask "use detected X?" instead of asking for a key.
+ */
+export async function detectExistingCredentials(): Promise<DetectedCredential[]> {
+  const detected: DetectedCredential[] = [];
+
+  // settings.json
+  try {
+    const settingsPath = kcodePath("settings.json");
+    if (existsSync(settingsPath)) {
+      const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+      for (const p of PROVIDERS) {
+        const key = settings[p.settingsField];
+        if (typeof key === "string" && key.length > 0) {
+          detected.push({
+            providerId: p.id,
+            source: "settings",
+            summary: `${p.label.split(" (")[0]} — key in ~/.kcode/settings.json`,
+          });
+        }
+      }
+    }
+  } catch {
+    /* malformed settings — skip */
+  }
+
+  // Env vars
+  for (const p of PROVIDERS) {
+    // Don't double-count if already detected via settings
+    if (detected.some((d) => d.providerId === p.id)) continue;
+    const v = process.env[p.envVar];
+    if (v && v.length > 0) {
+      detected.push({
+        providerId: p.id,
+        source: "env",
+        summary: `${p.label.split(" (")[0]} — key in $${p.envVar}`,
+      });
+    }
+  }
+
+  // OAuth sessions
+  try {
+    const { getAuthSessionManager } = await import("./auth/session.js");
+    const { resolveProviderConfig } = await import("./auth/oauth-flow.js");
+    const manager = getAuthSessionManager();
+    for (const p of PROVIDERS) {
+      if (!p.supportsOAuth) continue;
+      if (detected.some((d) => d.providerId === p.id)) continue;
+      try {
+        const cfg = resolveProviderConfig(p.id);
+        const token = await manager.getAccessToken(p.id, cfg ?? undefined);
+        if (token) {
+          detected.push({
+            providerId: p.id,
+            source: "oauth",
+            summary: `${p.label.split(" (")[0]} — OAuth session via /auth`,
+          });
+        }
+      } catch {
+        /* provider not OAuth-configured — skip */
+      }
+    }
+  } catch {
+    /* auth module missing — skip */
+  }
+
+  return detected;
+}
+
+// ─── CLI prompts ────────────────────────────────────────────────
+
+function prompt(question: string): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function confirm(question: string, defaultYes: boolean = true): Promise<boolean> {
+  const suffix = defaultYes ? " [Y/n]: " : " [y/N]: ";
+  const answer = (await prompt(question + suffix)).toLowerCase();
+  if (!answer) return defaultYes;
+  return answer.startsWith("y") || answer === "s" || answer === "si";
+}
+
+// ─── Public entry point ─────────────────────────────────────────
+
+export interface CloudSetupResult {
+  /** Provider ID the user configured (or picked from existing). */
+  providerId: string;
+  /** Model to use as the default. */
+  defaultModel: string;
+  /** Whether setup modified ~/.kcode/settings.json. */
+  settingsUpdated: boolean;
+  /** If set, user opted out entirely — caller should fall back to local. */
+  declined?: boolean;
+}
+
+/**
+ * Walk the user through picking / confirming a cloud provider. Writes
+ * the resulting API key to ~/.kcode/settings.json if they provide one,
+ * and returns the chosen provider + default model.
+ *
+ * If the user declines cloud entirely, returns `{ declined: true }`
+ * so the caller can fall back to local (or exit with a clear message).
+ */
+export async function runCloudSetup(opts?: {
+  tierReason?: string;
+}): Promise<CloudSetupResult> {
+  console.log();
+  console.log("\x1b[1m\x1b[36m   Cloud provider setup\x1b[0m");
+  console.log();
+  if (opts?.tierReason) {
+    console.log(`   \x1b[2m${opts.tierReason}\x1b[0m`);
+    console.log(
+      `   \x1b[2mCloud inference is recommended for your hardware. Setting it up now.\x1b[0m`,
+    );
+    console.log();
+  }
+
+  const existing = await detectExistingCredentials();
+
+  // Fast path: user already has credentials configured somewhere
+  if (existing.length > 0) {
+    console.log("   \x1b[32m✓\x1b[0m Detected existing credentials:");
+    existing.forEach((d, i) => console.log(`     ${i + 1}. ${d.summary}`));
+    console.log();
+    const useExisting = await confirm(
+      `   Use existing credentials${existing.length === 1 ? ` (${existing[0]!.providerId})` : ""}?`,
+      true,
+    );
+    if (useExisting) {
+      // If multiple, let user pick
+      let chosen = existing[0]!;
+      if (existing.length > 1) {
+        const pick = await prompt(`   Which one? (1-${existing.length}): `);
+        const idx = parseInt(pick, 10) - 1;
+        if (!Number.isNaN(idx) && idx >= 0 && idx < existing.length) {
+          chosen = existing[idx]!;
+        }
+      }
+      const providerSpec = PROVIDERS.find((p) => p.id === chosen.providerId)!;
+      return {
+        providerId: chosen.providerId,
+        defaultModel: providerSpec.suggestedModels[0]!,
+        settingsUpdated: false,
+      };
+    }
+  }
+
+  // Full path: pick a provider from scratch
+  console.log("   Available cloud providers:");
+  console.log();
+  PROVIDERS.forEach((p, i) => {
+    console.log(`     ${i + 1}. ${p.label}`);
+    console.log(`        \x1b[2m${p.costNote}\x1b[0m`);
+  });
+  console.log(`     ${PROVIDERS.length + 1}. Skip cloud setup (local only)`);
+  console.log();
+
+  const pick = await prompt(`   Pick a provider [1-${PROVIDERS.length + 1}]: `);
+  const idx = parseInt(pick, 10) - 1;
+
+  if (idx === PROVIDERS.length) {
+    return {
+      providerId: "",
+      defaultModel: "",
+      settingsUpdated: false,
+      declined: true,
+    };
+  }
+
+  if (Number.isNaN(idx) || idx < 0 || idx >= PROVIDERS.length) {
+    console.log("   \x1b[31m✗\x1b[0m Invalid choice, skipping cloud setup.");
+    return {
+      providerId: "",
+      defaultModel: "",
+      settingsUpdated: false,
+      declined: true,
+    };
+  }
+
+  const spec = PROVIDERS[idx]!;
+  console.log();
+  console.log(`   Selected: \x1b[1m${spec.label}\x1b[0m`);
+  console.log(`   Get an API key from: \x1b[36m${spec.signupUrl}\x1b[0m`);
+  console.log();
+
+  // OAuth hint for supported providers
+  if (spec.supportsOAuth) {
+    console.log(
+      `   \x1b[2mTip: you can also log in via browser with \`kcode auth login ${spec.id}\` after setup.\x1b[0m`,
+    );
+    console.log();
+  }
+
+  const apiKey = await prompt("   Paste your API key (or leave blank to skip): ");
+  if (!apiKey) {
+    console.log("   \x1b[33m!\x1b[0m No key entered — you can run `kcode auth login` later.");
+    return {
+      providerId: spec.id,
+      defaultModel: spec.suggestedModels[0]!,
+      settingsUpdated: false,
+    };
+  }
+
+  // Write to settings.json
+  const settingsPath = kcodePath("settings.json");
+  let settings: Record<string, unknown> = {};
+  try {
+    if (existsSync(settingsPath)) {
+      settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    }
+  } catch {
+    /* start fresh */
+  }
+  settings[spec.settingsField] = apiKey;
+  try {
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+    console.log(
+      `   \x1b[32m✓\x1b[0m Saved ${spec.settingsField} to ~/.kcode/settings.json`,
+    );
+  } catch (err) {
+    log.warn("cloud-setup", `failed to write settings.json: ${err}`);
+  }
+
+  return {
+    providerId: spec.id,
+    defaultModel: spec.suggestedModels[0]!,
+    settingsUpdated: true,
+  };
+}
+
+// ─── Export for wizard consumption ──────────────────────────────
+
+export { PROVIDERS as CLOUD_PROVIDER_OPTIONS };

--- a/src/core/hardware-tier.test.ts
+++ b/src/core/hardware-tier.test.ts
@@ -1,0 +1,105 @@
+// Hardware tier classification tests.
+
+import { describe, expect, test } from "bun:test";
+import type { HardwareInfo } from "./hardware";
+import { classifyHardware, tierLabel } from "./hardware-tier";
+
+function hw(overrides: Partial<HardwareInfo>): HardwareInfo {
+  return {
+    platform: "linux",
+    arch: "x64",
+    ramMB: 16 * 1024,
+    totalVramMB: 0,
+    gpus: [],
+    gpuName: null,
+    gpuDriver: null,
+    cpuModel: "Test CPU",
+    cpuCores: 8,
+    ...overrides,
+  } as HardwareInfo;
+}
+
+describe("classifyHardware — discrete GPU", () => {
+  test("24GB VRAM = strong", () => {
+    const r = classifyHardware(hw({ totalVramMB: 24 * 1024 }));
+    expect(r.tier).toBe("strong");
+    expect(r.primary).toBe("local");
+  });
+
+  test("16GB VRAM = medium", () => {
+    const r = classifyHardware(hw({ totalVramMB: 16 * 1024 }));
+    expect(r.tier).toBe("medium");
+    expect(r.primary).toBe("local");
+  });
+
+  test("6GB VRAM = weak (cloud-first)", () => {
+    const r = classifyHardware(hw({ totalVramMB: 6 * 1024 }));
+    expect(r.tier).toBe("weak");
+    expect(r.primary).toBe("cloud");
+  });
+
+  test("dual GPU (8+16=24GB) = strong", () => {
+    const r = classifyHardware(hw({ totalVramMB: 24 * 1024 }));
+    expect(r.tier).toBe("strong");
+  });
+});
+
+describe("classifyHardware — Apple Silicon", () => {
+  test("M3 Max 64GB = strong", () => {
+    const r = classifyHardware(
+      hw({ platform: "darwin", arch: "arm64", ramMB: 64 * 1024 }),
+    );
+    expect(r.tier).toBe("strong");
+    expect(r.primary).toBe("local");
+    expect(r.reason).toContain("Apple Silicon");
+  });
+
+  test("M3 Pro 18GB = medium", () => {
+    const r = classifyHardware(
+      hw({ platform: "darwin", arch: "arm64", ramMB: 18 * 1024 }),
+    );
+    expect(r.tier).toBe("medium");
+    expect(r.primary).toBe("local");
+  });
+
+  test("M3 8GB = weak (cloud-first)", () => {
+    const r = classifyHardware(
+      hw({ platform: "darwin", arch: "arm64", ramMB: 8 * 1024 }),
+    );
+    expect(r.tier).toBe("weak");
+    expect(r.primary).toBe("cloud");
+  });
+});
+
+describe("classifyHardware — CPU only", () => {
+  test("No GPU, 16GB RAM (canonical Fedora case) = weak cloud-first", () => {
+    const r = classifyHardware(hw({ totalVramMB: 0, ramMB: 16 * 1024 }));
+    expect(r.tier).toBe("weak");
+    expect(r.primary).toBe("cloud");
+    expect(r.offerAlternative).toBe(true);
+    expect(r.reason).toContain("16GB RAM");
+  });
+
+  test("No GPU, 8GB RAM = unusable", () => {
+    const r = classifyHardware(hw({ totalVramMB: 0, ramMB: 8 * 1024 }));
+    expect(r.tier).toBe("unusable");
+    expect(r.primary).toBe("cloud");
+    expect(r.offerAlternative).toBe(false);
+  });
+
+  test("No GPU, 64GB RAM = weak but viable", () => {
+    const r = classifyHardware(hw({ totalVramMB: 0, ramMB: 64 * 1024 }));
+    expect(r.tier).toBe("weak");
+    expect(r.primary).toBe("cloud");
+    expect(r.offerAlternative).toBe(true);
+  });
+});
+
+describe("tierLabel", () => {
+  test("returns human-readable labels", () => {
+    expect(tierLabel("strong")).toContain("local-first");
+    expect(tierLabel("medium")).toContain("balanced");
+    expect(tierLabel("weak")).toContain("cloud-first");
+    expect(tierLabel("unusable")).toContain("cloud-only");
+  });
+});

--- a/src/core/hardware-tier.ts
+++ b/src/core/hardware-tier.ts
@@ -1,0 +1,136 @@
+// KCode — Hardware Tier Classification
+//
+// Classifies a user's hardware into one of four tiers so the setup
+// wizard can pick the right flow:
+//
+//   strong    → local-first with the largest viable model
+//   medium    → local-first with a balanced model + "or use cloud"
+//   weak      → cloud-first; local only as a small-model fallback
+//   unusable  → cloud-only; no viable local option
+//
+// Motivation: the v2.10.96 wizard assumed local is always the right
+// answer and tried to download an 18GB model onto a Fedora box with
+// 16GB RAM and no GPU — which technically fits via mmap but runs at
+// ~1 token/sec. Better: detect hardware, and when the hardware can't
+// run local at usable speed, route straight to cloud providers.
+
+import type { HardwareInfo } from "./hardware";
+
+export type HardwareTier = "strong" | "medium" | "weak" | "unusable";
+
+export interface TierClassification {
+  tier: HardwareTier;
+  reason: string;
+  /** Suggested primary path: "local" or "cloud" */
+  primary: "local" | "cloud";
+  /** Whether the alternative path should be offered alongside the primary */
+  offerAlternative: boolean;
+}
+
+/**
+ * Classify a user's hardware into one of four tiers. Thresholds are
+ * tuned for usable speed (≥10 tok/s for common coding models) rather
+ * than "technically fits".
+ *
+ * Rules (checked in order):
+ *   1. Apple Silicon with unified memory gets a bonus — mlx models
+ *      run well on Apple GPU cores with relatively modest RAM.
+ *   2. Discrete GPU VRAM is the primary gate — ≥20GB = strong,
+ *      8-20GB = medium, <8GB = weak (CPU-only by necessity).
+ *   3. No GPU falls back to RAM — ≥32GB = weak (viable for 8B Q4),
+ *      16-32GB = weak (only 4B fits at speed), <12GB = unusable.
+ */
+export function classifyHardware(hw: HardwareInfo): TierClassification {
+  // Apple Silicon special case: unified memory + mlx
+  if (hw.platform === "darwin" && hw.arch === "arm64") {
+    if (hw.ramMB >= 32 * 1024) {
+      return {
+        tier: "strong",
+        reason: `Apple Silicon with ${Math.round(hw.ramMB / 1024)}GB unified memory`,
+        primary: "local",
+        offerAlternative: true,
+      };
+    }
+    if (hw.ramMB >= 16 * 1024) {
+      return {
+        tier: "medium",
+        reason: `Apple Silicon with ${Math.round(hw.ramMB / 1024)}GB unified memory (medium models)`,
+        primary: "local",
+        offerAlternative: true,
+      };
+    }
+    return {
+      tier: "weak",
+      reason: `Apple Silicon with only ${Math.round(hw.ramMB / 1024)}GB RAM`,
+      primary: "cloud",
+      offerAlternative: true,
+    };
+  }
+
+  // Discrete GPU tier
+  if (hw.totalVramMB > 0) {
+    const vramGB = hw.totalVramMB / 1024;
+    if (vramGB >= 20) {
+      return {
+        tier: "strong",
+        reason: `Discrete GPU with ${vramGB.toFixed(0)}GB VRAM`,
+        primary: "local",
+        offerAlternative: true,
+      };
+    }
+    if (vramGB >= 8) {
+      return {
+        tier: "medium",
+        reason: `Discrete GPU with ${vramGB.toFixed(0)}GB VRAM (medium models)`,
+        primary: "local",
+        offerAlternative: true,
+      };
+    }
+    return {
+      tier: "weak",
+      reason: `Discrete GPU with only ${vramGB.toFixed(1)}GB VRAM (small models only)`,
+      primary: "cloud",
+      offerAlternative: true,
+    };
+  }
+
+  // CPU-only — RAM tier
+  const ramGB = hw.ramMB / 1024;
+  if (ramGB < 12) {
+    return {
+      tier: "unusable",
+      reason: `No GPU and only ${ramGB.toFixed(0)}GB RAM — local inference not viable`,
+      primary: "cloud",
+      offerAlternative: false,
+    };
+  }
+  if (ramGB < 32) {
+    return {
+      tier: "weak",
+      reason: `No GPU, ${ramGB.toFixed(0)}GB RAM — only tiny models (4B) at usable speed`,
+      primary: "cloud",
+      offerAlternative: true, // local fallback with mark5-pico is OK
+    };
+  }
+  // >=32GB RAM CPU-only — still "weak" from a speed POV but at least viable
+  return {
+    tier: "weak",
+    reason: `No GPU, ${ramGB.toFixed(0)}GB RAM — 8B models run at moderate speed via CPU`,
+    primary: "cloud",
+    offerAlternative: true,
+  };
+}
+
+/** Human-readable label for a tier. Used in wizard output. */
+export function tierLabel(tier: HardwareTier): string {
+  switch (tier) {
+    case "strong":
+      return "Strong (local-first, large models)";
+    case "medium":
+      return "Medium (local-first, balanced models)";
+    case "weak":
+      return "Weak (cloud-first with local fallback)";
+    case "unusable":
+      return "Local not viable (cloud-only)";
+  }
+}

--- a/src/core/setup-wizard.ts
+++ b/src/core/setup-wizard.ts
@@ -193,6 +193,94 @@ export async function runSetup(options?: {
   console.log();
 
   // ═══════════════════════════════════════════════════════════════
+  //  Step 1b: Hardware Tier Check → Cloud-First for Weak Hardware
+  // ═══════════════════════════════════════════════════════════════
+  //
+  // If the user's hardware can't run local at usable speed, route
+  // straight to cloud setup instead of downloading a giant model
+  // that'll crawl at 1 tok/s. User can still pick local as a
+  // fallback inside runCloudSetup if they want.
+  //
+  // Skip this branch when:
+  //   - options.model is explicit (they know what they want)
+  //   - KCODE_FORCE_LOCAL env is set (escape hatch)
+
+  const forceLocal = process.env.KCODE_FORCE_LOCAL === "1";
+  if (!options?.model && !forceLocal) {
+    const { classifyHardware } = await import("./hardware-tier.js");
+    const tier = classifyHardware(hw);
+
+    if (tier.primary === "cloud") {
+      console.log(
+        `    ${C.yellow}⚡${C.reset} Hardware tier: ${C.bold}${tier.tier}${C.reset} — ${tier.reason}`,
+      );
+      console.log(`    ${C.dim}Local inference would be slow on this hardware. Routing to cloud setup.${C.reset}`);
+      console.log();
+
+      const { runCloudSetup } = await import("./cloud-setup.js");
+      const cloudResult = await runCloudSetup({ tierReason: tier.reason });
+
+      if (!cloudResult.declined) {
+        // Cloud path succeeded — record as default model and finish.
+        try {
+          const { addModel: addM, setDefaultModel: setDef } = await import("./models.js");
+          await addM({
+            name: cloudResult.defaultModel,
+            baseUrl:
+              cloudResult.providerId === "anthropic"
+                ? "https://api.anthropic.com"
+                : cloudResult.providerId === "openai"
+                  ? "https://api.openai.com"
+                  : cloudResult.providerId === "groq"
+                    ? "https://api.groq.com/openai"
+                    : cloudResult.providerId === "deepseek"
+                      ? "https://api.deepseek.com"
+                      : "https://api.together.xyz",
+            provider: cloudResult.providerId === "anthropic" ? "anthropic" : "openai",
+            description: `Configured via setup wizard (${new Date().toISOString().slice(0, 10)})`,
+          });
+          await setDef(cloudResult.defaultModel);
+        } catch (err) {
+          log.warn("setup", `failed to register cloud model: ${err}`);
+        }
+
+        // Mark setup complete
+        try {
+          const { writeFileSync, mkdirSync } = await import("node:fs");
+          const { dirname } = await import("node:path");
+          mkdirSync(dirname(SETUP_MARKER), { recursive: true });
+          writeFileSync(SETUP_MARKER, new Date().toISOString());
+        } catch {
+          /* non-fatal */
+        }
+
+        console.log();
+        console.log(
+          `    ${C.green}✓${C.reset} ${C.bold}Setup complete (cloud mode)${C.reset}`,
+        );
+        console.log(`    Default model: ${C.cyan}${cloudResult.defaultModel}${C.reset}`);
+        console.log(`    Run ${C.bold}kcode${C.reset} to start.`);
+        console.log();
+        return;
+      }
+
+      // User declined cloud → fall through to local path with
+      // whatever mark5-pico / nano fits. Print a note explaining.
+      console.log(
+        `    ${C.dim}Cloud skipped. Proceeding with local setup (expect slow inference).${C.reset}`,
+      );
+      console.log();
+    } else if (tier.offerAlternative) {
+      // Strong/medium hardware: still mention cloud is available as a
+      // secondary path. One-liner, not a full menu.
+      console.log(
+        `    ${C.dim}Tip: run ${C.reset}${C.bold}kcode cloud${C.dim} to also configure a cloud provider as fallback.${C.reset}`,
+      );
+      console.log();
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════
   //  Step 2: Model Selection
   // ═══════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Problem
User tried to install kcode on a Fedora box with 16GB RAM, no GPU. Setup wizard tried to download an 18GB model that would crawl at ~1 tok/s via SSD mmap. The wizard assumed local is always the right answer — forcing slow local is worse UX than routing to cloud.

## Solution: hardware tier → cloud-first for weak HW
Two new modules + a branch in the wizard.

### \`src/core/hardware-tier.ts\`
Classifies into \`strong | medium | weak | unusable\` based on VRAM/RAM thresholds tuned for **usable speed** (≥10 tok/s target). Thresholds:
- VRAM ≥ 20GB → strong
- VRAM 8-20GB → medium
- VRAM < 8GB or no GPU → weak/unusable based on RAM
- Apple Silicon special-cased (unified memory + mlx)

### \`src/core/cloud-setup.ts\`
Readline CLI flow. Detects existing credentials (settings.json, env vars, OAuth) and offers to use them first. Otherwise shows provider menu (Anthropic, OpenAI, Groq, DeepSeek, Together) with signup URL + cost note per provider.

### Wizard branch
Between Step 1 (HW detection) and Step 2 (model selection):
- If tier.primary === \"cloud\" → run cloud setup, register chosen model, exit wizard clean
- If user declines cloud → fall through to local with \"expect slow inference\" warning
- Strong/medium HW: one-liner tip mentioning \`kcode cloud\` as secondary

## Escape hatches
- \`--model <name>\`: explicit override, skips tier check
- \`KCODE_FORCE_LOCAL=1\`: env var to force the old flow

## Test plan
- [x] 11/11 new tests in \`hardware-tier.test.ts\` covering all 4 tiers
- [x] \`bun run build\` — v2.10.97 deployed
- [x] Canonical Fedora case: 16GB RAM + no GPU → tier=weak, primary=cloud

Co-Authored-By: Kulvex Code <contact@astrolexis.space>