### PR TITLE
feat: license generator Web UI + signing keypair + v2.10.100

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.99",
+  "version": "2.10.100",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -9,6 +9,7 @@ export { registerDistillCommand } from "./distill";
 export { registerDoctorCommand } from "./doctor";
 export { registerHistoryCommand } from "./history";
 export { registerInitCommand } from "./init";
+export { registerLicenseCommand } from "./license";
 export { registerMcpCommand } from "./mcp";
 export { registerMeshCommand } from "./mesh";
 export { registerModelsCommand } from "./models";

--- a/src/cli/commands/license.ts
+++ b/src/cli/commands/license.ts
@@ -1,0 +1,175 @@
+// KCode — License Management CLI
+//
+// Subcommands:
+//   kcode license status        → show current license (verification only)
+//   kcode license deactivate    → remove license from this machine
+//   kcode license serve         → launch Web UI for generating licenses
+//   kcode license init-keypair  → generate a fresh RSA signing keypair
+//   kcode license generate      → CLI-mode quick-gen (for scripting)
+
+import type { Command } from "commander";
+
+export function registerLicenseCommand(program: Command): void {
+  const licenseCmd = program
+    .command("license")
+    .description("Manage your KCode license");
+
+  // ─── status ──────────────────────────────────────────────────
+
+  licenseCmd
+    .command("status")
+    .description("Show current license status")
+    .action(async () => {
+      const { formatLicenseStatus } = await import("../../core/license");
+      console.log(formatLicenseStatus());
+    });
+
+  // ─── deactivate ──────────────────────────────────────────────
+
+  licenseCmd
+    .command("deactivate")
+    .description("Remove license from this machine")
+    .action(async () => {
+      const { existsSync, unlinkSync } = await import("node:fs");
+      const { kcodePath } = await import("../../core/paths");
+      const path = kcodePath("license.jwt");
+      if (!existsSync(path)) {
+        console.log("No license file found at", path);
+        return;
+      }
+      unlinkSync(path);
+      console.log("✓ License removed from this machine.");
+    });
+
+  // ─── serve (Web UI) ──────────────────────────────────────────
+
+  licenseCmd
+    .command("serve")
+    .description("Launch the license generator Web UI on localhost")
+    .option("-p, --port <port>", "Port to bind", "11200")
+    .option("--host <host>", "Host to bind (default: 127.0.0.1)", "127.0.0.1")
+    .option("--open", "Open in browser after starting", false)
+    .action(
+      async (opts: { port: string; host: string; open: boolean }) => {
+        const port = parseInt(opts.port, 10);
+        if (!Number.isFinite(port) || port < 1024 || port > 65535) {
+          console.error(`Invalid port: ${opts.port} (must be 1024-65535)`);
+          process.exit(1);
+        }
+
+        const { startLicenseServer } = await import("../../license-ui/server");
+        const { url } = await startLicenseServer({ port, host: opts.host });
+
+        console.log(`\n  \x1b[32m✓\x1b[0m License generator running at \x1b[36m${url}\x1b[0m`);
+        console.log(`  \x1b[2mPress Ctrl+C to stop.\x1b[0m\n`);
+
+        if (opts.open) {
+          try {
+            const proc = Bun.spawn(
+              process.platform === "darwin"
+                ? ["open", url]
+                : process.platform === "win32"
+                  ? ["cmd", "/c", "start", url]
+                  : ["xdg-open", url],
+              { stdout: "ignore", stderr: "ignore" },
+            );
+            proc.unref();
+          } catch {
+            /* best effort */
+          }
+        }
+
+        // Keep process alive until Ctrl+C
+        await new Promise(() => {});
+      },
+    );
+
+  // ─── init-keypair ────────────────────────────────────────────
+
+  licenseCmd
+    .command("init-keypair")
+    .description("Generate a fresh RSA signing keypair (one-time setup)")
+    .option("--force", "Overwrite existing keypair (invalidates all prior licenses!)", false)
+    .action(async (opts: { force: boolean }) => {
+      const { generateKeypair } = await import("../../core/license-signer");
+      const result = generateKeypair({ force: opts.force });
+
+      if (result.preserved) {
+        console.log(`✓ Existing keypair preserved at ${result.privateKeyPath}`);
+        console.log(`  Use --force to regenerate (this will break all prior licenses).`);
+      } else {
+        console.log(`✓ New keypair generated`);
+        console.log(`  Private: ${result.privateKeyPath} (keep secret — 0600 perms)`);
+        console.log(`  Public:  ${result.publicKeyPath}`);
+      }
+      console.log();
+      console.log(`Public key (paste into src/core/license.ts KULVEX_LICENSE_PUBLIC_KEY):`);
+      console.log();
+      console.log(result.publicKeyPem);
+    });
+
+  // ─── generate (CLI-mode quick-gen) ───────────────────────────
+
+  licenseCmd
+    .command("generate")
+    .description("Generate a signed license JWT from CLI flags (for scripts)")
+    .requiredOption("--sub <email>", "Subject (customer email)")
+    .option("--tier <tier>", "pro | team | enterprise", "pro")
+    .option("--seats <n>", "Number of seats", "1")
+    .option(
+      "--features <list>",
+      "Comma-separated features (e.g. pro,enterprise,swarm)",
+      "pro",
+    )
+    .option("--expires <date>", "Expiry as ISO date (e.g. 2027-01-01)")
+    .option("--days <n>", "Expiry in N days from now (alternative to --expires)")
+    .option("--org <name>", "Organization name")
+    .option("--hardware <fingerprint>", "Bind to hardware fingerprint")
+    .option("--offline", "Allow offline activation", false)
+    .option("-o, --output <path>", "Write JWT to file instead of stdout")
+    .action(
+      async (opts: {
+        sub: string;
+        tier: string;
+        seats: string;
+        features: string;
+        expires?: string;
+        days?: string;
+        org?: string;
+        hardware?: string;
+        offline: boolean;
+        output?: string;
+      }) => {
+        const { signLicenseWithSummary } = await import("../../core/license-signer");
+        const expiresAt = opts.expires
+          ? opts.expires
+          : opts.days
+            ? Math.floor(Date.now() / 1000) + parseInt(opts.days, 10) * 86400
+            : Math.floor(Date.now() / 1000) + 365 * 86400; // default 1 year
+
+        try {
+          const result = signLicenseWithSummary({
+            sub: opts.sub,
+            tier: opts.tier as "pro" | "team" | "enterprise",
+            seats: parseInt(opts.seats, 10) || 1,
+            features: opts.features.split(",").map((s) => s.trim()).filter(Boolean),
+            expiresAt,
+            orgName: opts.org,
+            hardware: opts.hardware ?? null,
+            offline: opts.offline,
+          });
+
+          if (opts.output) {
+            const { writeFileSync } = await import("node:fs");
+            writeFileSync(opts.output, result.jwt, "utf-8");
+            console.log(`✓ License written to ${opts.output} (expires in ${result.expiresInDays} days)`);
+          } else {
+            console.log(result.jwt);
+          }
+        } catch (err) {
+          console.error(`Error: ${err instanceof Error ? err.message : err}`);
+          process.exit(1);
+        }
+      },
+    );
+}

