### PR TITLE
fix: live VRAM detection + download confirm + VRAM-fit priority + v2.10.98

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.97",
+  "version": "2.10.98",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/gpu-availability.test.ts
+++ b/src/core/gpu-availability.test.ts
@@ -1,0 +1,79 @@
+// Tests for live GPU availability detection + effectiveUsableVramMB
+// fallback math.
+
+import { describe, expect, test } from "bun:test";
+import {
+  detectGpuAvailability,
+  effectiveUsableVramMB,
+  type GpuAvailability,
+} from "./gpu-availability";
+
+describe("effectiveUsableVramMB", () => {
+  test("uses free VRAM with 10% safety margin when live data is available", () => {
+    const avail: GpuAvailability = {
+      totalMB: 12288,
+      freeMB: 8000,
+      usedMB: 4288,
+      source: "nvidia-smi",
+    };
+    const usable = effectiveUsableVramMB(avail, 12288);
+    // 8000 * 0.9 = 7200
+    expect(usable).toBe(7200);
+  });
+
+  test("falls back to 80% × 90% of total when free is null", () => {
+    const avail: GpuAvailability = {
+      totalMB: 12288,
+      freeMB: null,
+      usedMB: null,
+      source: "unknown",
+    };
+    const usable = effectiveUsableVramMB(avail, 12288);
+    // 12288 * 0.8 * 0.9 = 8847.36
+    expect(usable).toBeCloseTo(8847.36, 1);
+  });
+
+  test("returns 0 when free is zero", () => {
+    const avail: GpuAvailability = {
+      totalMB: 12288,
+      freeMB: 0,
+      usedMB: 12288,
+      source: "nvidia-smi",
+    };
+    expect(effectiveUsableVramMB(avail, 12288)).toBe(0);
+  });
+
+  test("handles negative-looking free values gracefully (clamped to 0)", () => {
+    const avail: GpuAvailability = {
+      totalMB: 12288,
+      freeMB: -100, // bogus driver report
+      usedMB: null,
+      source: "nvidia-smi",
+    };
+    expect(effectiveUsableVramMB(avail, 12288)).toBe(0);
+  });
+});
+
+describe("detectGpuAvailability — Apple Silicon short-circuit", () => {
+  test("darwin platform returns null free (unified memory)", async () => {
+    const r = await detectGpuAvailability("darwin", 32_000);
+    expect(r.source).toBe("apple-unified");
+    expect(r.freeMB).toBeNull();
+    expect(r.totalMB).toBe(32_000);
+  });
+});
+
+describe("detectGpuAvailability — nvidia-smi absent", () => {
+  test("returns null free when nvidia-smi is not installed", async () => {
+    // On a machine without an NVIDIA driver / nvidia-smi binary, the
+    // module should return a clean null-free result rather than throw.
+    // This test is indirect — in CI we may or may not have nvidia-smi,
+    // but either way the function must return a well-formed object.
+    const r = await detectGpuAvailability("linux", 0);
+    expect(r).toBeDefined();
+    expect(typeof r.totalMB).toBe("number");
+    // freeMB could be null (no nvidia-smi) or a number (CI has it);
+    // both are valid, we just don't throw.
+    expect(r.freeMB === null || typeof r.freeMB === "number").toBe(true);
+  });
+});

