### PR TITLE
fix: tier uses LIVE free VRAM + local/cloud prompt on medium + v2.10.99

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.98",
+  "version": "2.10.99",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/hardware-tier.test.ts
+++ b/src/core/hardware-tier.test.ts
@@ -95,6 +95,63 @@ describe("classifyHardware — CPU only", () => {
   });
 });
 
+describe("classifyHardware with live VRAM override", () => {
+  test("12GB card with 1GB free → unusable (no model fits)", () => {
+    const r = classifyHardware(
+      hw({ totalVramMB: 12 * 1024 }),
+      { liveUsableVramMB: 1024 },
+    );
+    expect(r.tier).toBe("unusable");
+    expect(r.primary).toBe("cloud");
+    expect(r.offerAlternative).toBe(false);
+    expect(r.reason).toContain("1.0GB free");
+  });
+
+  test("12GB card with 2GB free → weak (can still force local)", () => {
+    const r = classifyHardware(
+      hw({ totalVramMB: 12 * 1024 }),
+      { liveUsableVramMB: 2 * 1024 },
+    );
+    expect(r.tier).toBe("weak");
+    expect(r.primary).toBe("cloud");
+    expect(r.offerAlternative).toBe(true);
+  });
+
+  test("24GB card with only 6GB free → weak (downgraded from strong)", () => {
+    const r = classifyHardware(
+      hw({ totalVramMB: 24 * 1024 }),
+      { liveUsableVramMB: 6 * 1024 },
+    );
+    expect(r.tier).toBe("weak");
+    expect(r.primary).toBe("cloud");
+    expect(r.reason).toContain("6GB free of 24GB");
+  });
+
+  test("12GB card with 9.5GB free → medium (healthy local)", () => {
+    const r = classifyHardware(
+      hw({ totalVramMB: 12 * 1024 }),
+      { liveUsableVramMB: 9.5 * 1024 },
+    );
+    expect(r.tier).toBe("medium");
+    expect(r.primary).toBe("local");
+  });
+
+  test("24GB card with 22GB free → strong (confirmed by live)", () => {
+    const r = classifyHardware(
+      hw({ totalVramMB: 24 * 1024 }),
+      { liveUsableVramMB: 22 * 1024 },
+    );
+    expect(r.tier).toBe("strong");
+    expect(r.primary).toBe("local");
+  });
+
+  test("no liveUsableVramMB → falls back to total VRAM logic (backwards compat)", () => {
+    const r = classifyHardware(hw({ totalVramMB: 12 * 1024 }));
+    // Without live override, 12GB total = medium
+    expect(r.tier).toBe("medium");
+  });
+});
+
 describe("tierLabel", () => {
   test("returns human-readable labels", () => {
     expect(tierLabel("strong")).toContain("local-first");

--- a/src/core/hardware-tier.ts
+++ b/src/core/hardware-tier.ts
@@ -40,7 +40,63 @@ export interface TierClassification {
  *   3. No GPU falls back to RAM — ≥32GB = weak (viable for 8B Q4),
  *      16-32GB = weak (only 4B fits at speed), <12GB = unusable.
  */
-export function classifyHardware(hw: HardwareInfo): TierClassification {
+export function classifyHardware(
+  hw: HardwareInfo,
+  opts?: {
+    /**
+     * Live usable VRAM in MB — what's actually free right now, not
+     * what's physically installed. When provided, overrides
+     * hw.totalVramMB for tier decisions. This catches the case where
+     * a 12GB card has only 1GB free because Blender/another LLM is
+     * holding 11GB — we want "weak" in that case, not "medium".
+     *
+     * Detection-source note: nvidia-smi memory.free, collected via
+     * gpu-availability.ts.
+     */
+    liveUsableVramMB?: number;
+  },
+): TierClassification {
+  // When live usable VRAM is drastically lower than total (e.g., 1GB
+  // free of 12GB), force a downgrade to weak/unusable even if the
+  // card itself is medium or strong. The tiniest model in the catalog
+  // is 2.6GB — if that can't fit, local is not viable right now.
+  if (opts?.liveUsableVramMB !== undefined && hw.totalVramMB > 0) {
+    const liveGB = opts.liveUsableVramMB / 1024;
+    if (liveGB < 3) {
+      return {
+        tier: liveGB < 1.5 ? "unusable" : "weak",
+        reason: `Only ${liveGB.toFixed(1)}GB free of ${(hw.totalVramMB / 1024).toFixed(0)}GB VRAM (other processes holding the rest). Local inference not viable right now.`,
+        primary: "cloud",
+        offerAlternative: liveGB >= 1.5, // let them force-local if they want
+      };
+    }
+    // Between 3GB and full: classify based on LIVE usable instead of total
+    // so someone with 6GB free of 24GB gets "weak" not "strong".
+    if (liveGB < 8) {
+      return {
+        tier: "weak",
+        reason: `${liveGB.toFixed(0)}GB free of ${(hw.totalVramMB / 1024).toFixed(0)}GB VRAM — small models only`,
+        primary: "cloud",
+        offerAlternative: true,
+      };
+    }
+    if (liveGB < 20) {
+      return {
+        tier: "medium",
+        reason: `${liveGB.toFixed(0)}GB free VRAM — medium local models OK`,
+        primary: "local",
+        offerAlternative: true,
+      };
+    }
+    // liveGB >= 20 → strong regardless of total
+    return {
+      tier: "strong",
+      reason: `${liveGB.toFixed(0)}GB free VRAM — large local models viable`,
+      primary: "local",
+      offerAlternative: true,
+    };
+  }
+
   // Apple Silicon special case: unified memory + mlx
   if (hw.platform === "darwin" && hw.arch === "arm64") {
     if (hw.ramMB >= 32 * 1024) {

--- a/src/core/setup-wizard.ts
+++ b/src/core/setup-wizard.ts
@@ -193,22 +193,40 @@ export async function runSetup(options?: {
   console.log();
 
   // ═══════════════════════════════════════════════════════════════
-  //  Step 1b: Hardware Tier Check → Cloud-First for Weak Hardware
+  //  Step 1b: Live VRAM check + Hardware Tier Classification
   // ═══════════════════════════════════════════════════════════════
   //
-  // If the user's hardware can't run local at usable speed, route
-  // straight to cloud setup instead of downloading a giant model
-  // that'll crawl at 1 tok/s. User can still pick local as a
-  // fallback inside runCloudSetup if they want.
+  // Query nvidia-smi BEFORE tier classification so the tier reflects
+  // what's actually free right now, not what's physically installed.
+  // A 12GB card with only 1GB free (Blender/other LLM holding it)
+  // should be classified as "weak/unusable", not "medium".
   //
   // Skip this branch when:
   //   - options.model is explicit (they know what they want)
   //   - KCODE_FORCE_LOCAL env is set (escape hatch)
 
   const forceLocal = process.env.KCODE_FORCE_LOCAL === "1";
+
+  // Pre-compute live usable VRAM so both tier classification (here)
+  // and model recommendation (below) use the same figure.
+  let wizardUsableVramMB: number | undefined;
+  let wizardVramAvailability: { usedMB: number | null; freeMB: number | null; totalMB: number } | null = null;
+  if (hw.totalVramMB > 0) {
+    try {
+      const { detectGpuAvailability, effectiveUsableVramMB } = await import(
+        "./gpu-availability.js"
+      );
+      const avail = await detectGpuAvailability(hw.platform, hw.totalVramMB);
+      wizardUsableVramMB = effectiveUsableVramMB(avail, hw.totalVramMB);
+      wizardVramAvailability = avail;
+    } catch (err) {
+      log.debug("setup", `live VRAM detection failed: ${err}`);
+    }
+  }
+
   if (!options?.model && !forceLocal) {
     const { classifyHardware } = await import("./hardware-tier.js");
-    const tier = classifyHardware(hw);
+    const tier = classifyHardware(hw, { liveUsableVramMB: wizardUsableVramMB });
 
     if (tier.primary === "cloud") {
       console.log(
@@ -271,12 +289,74 @@ export async function runSetup(options?: {
       );
       console.log();
     } else if (tier.offerAlternative) {
-      // Strong/medium hardware: still mention cloud is available as a
-      // secondary path. One-liner, not a full menu.
+      // Strong/medium hardware: ASK the user whether they want local
+      // or cloud, don't assume local. A 12GB VRAM card can run
+      // local but cloud might be preferable for quality/speed
+      // reasons. Default = local (preserves local-first philosophy).
       console.log(
-        `    ${C.dim}Tip: run ${C.reset}${C.bold}kcode cloud${C.dim} to also configure a cloud provider as fallback.${C.reset}`,
+        `    ${C.dim}Hardware tier: ${C.reset}${C.bold}${tier.tier}${C.reset} ${C.dim}— ${tier.reason}${C.reset}`,
       );
       console.log();
+      const { createInterface } = await import("node:readline");
+      const rl = createInterface({ input: process.stdin, output: process.stdout });
+      const choice = await new Promise<string>((resolve) => {
+        rl.question(
+          `    Setup path: ${C.bold}[L]${C.reset}ocal model (recommended for your HW) or ${C.bold}[C]${C.reset}loud provider? [L/c]: `,
+          (a) => {
+            rl.close();
+            resolve(a.trim().toLowerCase());
+          },
+        );
+      });
+      console.log();
+
+      if (choice.startsWith("c")) {
+        // User picked cloud even on medium HW — run cloud setup
+        const { runCloudSetup } = await import("./cloud-setup.js");
+        const cloudResult = await runCloudSetup({ tierReason: tier.reason });
+
+        if (!cloudResult.declined) {
+          try {
+            const { addModel: addM, setDefaultModel: setDef } = await import("./models.js");
+            await addM({
+              name: cloudResult.defaultModel,
+              baseUrl:
+                cloudResult.providerId === "anthropic"
+                  ? "https://api.anthropic.com"
+                  : cloudResult.providerId === "openai"
+                    ? "https://api.openai.com"
+                    : cloudResult.providerId === "groq"
+                      ? "https://api.groq.com/openai"
+                      : cloudResult.providerId === "deepseek"
+                        ? "https://api.deepseek.com"
+                        : "https://api.together.xyz",
+              provider: cloudResult.providerId === "anthropic" ? "anthropic" : "openai",
+              description: `Configured via setup wizard (${new Date().toISOString().slice(0, 10)})`,
+            });
+            await setDef(cloudResult.defaultModel);
+          } catch (err) {
+            log.warn("setup", `failed to register cloud model: ${err}`);
+          }
+
+          try {
+            const { writeFileSync, mkdirSync } = await import("node:fs");
+            const { dirname } = await import("node:path");
+            mkdirSync(dirname(SETUP_MARKER), { recursive: true });
+            writeFileSync(SETUP_MARKER, new Date().toISOString());
+          } catch {
+            /* non-fatal */
+          }
+
+          console.log(
+            `    ${C.green}✓${C.reset} ${C.bold}Setup complete (cloud mode)${C.reset}`,
+          );
+          console.log(`    Default model: ${C.cyan}${cloudResult.defaultModel}${C.reset}`);
+          console.log();
+          return;
+        }
+        // Declined cloud too → fall through to local
+      }
+      // Default or 'L' → continue with local path below
     }
   }
 
@@ -287,38 +367,28 @@ export async function runSetup(options?: {
   stepHeader(2, "Selecting the best model for your system");
   console.log();
 
-  // Check LIVE VRAM availability, not just total. If another process
-  // (another LLM server, Blender, game, etc.) is already using part
-  // of the VRAM, we recommend based on what's actually free.
-  let usableVramMB: number | undefined;
-  if (hw.totalVramMB > 0) {
-    try {
-      const { detectGpuAvailability, effectiveUsableVramMB } = await import(
-        "./gpu-availability.js"
-      );
-      const avail = await detectGpuAvailability(hw.platform, hw.totalVramMB);
-      usableVramMB = effectiveUsableVramMB(avail, hw.totalVramMB);
-
-      if (avail.freeMB !== null && avail.usedMB !== null && avail.usedMB > 500) {
-        // Something is already using significant VRAM — tell the user
-        const usedGB = (avail.usedMB / 1024).toFixed(1);
-        const freeGB = (avail.freeMB / 1024).toFixed(1);
-        const totalGB = (avail.totalMB / 1024).toFixed(0);
-        console.log(
-          `    ${C.yellow}⚠${C.reset} Live VRAM check: ${C.bold}${usedGB} GB in use${C.reset} by other processes ` +
-            `(${freeGB} GB free of ${totalGB} GB total)`,
-        );
-        console.log(
-          `    ${C.dim}Recommending based on FREE VRAM, not total. Close other GPU apps for a larger model.${C.reset}`,
-        );
-        console.log();
-      }
-    } catch (err) {
-      log.debug("setup", `live VRAM detection failed: ${err}`);
-    }
+  // Reuse the wizardUsableVramMB / wizardVramAvailability computed
+  // in Step 1b above — no second nvidia-smi call.
+  if (
+    wizardVramAvailability &&
+    wizardVramAvailability.freeMB !== null &&
+    wizardVramAvailability.usedMB !== null &&
+    wizardVramAvailability.usedMB > 500
+  ) {
+    const usedGB = (wizardVramAvailability.usedMB / 1024).toFixed(1);
+    const freeGB = (wizardVramAvailability.freeMB / 1024).toFixed(1);
+    const totalGB = (wizardVramAvailability.totalMB / 1024).toFixed(0);
+    console.log(
+      `    ${C.yellow}⚠${C.reset} Live VRAM check: ${C.bold}${usedGB} GB in use${C.reset} by other processes ` +
+        `(${freeGB} GB free of ${totalGB} GB total)`,
+    );
+    console.log(
+      `    ${C.dim}Recommending based on FREE VRAM, not total. Close other GPU apps for a larger model.${C.reset}`,
+    );
+    console.log();
   }
 
-  const recommended = recommendModel(hw, { usableVramMB });
+  const recommended = recommendModel(hw, { usableVramMB: wizardUsableVramMB });
   const targetCodename = options?.model ?? recommended.codename;
   const entry = findCatalogEntry(targetCodename) ?? recommended;
 


### PR DESCRIPTION
## Problem
RTX 3060 (12GB) with 1GB free VRAM (Blender holding 11GB) got classified as tier=medium based on TOTAL VRAM → wizard ran local setup → no model actually fits.

Also: on healthy medium HW, wizard silently forced local with a one-line "tip" instead of asking user.

## Fixes
1. **\`classifyHardware\` accepts \`liveUsableVramMB\` override** — tier derived from actual free VRAM. Thresholds: <1.5GB = unusable, 1.5-8GB = weak, 8-20GB = medium, ≥20GB = strong.

2. **Wizard runs live VRAM check BEFORE classification** — single nvidia-smi call reused by both tier and model recommendation.

3. **Medium tier now prompts** \`[L]ocal or [C]loud? [L/c]:\` instead of silently forcing local. Default = local (preserves local-first philosophy).

## Test plan
- [x] 23/23 tests, 6 new live-VRAM scenarios
- [x] v2.10.99 deployed

Canonical fix: the 1.1GB-free RTX 3060 case from the user's node 194 — now correctly routes to cloud-first instead of failing silently with unusable local.

Co-Authored-By: Kulvex Code <contact@astrolexis.space>