--- a/src/core/license-signer.test.ts
+++ b/src/core/license-signer.test.ts
@@ -1,0 +1,140 @@
+// License signer tests. Uses a temporary KCODE_HOME to avoid
+// touching the real keypair.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  generateKeypair,
+  signLicense,
+  signLicenseWithSummary,
+} from "./license-signer";
+import { verifyLicenseJwt } from "./license";
+
+let testHome: string;
+let origHome: string | undefined;
+let origPubKey: string | undefined;
+
+beforeEach(() => {
+  origHome = process.env.KCODE_HOME;
+  origPubKey = process.env.KCODE_LICENSE_PUBLIC_KEY;
+  testHome = join(tmpdir(), `kcode-signer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(testHome, { recursive: true });
+  process.env.KCODE_HOME = testHome;
+});
+
+afterEach(() => {
+  if (origHome === undefined) delete process.env.KCODE_HOME;
+  else process.env.KCODE_HOME = origHome;
+  if (origPubKey === undefined) delete process.env.KCODE_LICENSE_PUBLIC_KEY;
+  else process.env.KCODE_LICENSE_PUBLIC_KEY = origPubKey;
+  if (existsSync(testHome)) rmSync(testHome, { recursive: true, force: true });
+});
+
+describe("generateKeypair", () => {
+  test("creates new keypair when none exists", () => {
+    const r = generateKeypair();
+    expect(r.preserved).toBe(false);
+    expect(existsSync(r.privateKeyPath)).toBe(true);
+    expect(existsSync(r.publicKeyPath)).toBe(true);
+    expect(r.publicKeyPem).toContain("BEGIN PUBLIC KEY");
+  });
+
+  test("preserves existing keypair without --force", () => {
+    const first = generateKeypair();
+    const second = generateKeypair();
+    expect(second.preserved).toBe(true);
+    expect(second.publicKeyPem).toBe(first.publicKeyPem);
+  });
+
+  test("regenerates with force=true", () => {
+    const first = generateKeypair();
+    const second = generateKeypair({ force: true });
+    expect(second.preserved).toBe(false);
+    expect(second.publicKeyPem).not.toBe(first.publicKeyPem);
+  });
+});
+
+describe("signLicense round-trip", () => {
+  test("signs a JWT that passes verifyLicenseJwt", () => {
+    const kp = generateKeypair();
+    process.env.KCODE_LICENSE_PUBLIC_KEY = kp.publicKeyPem;
+
+    const jwt = signLicense({
+      sub: "user@example.com",
+      features: ["pro", "swarm"],
+      seats: 1,
+      expiresAt: Math.floor(Date.now() / 1000) + 86400, // tomorrow
+      tier: "pro",
+    });
+
+    const verified = verifyLicenseJwt(jwt);
+    expect(verified.valid).toBe(true);
+    expect(verified.claims?.sub).toBe("user@example.com");
+    expect(verified.claims?.features).toEqual(["pro", "swarm"]);
+    expect(verified.claims?.tier).toBe("pro");
+  });
+
+  test("rejects past expiry dates", () => {
+    generateKeypair();
+    expect(() =>
+      signLicense({
+        sub: "user@example.com",
+        features: ["pro"],
+        seats: 1,
+        expiresAt: Math.floor(Date.now() / 1000) - 100, // past
+      }),
+    ).toThrow(/Invalid expiresAt/);
+  });
+
+  test("accepts ISO date strings for expiresAt", () => {
+    const kp = generateKeypair();
+    process.env.KCODE_LICENSE_PUBLIC_KEY = kp.publicKeyPem;
+    const nextYear = new Date();
+    nextYear.setFullYear(nextYear.getFullYear() + 1);
+
+    const jwt = signLicense({
+      sub: "user@example.com",
+      features: ["pro"],
+      seats: 1,
+      expiresAt: nextYear.toISOString(),
+    });
+    const verified = verifyLicenseJwt(jwt);
+    expect(verified.valid).toBe(true);
+  });
+
+  test("hardware binding shows up in claims", () => {
+    const kp = generateKeypair();
+    process.env.KCODE_LICENSE_PUBLIC_KEY = kp.publicKeyPem;
+    const jwt = signLicense({
+      sub: "user@example.com",
+      features: ["pro"],
+      seats: 1,
+      expiresAt: Math.floor(Date.now() / 1000) + 86400,
+      hardware: "abc123fingerprint",
+    });
+    const verified = verifyLicenseJwt(jwt);
+    expect(verified.claims?.hardware).toBe("abc123fingerprint");
+  });
+});
+
+describe("signLicenseWithSummary", () => {
+  test("returns jwt + claims + expiresInDays", () => {
+    generateKeypair();
+    const r = signLicenseWithSummary({
+      sub: "user@example.com",
+      features: ["pro"],
+      seats: 5,
+      expiresAt: Math.floor(Date.now() / 1000) + 30 * 86400,
+      tier: "team",
+      orgName: "Acme",
+    });
+    expect(r.jwt.split(".")).toHaveLength(3);
+    expect(r.claims.sub).toBe("user@example.com");
+    expect(r.claims.orgName).toBe("Acme");
+    expect(r.claims.tier).toBe("team");
+    expect(r.expiresInDays).toBeGreaterThanOrEqual(29);
+    expect(r.expiresInDays).toBeLessThanOrEqual(30);
+  });
+});

--- a/src/core/license-signer.ts
+++ b/src/core/license-signer.ts
@@ -1,0 +1,190 @@
+// KCode — License JWT Signer
+//
+// Generates RS256-signed JWT licenses compatible with the verifier in
+// src/core/license.ts. Private key reads from:
+//   1. KCODE_LICENSE_PRIVATE_KEY env var (path to PEM file), or
+//   2. ~/.kcode/license-signing.pem
+//
+// The public key (for pasting into license.ts) comes from
+// `generateKeypair()` which writes both halves to ~/.kcode/.
+//
+// Security: the private key NEVER leaves the local filesystem.
+// Signing happens in-process; no network calls.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  createPrivateKey,
+  createPublicKey,
+  createSign,
+  generateKeyPairSync,
+} from "node:crypto";
+import { chmodSync } from "node:fs";
+import { dirname } from "node:path";
+import { kcodePath } from "./paths";
+
+// ─── Types (mirror src/core/license.ts::LicenseClaims) ──────────
+
+export interface LicenseInput {
+  /** Issuer — e.g. "kulvex-licensing". */
+  iss?: string;
+  /** Subject — typically the customer email. */
+  sub: string;
+  /** Features granted — e.g. ["pro", "enterprise", "swarm"]. */
+  features: string[];
+  /** Number of seats (1 for individual). */
+  seats: number;
+  /** Expiry as ISO string or Unix timestamp. */
+  expiresAt: string | number;
+  /** Whether the license allows offline / air-gapped activation. */
+  offline?: boolean;
+  /** Hardware fingerprint to bind this license to a specific machine.
+   *  `null` = not hardware-bound (portable license). */
+  hardware?: string | null;
+  /** Display name of the customer's organization. */
+  orgName?: string;
+  /** Tier (pro / team / enterprise). */
+  tier?: "pro" | "team" | "enterprise";
+}
+
+// ─── Paths ──────────────────────────────────────────────────────
+
+const PRIVATE_KEY_PATH = () =>
+  process.env.KCODE_LICENSE_PRIVATE_KEY ?? kcodePath("license-signing.pem");
+const PUBLIC_KEY_PATH = () => kcodePath("license-signing.pub.pem");
+
+// ─── Keypair generation ─────────────────────────────────────────
+
+export interface KeypairResult {
+  privateKeyPath: string;
+  publicKeyPath: string;
+  publicKeyPem: string;
+  /** True if an existing keypair was found and preserved. */
+  preserved: boolean;
+}
+
+export function generateKeypair(opts?: { force?: boolean }): KeypairResult {
+  const privPath = PRIVATE_KEY_PATH();
+  const pubPath = PUBLIC_KEY_PATH();
+
+  if (!opts?.force && existsSync(privPath)) {
+    // Preserve existing keypair — signing keys shouldn't be
+    // casually regenerated since that invalidates all prior licenses.
+    const existingPub = existsSync(pubPath)
+      ? readFileSync(pubPath, "utf-8")
+      : derivePublicKey(readFileSync(privPath, "utf-8"));
+    return {
+      privateKeyPath: privPath,
+      publicKeyPath: pubPath,
+      publicKeyPem: existingPub,
+      preserved: true,
+    };
+  }
+
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+
+  mkdirSync(dirname(privPath), { recursive: true });
+  writeFileSync(privPath, privateKey, "utf-8");
+  try {
+    chmodSync(privPath, 0o600);
+  } catch {
+    // Non-POSIX — best effort
+  }
+  writeFileSync(pubPath, publicKey, "utf-8");
+
+  return {
+    privateKeyPath: privPath,
+    publicKeyPath: pubPath,
+    publicKeyPem: publicKey,
+    preserved: false,
+  };
+}
+
+function derivePublicKey(privatePem: string): string {
+  const keyObj = createPrivateKey(privatePem);
+  const pub = createPublicKey(keyObj);
+  return pub.export({ type: "spki", format: "pem" }).toString();
+}
+
+// ─── Signing ────────────────────────────────────────────────────
+
+/** Load the configured private key or throw with a clear message. */
+export function loadPrivateKey(): string {
+  const path = PRIVATE_KEY_PATH();
+  if (!existsSync(path)) {
+    throw new Error(
+      `No signing key found at ${path}. Run \`kcode license init-keypair\` first, or set KCODE_LICENSE_PRIVATE_KEY to point at an existing PEM file.`,
+    );
+  }
+  return readFileSync(path, "utf-8");
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf.toString("base64").replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+/**
+ * Sign a set of license claims into a JWT compatible with
+ * src/core/license.ts::verifyLicenseJwt. Returns the compact JWT string.
+ */
+export function signLicense(input: LicenseInput, privateKeyOverride?: string): string {
+  const privateKeyPem = privateKeyOverride ?? loadPrivateKey();
+
+  const now = Math.floor(Date.now() / 1000);
+  const exp =
+    typeof input.expiresAt === "number"
+      ? Math.floor(input.expiresAt)
+      : Math.floor(new Date(input.expiresAt).getTime() / 1000);
+
+  if (!Number.isFinite(exp) || exp <= now) {
+    throw new Error(
+      `Invalid expiresAt: must be a future date. Got ${input.expiresAt}`,
+    );
+  }
+
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = {
+    // Default matches the hardcoded verifier check in license.ts:113
+    iss: input.iss ?? "kulvex.ai",
+    sub: input.sub,
+    features: input.features,
+    seats: input.seats,
+    iat: now,
+    exp,
+    offline: input.offline ?? false,
+    hardware: input.hardware ?? null,
+    orgName: input.orgName,
+    tier: input.tier ?? "pro",
+  };
+
+  const headerB64 = base64UrlEncode(Buffer.from(JSON.stringify(header)));
+  const payloadB64 = base64UrlEncode(Buffer.from(JSON.stringify(payload)));
+  const signingInput = `${headerB64}.${payloadB64}`;
+
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const signature = base64UrlEncode(signer.sign(privateKeyPem));
+
+  return `${signingInput}.${signature}`;
+}
+
+/** Same as signLicense but returns the full JWT plus a summary of claims. */
+export function signLicenseWithSummary(
+  input: LicenseInput,
+): { jwt: string; claims: Record<string, unknown>; expiresInDays: number } {
+  const jwt = signLicense(input);
+  const parts = jwt.split(".");
+  const payload = JSON.parse(
+    Buffer.from(parts[1]!.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString(),
+  );
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    jwt,
+    claims: payload,
+    expiresInDays: Math.floor((payload.exp - now) / 86400),
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ import {
   registerDoctorCommand,
   registerHistoryCommand,
   registerInitCommand,
+  registerLicenseCommand,
   registerMcpCommand,
   registerMeshCommand,
   registerModelsCommand,
@@ -363,6 +364,7 @@ registerDoctorCommand(program);
 registerTeachCommand(program);
 registerStatsCommand(program);
 registerInitCommand(program);
+registerLicenseCommand(program);
 registerNewCommand(program);
 registerResumeCommand(program);
 registerSearchCommand(program);

--- a/src/license-ui/server.ts
+++ b/src/license-ui/server.ts
@@ -1,0 +1,278 @@
+// KCode — License Generator Web UI
+//
+// Launches a local Bun.serve on 127.0.0.1 with an HTML form for
+// creating RS256-signed license JWTs. Invoked via
+// `kcode license serve [--port N]`.
+//
+// Security model: localhost-only by default. Path `/` serves the
+// form HTML inline (no build step). POST /api/generate takes form
+// data, calls license-signer, returns the JWT. POST /api/init-keypair
+// generates a keypair if none exists.
+
+import { log } from "../core/logger";
+import {
+  generateKeypair,
+  signLicenseWithSummary,
+  type LicenseInput,
+} from "../core/license-signer";
+
+// ─── HTML (embedded — no build step) ───────────────────────────
+
+const HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>KCode License Generator</title>
+<style>
+:root { --bg:#0a0f1c; --fg:#e2e8f0; --accent:#00f5ff; --border:#334155; --ok:#10b981; --warn:#f59e0b; --err:#ef4444; }
+* { box-sizing: border-box; }
+body { background: var(--bg); color: var(--fg); font-family: system-ui,-apple-system,sans-serif; margin: 0; padding: 2rem; max-width: 720px; margin-inline: auto; }
+h1 { font-size: 1.5rem; margin-bottom: 0.25rem; letter-spacing: -0.02em; }
+.sub { color: #94a3b8; font-size: 0.9rem; margin-bottom: 2rem; }
+.card { background: #111827; border: 1px solid var(--border); border-radius: 12px; padding: 1.5rem; margin-bottom: 1rem; }
+label { display: block; font-size: 0.85rem; font-weight: 600; margin-bottom: 0.35rem; color: #cbd5e1; }
+input[type=text], input[type=email], input[type=number], input[type=date], textarea, select {
+  width: 100%; padding: 0.6rem 0.8rem; background: #0f172a; color: var(--fg); border: 1px solid var(--border); border-radius: 8px; font-size: 0.95rem; font-family: inherit;
+}
+input:focus, textarea:focus, select:focus { outline: none; border-color: var(--accent); }
+.row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem; }
+.row.one { grid-template-columns: 1fr; }
+.features { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.5rem; }
+.features label { display: inline-flex; align-items: center; gap: 0.4rem; background: #1e293b; padding: 0.4rem 0.75rem; border-radius: 20px; cursor: pointer; font-size: 0.85rem; font-weight: 500; border: 1px solid transparent; }
+.features input[type=checkbox] { accent-color: var(--accent); cursor: pointer; }
+.features label.checked { border-color: var(--accent); background: #0c4a6e; }
+button { background: var(--accent); color: #000; border: none; padding: 0.75rem 1.5rem; border-radius: 8px; font-weight: 600; cursor: pointer; font-size: 0.95rem; }
+button:hover { filter: brightness(1.1); }
+button.secondary { background: #334155; color: var(--fg); }
+.output { background: #020617; border: 1px solid var(--border); border-radius: 8px; padding: 1rem; font-family: monospace; font-size: 0.8rem; overflow-wrap: break-word; white-space: pre-wrap; max-height: 200px; overflow-y: auto; }
+.actions { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
+.hint { color: #64748b; font-size: 0.8rem; margin-top: 0.3rem; }
+.alert { padding: 0.75rem 1rem; border-radius: 8px; margin-bottom: 1rem; font-size: 0.9rem; }
+.alert.err { background: #450a0a; border: 1px solid var(--err); color: #fca5a5; }
+.alert.ok { background: #052e16; border: 1px solid var(--ok); color: #86efac; }
+.claims { font-size: 0.8rem; color: #94a3b8; margin-top: 0.5rem; }
+.claims span { display: inline-block; margin-right: 0.75rem; }
+.claims b { color: var(--fg); }
+</style>
+</head>
+<body>
+<h1>⚡ KCode License Generator</h1>
+<div class="sub">Creates RS256-signed JWT licenses. Private key stays on this machine.</div>
+
+<div id="alert"></div>
+
+<form id="form" class="card">
+  <div class="row">
+    <div>
+      <label for="sub">Email (subject)</label>
+      <input type="email" id="sub" required placeholder="user@example.com">
+    </div>
+    <div>
+      <label for="orgName">Organization (optional)</label>
+      <input type="text" id="orgName" placeholder="Acme Inc.">
+    </div>
+  </div>
+
+  <div class="row">
+    <div>
+      <label for="tier">Tier</label>
+      <select id="tier">
+        <option value="pro">Pro</option>
+        <option value="team">Team</option>
+        <option value="enterprise">Enterprise</option>
+      </select>
+    </div>
+    <div>
+      <label for="seats">Seats</label>
+      <input type="number" id="seats" value="1" min="1" max="10000">
+    </div>
+  </div>
+
+  <div class="row one">
+    <div>
+      <label>Features granted</label>
+      <div class="features" id="features">
+        <label><input type="checkbox" value="pro" checked> Pro</label>
+        <label><input type="checkbox" value="enterprise"> Enterprise</label>
+        <label><input type="checkbox" value="swarm"> Swarm</label>
+        <label><input type="checkbox" value="audit"> Audit Engine</label>
+        <label><input type="checkbox" value="rag"> RAG</label>
+        <label><input type="checkbox" value="cloud-sync"> Cloud Sync</label>
+        <label><input type="checkbox" value="analytics"> Analytics</label>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div>
+      <label for="expiresAt">Expires on</label>
+      <input type="date" id="expiresAt" required>
+      <div class="hint">Must be a future date.</div>
+    </div>
+    <div>
+      <label for="hardware">Hardware fingerprint (optional)</label>
+      <input type="text" id="hardware" placeholder="leave blank = portable">
+      <div class="hint">Binds license to a specific machine.</div>
+    </div>
+  </div>
+
+  <div class="row one">
+    <label><input type="checkbox" id="offline"> Allow offline activation (air-gapped / on-prem)</label>
+  </div>
+
+  <button type="submit">Generate License</button>
+  <button type="button" class="secondary" id="keypairBtn">Init keypair (first-time setup)</button>
+</form>
+
+<div class="card" id="result" style="display:none">
+  <label>JWT (paste into <code>~/.kcode/license.jwt</code> on target machine)</label>
+  <div class="output" id="jwt"></div>
+  <div class="actions">
+    <button id="copyBtn" type="button">Copy JWT</button>
+    <button id="downloadBtn" type="button" class="secondary">Download .jwt</button>
+  </div>
+  <div class="claims" id="claimsPreview"></div>
+</div>
+
+<script>
+const form = document.getElementById("form");
+const alertEl = document.getElementById("alert");
+const featureBoxes = document.querySelectorAll("#features input[type=checkbox]");
+
+// Default expiry = 1 year
+const oneYear = new Date(); oneYear.setFullYear(oneYear.getFullYear() + 1);
+document.getElementById("expiresAt").valueAsDate = oneYear;
+
+// Toggle visual state on feature checkboxes
+featureBoxes.forEach(cb => {
+  const updateLabel = () => cb.parentElement.classList.toggle("checked", cb.checked);
+  updateLabel();
+  cb.addEventListener("change", updateLabel);
+});
+
+function showAlert(kind, msg) {
+  alertEl.innerHTML = \`<div class="alert \${kind}">\${msg}</div>\`;
+  if (kind === "ok") setTimeout(() => { alertEl.innerHTML = ""; }, 4000);
+}
+
+form.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const features = [...featureBoxes].filter(c => c.checked).map(c => c.value);
+  if (features.length === 0) { showAlert("err", "Select at least one feature."); return; }
+
+  const body = {
+    sub: document.getElementById("sub").value.trim(),
+    orgName: document.getElementById("orgName").value.trim() || undefined,
+    tier: document.getElementById("tier").value,
+    seats: parseInt(document.getElementById("seats").value, 10),
+    features,
+    expiresAt: document.getElementById("expiresAt").value,
+    hardware: document.getElementById("hardware").value.trim() || null,
+    offline: document.getElementById("offline").checked,
+  };
+
+  try {
+    const res = await fetch("/api/generate", { method: "POST", headers: {"Content-Type":"application/json"}, body: JSON.stringify(body) });
+    const data = await res.json();
+    if (!res.ok) { showAlert("err", data.error || "Generation failed"); return; }
+
+    document.getElementById("result").style.display = "block";
+    document.getElementById("jwt").textContent = data.jwt;
+    const c = data.claims;
+    document.getElementById("claimsPreview").innerHTML =
+      \`<span><b>sub:</b> \${c.sub}</span><span><b>tier:</b> \${c.tier}</span><span><b>seats:</b> \${c.seats}</span><span><b>expires in:</b> \${data.expiresInDays} days</span>\${c.hardware ? \`<span><b>hw-bound:</b> \${c.hardware.slice(0,12)}…</span>\` : ""}\`;
+    showAlert("ok", "License generated. Copy or download below.");
+    window.__lastJwt = data.jwt;
+    window.__lastSub = c.sub;
+  } catch (err) {
+    showAlert("err", "Network error: " + err.message);
+  }
+});
+
+document.getElementById("keypairBtn").addEventListener("click", async () => {
+  try {
+    const res = await fetch("/api/init-keypair", { method: "POST" });
+    const data = await res.json();
+    if (!res.ok) { showAlert("err", data.error); return; }
+    if (data.preserved) {
+      showAlert("ok", "Existing keypair found at " + data.privateKeyPath + " — preserved.");
+    } else {
+      showAlert("ok", "New keypair generated. Public key written to " + data.publicKeyPath + ". Paste it into src/core/license.ts KULVEX_LICENSE_PUBLIC_KEY for verification.");
+    }
+  } catch (err) {
+    showAlert("err", "Network error: " + err.message);
+  }
+});
+
+document.getElementById("copyBtn").addEventListener("click", () => {
+  if (!window.__lastJwt) return;
+  navigator.clipboard.writeText(window.__lastJwt);
+  showAlert("ok", "Copied to clipboard.");
+});
+
+document.getElementById("downloadBtn").addEventListener("click", () => {
+  if (!window.__lastJwt) return;
+  const blob = new Blob([window.__lastJwt], { type: "text/plain" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = \`kcode-license-\${(window.__lastSub || "user").replace(/[^a-z0-9]/gi,"_")}.jwt\`;
+  a.click();
+  URL.revokeObjectURL(url);
+});
+</script>
+</body>
+</html>`;
+
+// ─── Server ─────────────────────────────────────────────────────
+
+export interface ServeOptions {
+  port: number;
+  host: string;
+}
+
+export async function startLicenseServer(opts: ServeOptions): Promise<{ url: string; stop: () => void }> {
+  const server = Bun.serve({
+    port: opts.port,
+    hostname: opts.host,
+    async fetch(req: Request): Promise<Response> {
+      const url = new URL(req.url);
+
+      if (url.pathname === "/" && req.method === "GET") {
+        return new Response(HTML, {
+          headers: { "content-type": "text/html; charset=utf-8" },
+        });
+      }
+
+      if (url.pathname === "/api/generate" && req.method === "POST") {
+        try {
+          const body = (await req.json()) as LicenseInput;
+          const result = signLicenseWithSummary(body);
+          return Response.json(result);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return Response.json({ error: msg }, { status: 400 });
+        }
+      }
+
+      if (url.pathname === "/api/init-keypair" && req.method === "POST") {
+        try {
+          const result = generateKeypair();
+          return Response.json(result);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return Response.json({ error: msg }, { status: 500 });
+        }
+      }
+
+      return new Response("Not found", { status: 404 });
+    },
+  });
+
+  const url = `http://${opts.host}:${opts.port}`;
+  log.info("license-ui", `license generator at ${url}`);
+  return {
+    url,
+    stop: () => server.stop(true),
+  };
+}


### PR DESCRIPTION
## New commands
\`\`\`
kcode license serve           # Web UI at http://127.0.0.1:11200
kcode license init-keypair    # RSA-2048 keypair (first-time)
kcode license generate        # CLI quick-gen for scripts
kcode license status          # existing, now wired up
kcode license deactivate      # remove ~/.kcode/license.jwt
\`\`\`

## Web UI
Single HTML form served inline by \`Bun.serve\`. Localhost-only by default. Inputs: email, org, tier, seats, features (multi-select), expiry (date picker), hardware binding, offline flag. Submit → JWT rendered with copy and download buttons.

## Signing
- RS256 JWT compatible with the existing verifier in \`src/core/license.ts\`
- Private key at \`~/.kcode/license-signing.pem\` (0600) or \`KCODE_LICENSE_PRIVATE_KEY\` env
- \`init-keypair\` preserves existing unless \`--force\`
- Default issuer \`kulvex.ai\` to match the verifier's hardcoded check (caught during testing)

## CLI quick-gen example
\`\`\`bash
kcode license generate --sub user@example.com --tier pro \\
  --days 365 --features pro,swarm --output user.jwt
\`\`\`

## Security
Private key never leaves the generator machine. Intended for maintainer/admin use. Public kcode releases don't need to bundle a private key — \`init-keypair\` creates one on demand.

## Test plan
- [x] 8 new tests in \`license-signer.test.ts\` (keypair, round-trip sign→verify, past-date reject, ISO-string parse, hardware binding, summary shape)
- [x] Live run: init-keypair generated RSA-2048 keypair, CLI generate produced valid JWT
- [x] v2.10.100 deployed

Co-Authored-By: Kulvex Code <contact@astrolexis.space>