--- a/src/core/gpu-availability.ts
+++ b/src/core/gpu-availability.ts
@@ -1,0 +1,154 @@
+// KCode — Live GPU Availability Detection
+//
+// `hardware.ts` reports TOTAL VRAM (physical capacity). For model
+// recommendation we need FREE VRAM — what's actually available right
+// now. A 12GB card with 8GB already in use by another app has only
+// 4GB usable for inference.
+//
+// This module is called by the setup wizard before recommendModel
+// so recommendations match reality, not marketing specs.
+
+import { log } from "./logger";
+
+export interface GpuAvailability {
+  /** Total VRAM (physical capacity) in MB. */
+  totalMB: number;
+  /** VRAM currently free in MB. `null` if detection failed. */
+  freeMB: number | null;
+  /** VRAM currently used by other processes in MB. `null` on failure. */
+  usedMB: number | null;
+  /** Source of the data (for logging / debug). */
+  source: "nvidia-smi" | "apple-unified" | "unknown";
+}
+
+/**
+ * Detect free VRAM across all discrete GPUs by querying nvidia-smi.
+ * Sums free memory across cards so multi-GPU setups get the combined
+ * value (same as hardware.ts totals vramMB).
+ *
+ * Returns `freeMB: null` if:
+ *   - No nvidia-smi available (non-NVIDIA GPU, driver missing)
+ *   - The query times out (10s)
+ *   - Parse failure
+ *
+ * In the `null` case, the caller should fall back to a conservative
+ * fraction of totalVramMB (e.g. 0.8x) since we can't confirm what's
+ * free.
+ */
+export async function detectGpuAvailability(
+  platform: string,
+  totalVramMB: number,
+): Promise<GpuAvailability> {
+  // Apple Silicon has unified memory — no separate VRAM pool, and
+  // no per-app free/used tracking at the level we can easily query.
+  // Caller should treat the full reported RAM as "available modulo OS".
+  if (platform === "darwin") {
+    return {
+      totalMB: totalVramMB,
+      freeMB: null, // caller falls back to ramMB * 0.75 or similar
+      usedMB: null,
+      source: "apple-unified",
+    };
+  }
+
+  try {
+    const output = await runNvidiaSmi();
+    if (!output) {
+      log.debug("gpu-availability", "nvidia-smi returned no output");
+      return {
+        totalMB: totalVramMB,
+        freeMB: null,
+        usedMB: null,
+        source: "unknown",
+      };
+    }
+
+    // CSV: free,used,total — one row per GPU in MB
+    let sumFree = 0;
+    let sumUsed = 0;
+    let sumTotal = 0;
+    let rows = 0;
+    for (const line of output.split("\n")) {
+      const parts = line.split(",").map((s) => s.trim());
+      if (parts.length < 3) continue;
+      const free = parseInt(parts[0]!, 10);
+      const used = parseInt(parts[1]!, 10);
+      const total = parseInt(parts[2]!, 10);
+      if (!Number.isFinite(free) || !Number.isFinite(used) || !Number.isFinite(total)) continue;
+      sumFree += free;
+      sumUsed += used;
+      sumTotal += total;
+      rows++;
+    }
+    if (rows === 0) {
+      return {
+        totalMB: totalVramMB,
+        freeMB: null,
+        usedMB: null,
+        source: "unknown",
+      };
+    }
+
+    return {
+      totalMB: sumTotal,
+      freeMB: sumFree,
+      usedMB: sumUsed,
+      source: "nvidia-smi",
+    };
+  } catch (err) {
+    log.debug("gpu-availability", `detection failed: ${err}`);
+    return {
+      totalMB: totalVramMB,
+      freeMB: null,
+      usedMB: null,
+      source: "unknown",
+    };
+  }
+}
+
+async function runNvidiaSmi(): Promise<string | null> {
+  const { execSync } = require("node:child_process") as typeof import("node:child_process");
+  const candidatePaths = [
+    "/usr/bin/nvidia-smi",
+    "nvidia-smi",
+    "/usr/local/bin/nvidia-smi",
+    "/usr/local/cuda/bin/nvidia-smi",
+    "/opt/cuda/bin/nvidia-smi",
+  ];
+  const query = "--query-gpu=memory.free,memory.used,memory.total --format=csv,noheader,nounits";
+
+  for (const smiPath of candidatePaths) {
+    try {
+      const out = execSync(`${smiPath} ${query}`, {
+        encoding: "utf-8",
+        timeout: 5_000,
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim();
+      if (out) return out;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+/**
+ * Compute effective usable VRAM for recommendation purposes. Uses
+ * live free-VRAM when available, falls back to a conservative fraction
+ * of total VRAM when detection fails.
+ *
+ * Applies a 10% safety margin on top — even if nvidia-smi says 12GB
+ * is free, we reserve some for KV cache + runtime overhead.
+ */
+export function effectiveUsableVramMB(
+  availability: GpuAvailability,
+  totalVramMB: number,
+): number {
+  const SAFETY = 0.9;
+  if (availability.freeMB !== null) {
+    // Live detection: use actual free with safety margin
+    return Math.max(0, availability.freeMB * SAFETY);
+  }
+  // Fallback: conservative fraction of total (assume ~20% is in use)
+  return totalVramMB * 0.8 * SAFETY;
+}

--- a/src/core/model-catalog.ts
+++ b/src/core/model-catalog.ts
@@ -217,7 +217,18 @@ export function getAvailableModels(): {
 }
 
 /** Recommend the best model for the detected hardware */
-export function recommendModel(hw: HardwareInfo): CatalogEntry {
+export function recommendModel(
+  hw: HardwareInfo,
+  opts?: {
+    /**
+     * Override the VRAM budget used for "fits in VRAM" calculations.
+     * When set, this replaces hw.totalVramMB * 0.9. Pass the live free
+     * VRAM (minus overhead) so recommendations match what's actually
+     * available, not marketing specs.
+     */
+    usableVramMB?: number;
+  },
+): CatalogEntry {
   // ── macOS Apple Silicon: unified memory + SSD offloading ──────
   // On Apple Silicon, RAM = VRAM (unified memory). Models larger than RAM
   // can still run via mlx_lm's disk offloading — Apple's fast NVMe SSDs
@@ -240,20 +251,44 @@ export function recommendModel(hw: HardwareInfo): CatalogEntry {
     if (best) return best;
   }
 
-  // ── Discrete GPU: pick largest model that can run ─────────────
-  // Priority: full VRAM fit > partial GPU offload (GPU + CPU/RAM via mmap)
-  // With mmap, llama.cpp streams layers that don't fit in VRAM from SSD/RAM.
-  // We allow models up to VRAM + 70% of system RAM (mmap handles the rest).
+  // ── Discrete GPU: pick largest model that fits FULLY in VRAM ──
+  // Priority: usable speed > max size. Previously we'd pick the
+  // largest model that technically fits via mmap (VRAM + 70% of
+  // RAM), but that hit the common failure mode where a 12GB card
+  // got recommended a 20GB model running at ~5 tok/s via SSD
+  // streaming. Users canceled the download every time. Fix:
+  //
+  //   Step 1: find the largest model that fits in VRAM × 0.9
+  //           (leaving 10% headroom for KV cache + overhead).
+  //   Step 2: only fall back to mmap-fits if NO model fits in VRAM.
+  //
+  // This produces faster models at the cost of slightly smaller
+  // ones. Users who want the biggest can still pass --model
+  // explicitly.
   if (hw.totalVramMB > 0) {
-    let best: CatalogEntry | null = null;
-    const totalCapacityMB = hw.totalVramMB + hw.ramMB * 0.7;
+    // Use live usable VRAM if provided (caller detected via nvidia-smi
+    // memory.free), otherwise fall back to 90% of total.
+    const vramFitMB = opts?.usableVramMB ?? hw.totalVramMB * 0.9;
+    let vramBest: CatalogEntry | null = null;
     for (const entry of MODEL_CATALOG) {
       const modelMB = entry.sizeGB * 1024;
-      if (modelMB <= totalCapacityMB && (!best || entry.sizeGB > best.sizeGB)) {
-        best = entry;
+      if (modelMB <= vramFitMB && (!vramBest || entry.sizeGB > vramBest.sizeGB)) {
+        vramBest = entry;
       }
     }
-    if (best) return best;
+    if (vramBest) return vramBest;
+
+    // No model fits fully — fall back to mmap (old behavior, but
+    // only reached when the GPU is too small for any listed model).
+    const totalCapacityMB = hw.totalVramMB + hw.ramMB * 0.7;
+    let mmapBest: CatalogEntry | null = null;
+    for (const entry of MODEL_CATALOG) {
+      const modelMB = entry.sizeGB * 1024;
+      if (modelMB <= totalCapacityMB && (!mmapBest || entry.sizeGB > mmapBest.sizeGB)) {
+        mmapBest = entry;
+      }
+    }
+    if (mmapBest) return mmapBest;
   }
 
   // ── CPU mode: model runs in system RAM via mmap ────────────────

--- a/src/core/setup-wizard.ts
+++ b/src/core/setup-wizard.ts
@@ -287,7 +287,38 @@ export async function runSetup(options?: {
   stepHeader(2, "Selecting the best model for your system");
   console.log();
 
-  const recommended = recommendModel(hw);
+  // Check LIVE VRAM availability, not just total. If another process
+  // (another LLM server, Blender, game, etc.) is already using part
+  // of the VRAM, we recommend based on what's actually free.
+  let usableVramMB: number | undefined;
+  if (hw.totalVramMB > 0) {
+    try {
+      const { detectGpuAvailability, effectiveUsableVramMB } = await import(
+        "./gpu-availability.js"
+      );
+      const avail = await detectGpuAvailability(hw.platform, hw.totalVramMB);
+      usableVramMB = effectiveUsableVramMB(avail, hw.totalVramMB);
+
+      if (avail.freeMB !== null && avail.usedMB !== null && avail.usedMB > 500) {
+        // Something is already using significant VRAM — tell the user
+        const usedGB = (avail.usedMB / 1024).toFixed(1);
+        const freeGB = (avail.freeMB / 1024).toFixed(1);
+        const totalGB = (avail.totalMB / 1024).toFixed(0);
+        console.log(
+          `    ${C.yellow}⚠${C.reset} Live VRAM check: ${C.bold}${usedGB} GB in use${C.reset} by other processes ` +
+            `(${freeGB} GB free of ${totalGB} GB total)`,
+        );
+        console.log(
+          `    ${C.dim}Recommending based on FREE VRAM, not total. Close other GPU apps for a larger model.${C.reset}`,
+        );
+        console.log();
+      }
+    } catch (err) {
+      log.debug("setup", `live VRAM detection failed: ${err}`);
+    }
+  }
+
+  const recommended = recommendModel(hw, { usableVramMB });
   const targetCodename = options?.model ?? recommended.codename;
   const entry = findCatalogEntry(targetCodename) ?? recommended;
 
@@ -487,6 +518,53 @@ export async function runSetup(options?: {
 
   stepHeader(4, `Downloading ${entry.codename}`);
   console.log();
+
+  // Ask before large / slow downloads. Skip the prompt when:
+  //   - user passed --yes or --model explicitly (they know what they want)
+  //   - model is already downloaded (not re-downloading anything)
+  //   - KCODE_SKIP_DOWNLOAD_CONFIRM=1 is set (CI / scripted installs)
+  const modelAlreadyDownloaded =
+    !useMlx && isModelDownloaded(entry.codename) && !options?.force;
+  const skipConfirm =
+    options?.yes ||
+    options?.model ||
+    modelAlreadyDownloaded ||
+    process.env.KCODE_SKIP_DOWNLOAD_CONFIRM === "1";
+
+  if (!skipConfirm) {
+    const { createInterface } = await import("node:readline");
+    const willUseMmap =
+      hw.totalVramMB > 0 && entry.sizeGB * 1024 > hw.totalVramMB * 0.9;
+    const warnLine = willUseMmap
+      ? `    ${C.yellow}⚠${C.reset} This model (${entry.sizeGB} GB) exceeds your VRAM (${(hw.totalVramMB / 1024).toFixed(0)} GB). It will run via partial GPU + SSD streaming — noticeably slower than a fully-in-VRAM model.`
+      : null;
+    if (warnLine) {
+      console.log(warnLine);
+      console.log(
+        `    ${C.dim}Consider a smaller model (e.g. mark5-nano, deepseek-coder-v2) with ${C.reset}${C.bold}--model <codename>${C.reset}${C.dim}, or run ${C.reset}${C.bold}kcode cloud${C.reset}${C.dim} for cloud instead.${C.reset}`,
+      );
+      console.log();
+    }
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    const answer = await new Promise<string>((resolve) => {
+      rl.question(
+        `    Download ${entry.codename} (${entry.sizeGB} GB)? [Y/n]: `,
+        (a) => {
+          rl.close();
+          resolve(a.trim().toLowerCase());
+        },
+      );
+    });
+    if (answer && !(answer.startsWith("y") || answer === "s" || answer === "si")) {
+      console.log();
+      console.log(
+        `    ${C.yellow}Download cancelled.${C.reset} Re-run ${C.bold}setup${C.reset} with ${C.bold}--model <codename>${C.reset} to pick a different one, or ${C.bold}kcode cloud${C.reset} for cloud setup.`,
+      );
+      console.log();
+      return;
+    }
+    console.log();
+  }
 
   let modelPath: string;
 


### PR DESCRIPTION
## Three coordinated fixes after Fedora/RTX 3060 testing
User ran setup wizard on a 12GB RTX 3060. Wizard picked \`codellama-34b\` (20GB, runs at ~5 tok/s via SSD streaming) and started a 20GB download without asking. User hit Ctrl+C.

## Fix 1: VRAM-fit priority over mmap-fit
Previously \`recommendModel\` picked the largest model where \`modelMB <= totalVramMB + 0.7 × ramMB\` — i.e. anything mmap could stream. Now picks largest that fits in VRAM × 0.9 first; falls back to mmap only when nothing fits.

## Fix 2: Live VRAM detection
New \`src/core/gpu-availability.ts\` queries \`nvidia-smi --query-gpu=memory.free,memory.used,memory.total\`. Recommendations use **free** VRAM, not total — respects other processes already holding VRAM. Apple Silicon short-circuits to unified-memory. Falls back to conservative \`totalVramMB × 0.8 × 0.9\` when nvidia-smi is absent.

## Fix 3: Confirm before download
Wizard asks \`Download <model> (<size> GB)? [Y/n]\` before starting. Extra warning when model exceeds VRAM. Skipped with \`--yes\` / \`--model\` / already-downloaded / \`KCODE_SKIP_DOWNLOAD_CONFIRM=1\`.

## Before/after
Before (12GB VRAM):
```
→ recommends codellama-34b (20GB)
→ starts 20GB download silently (slow mmap)
```
After:
```
⚠ Live VRAM check: 2.0 GB in use (10.0 GB free of 12 GB total)
→ recommends deepseek-coder-v2 (10GB) or mark5-nano (6GB)
→ asks: Download deepseek-coder-v2 (10 GB)? [Y/n]
```

## Test plan
- [x] 6/6 new tests in \`gpu-availability.test.ts\` (safety margin, nulls, negative clamp, Apple short-circuit)
- [x] 17/17 hardware suite
- [x] v2.10.98 deployed

Co-Authored-By: Kulvex Code <contact@astrolexis.space>