### PR TITLE
feat: license activate accepts pasted JWT (no file needed) + v2.10.102

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.101",
+  "version": "2.10.102",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/cli/commands/license.ts
+++ b/src/cli/commands/license.ts
@@ -19,6 +19,22 @@
 
 import type { Command } from "commander";
 
+/**
+ * Cheap heuristic: does this look like a JWT string rather than a
+ * file path? JWTs are three dot-separated base64url chunks with a
+ * deterministic header prefix (eyJ = {"al...). Anything else is
+ * treated as a path.
+ */
+function looksLikeJwt(s: string): boolean {
+  const t = s.trim();
+  if (t.length < 50) return false; // shortest plausible JWT still > 50 chars
+  if (t.includes("/") || t.includes("\\")) return false; // path separator → it's a path
+  if (t.includes(" ") || t.includes("\n")) return false; // whitespace → not a JWT arg
+  const parts = t.split(".");
+  if (parts.length !== 3) return false;
+  return t.startsWith("eyJ"); // all base64url-encoded {"alg":...} headers start with this
+}
+
 /** True if this machine has a private signing key configured. */
 function hasPrivateSigningKey(): boolean {
   const { existsSync } = require("node:fs") as typeof import("node:fs");
@@ -65,9 +81,11 @@ export function registerLicenseCommand(program: Command): void {
   // ─── activate (end-user primary flow) ────────────────────────
 
   licenseCmd
-    .command("activate <jwt-file>")
-    .description("Activate a license from a .jwt file provided by Astrolexis")
-    .action(async (jwtFile: string) => {
+    .command("activate [jwt-or-file]")
+    .description(
+      "Activate a license — accepts a .jwt file path OR the raw JWT string pasted directly. Omit argument for interactive paste prompt.",
+    )
+    .action(async (jwtOrFile: string | undefined) => {
       const { existsSync, readFileSync, mkdirSync, writeFileSync } = await import(
         "node:fs"
       );
@@ -75,13 +93,44 @@ export function registerLicenseCommand(program: Command): void {
       const { kcodePath } = await import("../../core/paths");
       const { verifyLicenseJwt } = await import("../../core/license");
 
-      const absPath = resolve(jwtFile);
-      if (!existsSync(absPath)) {
-        console.error(`\x1b[31m✗\x1b[0m File not found: ${absPath}`);
+      let token: string;
+
+      if (!jwtOrFile) {
+        // Interactive: prompt for paste. User pastes JWT, Enter.
+        const { createInterface } = await import("node:readline");
+        const rl = createInterface({ input: process.stdin, output: process.stdout });
+        token = await new Promise<string>((r) => {
+          rl.question(
+            "Paste your license JWT (press Enter when done):\n> ",
+            (a) => {
+              rl.close();
+              r(a.trim());
+            },
+          );
+        });
+      } else if (looksLikeJwt(jwtOrFile)) {
+        // User pasted the JWT directly as the argument.
+        token = jwtOrFile.trim();
+      } else {
+        // Treat as file path (supports ~ expansion).
+        const home = process.env.HOME ?? "";
+        const expanded = jwtOrFile.startsWith("~/") ? home + jwtOrFile.slice(1) : jwtOrFile;
+        const absPath = resolve(expanded);
+        if (!existsSync(absPath)) {
+          console.error(`\x1b[31m✗\x1b[0m File not found: ${absPath}`);
+          console.error(
+            `  \x1b[2mTip: if you meant to paste the JWT directly, wrap it in quotes.\x1b[0m`,
+          );
+          process.exit(1);
+        }
+        token = readFileSync(absPath, "utf-8").trim();
+      }
+
+      if (!token) {
+        console.error(`\x1b[31m✗\x1b[0m No license token provided.`);
         process.exit(1);
       }
 
-      const token = readFileSync(absPath, "utf-8").trim();
       const result = verifyLicenseJwt(token);
       if (!result.valid || !result.claims) {
         console.error(`\x1b[31m✗\x1b[0m License invalid: ${result.error}`);

--- a/src/ui/hooks/useMessageProcessor.ts
+++ b/src/ui/hooks/useMessageProcessor.ts
@@ -491,7 +491,7 @@ export function useMessageProcessor(params: UseMessageProcessorParams): UseMessa
                   kind: "text",
                   role: "system",
                   text:
-                    "\n  Usage: /license activate <path-to-file.jwt>\n  Example: /license activate ~/Downloads/license.jwt\n",
+                    "\n  Usage:\n    /license activate <path>                — from a .jwt file\n    /license activate eyJhbGci...xyz        — paste the JWT directly\n",
                 },
               ]);
               return;
@@ -503,20 +503,39 @@ export function useMessageProcessor(params: UseMessageProcessorParams): UseMessa
             const { kcodePath } = await import("../../core/paths");
             const { verifyLicenseJwt } = await import("../../core/license");
 
-            // Expand ~ if present
-            const home = process.env.HOME ?? "";
-            const expanded = arg.startsWith("~/") ? home + arg.slice(1) : arg;
-            const absPath = resolve(expanded);
+            // Autodetect: is this the JWT itself, or a path?
+            // JWTs are 3 dot-separated base64url chunks, start with "eyJ",
+            // contain no path separators or whitespace, and are long.
+            const looksLikeJwt =
+              arg.trim().length >= 50 &&
+              arg.trim().startsWith("eyJ") &&
+              arg.trim().split(".").length === 3 &&
+              !arg.includes("/") &&
+              !arg.includes("\\") &&
+              !arg.includes(" ");
 
-            if (!existsSync(absPath)) {
-              setCompleted((prev) => [
-                ...prev,
-                { kind: "text", role: "system", text: `\n  \u2717 File not found: ${absPath}\n` },
-              ]);
-              return;
+            let token: string;
+            if (looksLikeJwt) {
+              token = arg.trim();
+            } else {
+              // Expand ~ if present
+              const home = process.env.HOME ?? "";
+              const expanded = arg.startsWith("~/") ? home + arg.slice(1) : arg;
+              const absPath = resolve(expanded);
+
+              if (!existsSync(absPath)) {
+                setCompleted((prev) => [
+                  ...prev,
+                  {
+                    kind: "text",
+                    role: "system",
+                    text: `\n  \u2717 File not found: ${absPath}\n  (If you meant to paste the JWT directly, make sure it starts with \"eyJ\" and has no spaces.)\n`,
+                  },
+                ]);
+                return;
+              }
+              token = readFileSync(absPath, "utf-8").trim();
             }
-
-            const token = readFileSync(absPath, "utf-8").trim();
             const result = verifyLicenseJwt(token);
             if (!result.valid || !result.claims) {
               setCompleted((prev) => [


### PR DESCRIPTION
## User feedback
> \"como carajos pego una licencia sin pegar un archivo\"

Fair. Requiring the end user to save the JWT to disk before activating is friction. Now both CLI and TUI accept the JWT string directly:

\`\`\`bash
# CLI (all three forms work)
kcode license activate ~/path.jwt            # file
kcode license activate \"eyJhbGci...xyz\"      # literal JWT
kcode license activate                        # interactive prompt

# TUI
/license activate ~/path.jwt                 # file
/license activate eyJhbGci...xyz             # literal JWT
\`\`\`

Detection: starts with \"eyJ\", 3 dot-separated parts, no spaces/slashes, ≥50 chars → literal JWT. Anything else → file path.

If a \"not found\" file looks like it might have been an attempted paste, the error message hints at that.

## Test plan
- [x] \`kcode license activate \"\$(cat license.jwt)\"\` — detected as JWT, parsed ✓
- [x] v2.10.102 deployed

Co-Authored-By: Kulvex Code <contact@astrolexis.space>