### PR TITLE
feat: Astrolexis OAuth subscription + /login in TUI + v2.10.103

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.102",
+  "version": "2.10.103",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/auth/oauth-flow.ts
+++ b/src/core/auth/oauth-flow.ts
@@ -18,6 +18,19 @@ export const PROVIDER_CONFIGS: Record<string, Partial<OAuthConfig>> = {
     scopes: ["api", "sync"],
     label: "KCode Cloud",
   },
+  astrolexis: {
+    // Astrolexis licensing: OAuth PKCE against astrolexis.space.
+    // The site handles login/signup, binds the kcode install to the
+    // user's subscription, and returns an access_token. The access
+    // token is later used to hit GET /api/subscription for tier +
+    // feature + seat info — see src/core/subscription.ts.
+    provider: "astrolexis",
+    authorizationUrl: "https://astrolexis.space/oauth/authorize",
+    tokenUrl: "https://astrolexis.space/oauth/token",
+    clientId: "kcode-cli",
+    scopes: ["subscription:read"],
+    label: "Astrolexis",
+  },
   anthropic: {
     provider: "anthropic",
     authorizationUrl: "https://console.anthropic.com/oauth/authorize",

--- a/src/core/pro.ts
+++ b/src/core/pro.ts
@@ -174,8 +174,27 @@ export async function isPro(): Promise<boolean> {
 
 async function _doValidation(): Promise<boolean> {
   try {
+    // ── Priority 0: Astrolexis OAuth subscription ─────────────────
+    // The new canonical path: user ran /login in the TUI, we have
+    // an OAuth access token for astrolexis.space, and the server
+    // says their subscription is active. Cached for 1h to avoid
+    // hammering the API. Falls through to the offline/key paths
+    // below if no token is configured (e.g., air-gapped installs).
+    try {
+      const { hasProSubscription } = await import("./subscription.js");
+      const active = await hasProSubscription();
+      if (active) {
+        log.debug("pro", "Activated via Astrolexis OAuth subscription");
+        return true;
+      }
+    } catch (err) {
+      // Subscription module unavailable or threw — silently fall
+      // through. We don't want isPro() to throw under any condition.
+      log.debug("pro", `subscription check skipped: ${err}`);
+    }
+
     // ── Priority 1: Offline license file (JWT) ──────────────────
-    // Check for a signed license file first — this never requires network.
+    // Check for a signed license file next — this never requires network.
     // Supports air-gapped/on-prem deployments with permanent offline Pro.
     const licenseResult = checkOfflineLicense();
     if (licenseResult.valid) {

--- a/src/core/skills.ts
+++ b/src/core/skills.ts
@@ -401,6 +401,7 @@ export class SkillManager {
     lines.push("  /model, /toggle, /switch      Switch between local and cloud models");
     lines.push("  /cloud, /api-key, /provider   Configure cloud API providers");
     lines.push("  /auth                         OAuth login/status/logout for cloud providers");
+    lines.push("  /login, /logout               Astrolexis OAuth login / logout");
     lines.push("  /license                      License status / activate <path> / deactivate");
     lines.push("  /plugin, /plugins             Install, list, or remove plugins");
     lines.push("  /marketplace                  Browse and install plugins from the marketplace");

--- a/src/core/subscription.test.ts
+++ b/src/core/subscription.test.ts
@@ -1,0 +1,142 @@
+// Subscription client tests. Mocks the network so we never talk to
+// the real astrolexis.space during CI.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  formatSubscription,
+  getSubscription,
+  invalidateSubscriptionCache,
+  type Subscription,
+} from "./subscription";
+
+let testHome: string;
+let origHome: string | undefined;
+let origFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  origHome = process.env.KCODE_HOME;
+  origFetch = globalThis.fetch;
+  testHome = join(tmpdir(), `kcode-sub-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(testHome, { recursive: true });
+  process.env.KCODE_HOME = testHome;
+  invalidateSubscriptionCache();
+});
+
+afterEach(() => {
+  if (origHome === undefined) delete process.env.KCODE_HOME;
+  else process.env.KCODE_HOME = origHome;
+  globalThis.fetch = origFetch;
+  if (existsSync(testHome)) rmSync(testHome, { recursive: true, force: true });
+  invalidateSubscriptionCache();
+});
+
+describe("getSubscription — network paths", () => {
+  test("returns free/none when no OAuth token is configured", async () => {
+    // No keychain token → fetchFromServer throws → fallback to free
+    globalThis.fetch = async () => new Response("", { status: 500 });
+    const sub = await getSubscription({ forceRefresh: true });
+    expect(sub.tier).toBe("free");
+    expect(sub.status).toBe("none");
+  });
+
+  test("uses disk cache when network fails", async () => {
+    // Seed a disk cache
+    const cachedSub: Subscription = {
+      tier: "pro",
+      features: ["pro", "swarm"],
+      seats: 5,
+      status: "active",
+      expiresAt: Math.floor(Date.now() / 1000) + 86400,
+      customer: { email: "test@example.com" },
+      fetchedAt: Date.now() - 2 * 60 * 60 * 1000, // 2h old — past TTL
+    };
+    writeFileSync(
+      join(testHome, "subscription-cache.json"),
+      JSON.stringify(cachedSub),
+      "utf-8",
+    );
+
+    // Network fails
+    globalThis.fetch = async () => {
+      throw new Error("network down");
+    };
+
+    const sub = await getSubscription({ forceRefresh: true });
+    // Stale cache returned instead of failing
+    expect(sub.tier).toBe("pro");
+    expect(sub.customer?.email).toBe("test@example.com");
+  });
+
+  test("serves fresh disk cache without hitting network", async () => {
+    const freshSub: Subscription = {
+      tier: "pro",
+      features: ["pro"],
+      seats: 1,
+      status: "active",
+      expiresAt: Math.floor(Date.now() / 1000) + 86400,
+      fetchedAt: Date.now() - 1000, // 1s old — well within TTL
+    };
+    writeFileSync(
+      join(testHome, "subscription-cache.json"),
+      JSON.stringify(freshSub),
+      "utf-8",
+    );
+
+    let fetchCalls = 0;
+    globalThis.fetch = async () => {
+      fetchCalls++;
+      return new Response("", { status: 500 });
+    };
+
+    const sub = await getSubscription(); // no forceRefresh
+    expect(sub.tier).toBe("pro");
+    expect(fetchCalls).toBe(0); // disk cache served, no network
+  });
+});
+
+describe("formatSubscription", () => {
+  test("free tier message", () => {
+    const text = formatSubscription({
+      tier: "free",
+      features: [],
+      seats: 0,
+      status: "none",
+      expiresAt: 0,
+      fetchedAt: Date.now(),
+    });
+    expect(text).toContain("Free tier");
+    expect(text).toContain("/login");
+  });
+
+  test("active pro subscription with expiry", () => {
+    const text = formatSubscription({
+      tier: "pro",
+      features: ["pro", "swarm"],
+      seats: 5,
+      status: "active",
+      expiresAt: Math.floor(Date.now() / 1000) + 30 * 86400,
+      customer: { email: "user@acme.com", orgName: "Acme" },
+      fetchedAt: Date.now(),
+    });
+    expect(text).toContain("pro");
+    expect(text).toContain("active");
+    expect(text).toContain("Seats: 5");
+    expect(text).toContain("user@acme.com");
+    expect(text).toContain("Acme");
+  });
+
+  test("lifetime subscription shows 'never'", () => {
+    const text = formatSubscription({
+      tier: "enterprise",
+      features: ["enterprise"],
+      seats: 100,
+      status: "active",
+      expiresAt: 0,
+      fetchedAt: Date.now(),
+    });
+    expect(text).toContain("never");
+  });
+});

--- a/src/core/subscription.ts
+++ b/src/core/subscription.ts
@@ -1,0 +1,282 @@
+// KCode — Astrolexis Subscription Client
+//
+// Replaces the local JWT license file with a live OAuth-backed
+// subscription check against astrolexis.space. End user runs
+// `/login` inside the TUI once; after that, kcode knows the tier /
+// features / seats by hitting GET /api/subscription with the stored
+// access token. Revocation is instant (server-side subscription
+// status changes propagate on the next check).
+//
+// Backend contract (what astrolexis.space must expose):
+//
+//   GET https://astrolexis.space/api/subscription
+//   Authorization: Bearer <access_token>
+//   →
+//   {
+//     "tier": "free" | "pro" | "team" | "enterprise",
+//     "features": ["pro", "swarm", "audit", ...],
+//     "seats": 5,
+//     "status": "active" | "past_due" | "canceled" | "trialing",
+//     "expiresAt": 1776600000,    // unix seconds; 0 for lifetime
+//     "customer": { "email": "...", "orgName": "Acme" }
+//   }
+//
+//   401 → token expired/revoked → caller should refresh or fall
+//         back to free tier
+//   403 → authenticated but no active subscription
+//
+// Cache: 1h in-memory to avoid hammering the API on every kcode
+// invocation or internal isPro() call. Force-refresh with
+// `invalidateSubscriptionCache()` after a /login.
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { log } from "./logger";
+import { kcodePath } from "./paths";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export type SubscriptionTier = "free" | "pro" | "team" | "enterprise";
+export type SubscriptionStatus =
+  | "active"
+  | "past_due"
+  | "canceled"
+  | "trialing"
+  | "none";
+
+export interface Subscription {
+  tier: SubscriptionTier;
+  features: string[];
+  seats: number;
+  status: SubscriptionStatus;
+  /** Unix seconds. 0 means no expiry (lifetime). */
+  expiresAt: number;
+  customer?: {
+    email?: string;
+    orgName?: string;
+  };
+  /** Unix ms when we last synced from the server. */
+  fetchedAt: number;
+}
+
+// ─── Constants ──────────────────────────────────────────────────
+
+const SUBSCRIPTION_ENDPOINT =
+  process.env.KCODE_SUBSCRIPTION_URL ??
+  "https://astrolexis.space/api/subscription";
+
+/** How long a fetched subscription is trusted before re-querying. */
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1h
+
+/** Disk cache file for offline operation — allows isPro() to return
+ * the last-known tier if the network is down or kcode is air-gapped. */
+const CACHE_FILE = () => kcodePath("subscription-cache.json");
+
+// ─── State ──────────────────────────────────────────────────────
+
+let _memCache: Subscription | null = null;
+
+// ─── Disk cache helpers ─────────────────────────────────────────
+
+function readDiskCache(): Subscription | null {
+  try {
+    const path = CACHE_FILE();
+    if (!existsSync(path)) return null;
+    const raw = JSON.parse(readFileSync(path, "utf-8"));
+    if (typeof raw.tier !== "string" || typeof raw.fetchedAt !== "number") return null;
+    return raw as Subscription;
+  } catch {
+    return null;
+  }
+}
+
+function writeDiskCache(sub: Subscription): void {
+  try {
+    const path = CACHE_FILE();
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(sub, null, 2), "utf-8");
+  } catch (err) {
+    log.debug("subscription", `failed to write cache: ${err}`);
+  }
+}
+
+// ─── Fetching ───────────────────────────────────────────────────
+
+/**
+ * Fetch subscription from astrolexis.space using the stored OAuth
+ * access token. Throws on network failures or if no token is
+ * available. 401 is translated into a free-tier Subscription object
+ * (token expired/revoked; caller should try a refresh separately).
+ */
+async function fetchFromServer(): Promise<Subscription> {
+  const { getAuthSessionManager } = await import("./auth/session.js");
+  const { resolveProviderConfig } = await import("./auth/oauth-flow.js");
+  const manager = getAuthSessionManager();
+  const cfg = resolveProviderConfig("astrolexis");
+  const token = await manager.getAccessToken("astrolexis", cfg ?? undefined);
+
+  if (!token) {
+    throw new Error("Not logged in to Astrolexis. Run /login in the TUI.");
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  try {
+    const res = await fetch(SUBSCRIPTION_ENDPOINT, {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${token}`,
+        accept: "application/json",
+      },
+      signal: controller.signal,
+    });
+
+    if (res.status === 401) {
+      // Token expired/revoked. Return free-tier as a default; caller
+      // can trigger a refresh if it wants.
+      log.debug("subscription", "401 from API — token expired or revoked");
+      return {
+        tier: "free",
+        features: [],
+        seats: 0,
+        status: "none",
+        expiresAt: 0,
+        fetchedAt: Date.now(),
+      };
+    }
+
+    if (res.status === 403) {
+      // Authenticated but no active subscription.
+      return {
+        tier: "free",
+        features: [],
+        seats: 0,
+        status: "canceled",
+        expiresAt: 0,
+        fetchedAt: Date.now(),
+      };
+    }
+
+    if (!res.ok) {
+      throw new Error(`subscription API returned ${res.status}`);
+    }
+
+    const raw = await res.json();
+    return {
+      tier: (raw.tier as SubscriptionTier) ?? "free",
+      features: Array.isArray(raw.features) ? raw.features : [],
+      seats: typeof raw.seats === "number" ? raw.seats : 1,
+      status: (raw.status as SubscriptionStatus) ?? "active",
+      expiresAt: typeof raw.expiresAt === "number" ? raw.expiresAt : 0,
+      customer: raw.customer,
+      fetchedAt: Date.now(),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// ─── Public API ─────────────────────────────────────────────────
+
+/**
+ * Get the current subscription, using cached data when possible.
+ *
+ * Cache priority:
+ *   1. Memory cache (if within TTL)
+ *   2. Disk cache (if within TTL)
+ *   3. Live fetch from astrolexis.space
+ *
+ * If live fetch fails and a stale disk cache exists, return the stale
+ * cache — this keeps kcode usable when the network is flaky. The
+ * cache file stores fetchedAt so we can tell callers how old it is.
+ */
+export async function getSubscription(opts?: {
+  forceRefresh?: boolean;
+}): Promise<Subscription> {
+  const now = Date.now();
+
+  // Memory cache
+  if (!opts?.forceRefresh && _memCache && now - _memCache.fetchedAt < CACHE_TTL_MS) {
+    return _memCache;
+  }
+
+  // Disk cache
+  if (!opts?.forceRefresh) {
+    const disk = readDiskCache();
+    if (disk && now - disk.fetchedAt < CACHE_TTL_MS) {
+      _memCache = disk;
+      return disk;
+    }
+  }
+
+  // Live fetch
+  try {
+    const sub = await fetchFromServer();
+    _memCache = sub;
+    writeDiskCache(sub);
+    return sub;
+  } catch (err) {
+    log.debug("subscription", `live fetch failed: ${err}`);
+    // Fall back to stale disk cache if present — better to let a
+    // paying user keep working offline than to hard-fail on network
+    // glitches.
+    const disk = readDiskCache();
+    if (disk) {
+      log.info(
+        "subscription",
+        `using stale disk cache (${Math.round((now - disk.fetchedAt) / 60000)}m old)`,
+      );
+      _memCache = disk;
+      return disk;
+    }
+    // No cache either → free tier.
+    return {
+      tier: "free",
+      features: [],
+      seats: 0,
+      status: "none",
+      expiresAt: 0,
+      fetchedAt: now,
+    };
+  }
+}
+
+/** Clear the in-memory cache. Called after /login or /logout. */
+export function invalidateSubscriptionCache(): void {
+  _memCache = null;
+}
+
+/**
+ * Quick-check: is the current subscription pro or better? Used by
+ * the existing isPro() path in src/core/pro.ts. Cached and non-
+ * blocking-friendly.
+ */
+export async function hasProSubscription(): Promise<boolean> {
+  const sub = await getSubscription();
+  return (
+    (sub.tier === "pro" || sub.tier === "team" || sub.tier === "enterprise") &&
+    (sub.status === "active" || sub.status === "trialing")
+  );
+}
+
+/** Human-readable summary for /license status in the TUI. */
+export function formatSubscription(sub: Subscription): string {
+  if (sub.tier === "free" || sub.status === "none") {
+    return "Free tier — no active subscription. Run /login to activate.";
+  }
+  const lines: string[] = [];
+  lines.push(`Tier: ${sub.tier}`);
+  lines.push(`Status: ${sub.status}`);
+  if (sub.seats > 0) lines.push(`Seats: ${sub.seats}`);
+  if (sub.features.length > 0) lines.push(`Features: ${sub.features.join(", ")}`);
+  if (sub.expiresAt > 0) {
+    const days = Math.floor((sub.expiresAt - Math.floor(Date.now() / 1000)) / 86400);
+    const when = new Date(sub.expiresAt * 1000).toISOString().slice(0, 10);
+    lines.push(`Expires: ${when} (${days} days)`);
+  } else {
+    lines.push(`Expires: never (lifetime)`);
+  }
+  if (sub.customer?.email) lines.push(`Customer: ${sub.customer.email}`);
+  if (sub.customer?.orgName) lines.push(`Org: ${sub.customer.orgName}`);
+  return lines.join("\n  ");
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -94,6 +94,8 @@ export default function App({ config, conversationManager, tools, initialSession
     names.add("/model");
     names.add("/switch");
     names.add("/license");
+    names.add("/login");
+    names.add("/logout");
     names.add("/plugin");
     names.add("/plugins");
     names.add("/hookify");
@@ -119,7 +121,9 @@ export default function App({ config, conversationManager, tools, initialSession
     descs["/toggle"] = "Switch between local and cloud models";
     descs["/model"] = "Switch between local and cloud models";
     descs["/switch"] = "Switch between local and cloud models";
-    descs["/license"] = "Show license status or activate a license (/license activate <path>)";
+    descs["/license"] = "Show license status or activate a license";
+    descs["/login"] = "Log in to Astrolexis (opens browser — PKCE OAuth)";
+    descs["/logout"] = "Log out of Astrolexis and clear cached subscription";
     descs["/plugin"] = "Install, list, or remove plugins";
     descs["/plugins"] = "Install, list, or remove plugins";
     descs["/hookify"] = "Manage dynamic hookify rules (create, list, toggle, delete, test)";

--- a/src/ui/hooks/useMessageProcessor.ts
+++ b/src/ui/hooks/useMessageProcessor.ts
@@ -475,6 +475,119 @@ export function useMessageProcessor(params: UseMessageProcessorParams): UseMessa
         return;
       }
 
+      // /login — OAuth PKCE flow against astrolexis.space.
+      // Generates a state + code verifier, opens the browser to
+      // astrolexis.space/oauth/authorize, starts a local callback
+      // server, exchanges the returned code for tokens, saves to
+      // keychain, invalidates the subscription cache so the next
+      // isPro() call re-fetches.
+      if (lower === "/login" || lower === "/login astrolexis") {
+        setCompleted((prev) => [...prev, { kind: "text", role: "user", text: userInput }]);
+        try {
+          const { loginProvider } = await import("../../core/auth/oauth-flow");
+          setCompleted((prev) => [
+            ...prev,
+            {
+              kind: "text",
+              role: "system",
+              text:
+                "\n  \u26A1 Opening browser for Astrolexis login...\n  A tab will open at astrolexis.space. Authorize the request there and the TUI will pick up the session automatically.\n",
+            },
+          ]);
+          const result = await loginProvider("astrolexis", {
+            onAuthUrl: (url) => {
+              setCompleted((prev) => [
+                ...prev,
+                {
+                  kind: "text",
+                  role: "system",
+                  text: `\n  If the browser didn't open, visit: ${url}\n`,
+                },
+              ]);
+              // Best-effort: open the URL with the OS default handler
+              try {
+                const opener =
+                  process.platform === "darwin"
+                    ? ["open", url]
+                    : process.platform === "win32"
+                      ? ["cmd", "/c", "start", url]
+                      : ["xdg-open", url];
+                const proc = Bun.spawn(opener, { stdout: "ignore", stderr: "ignore" });
+                proc.unref();
+              } catch {
+                /* user will click the fallback URL */
+              }
+            },
+          });
+
+          // Fresh login → invalidate subscription cache so next
+          // isPro() actually hits the server for the new token.
+          try {
+            const { invalidateSubscriptionCache, getSubscription, formatSubscription } =
+              await import("../../core/subscription");
+            invalidateSubscriptionCache();
+            const sub = await getSubscription({ forceRefresh: true });
+            setCompleted((prev) => [
+              ...prev,
+              {
+                kind: "text",
+                role: "system",
+                text: `\n  \u2713 Logged in to ${result.provider}.\n  ${formatSubscription(sub)}\n`,
+              },
+            ]);
+          } catch (err) {
+            setCompleted((prev) => [
+              ...prev,
+              {
+                kind: "text",
+                role: "system",
+                text: `\n  \u2713 Logged in to ${result.provider}, but subscription fetch failed: ${err instanceof Error ? err.message : err}\n`,
+              },
+            ]);
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          setCompleted((prev) => [
+            ...prev,
+            { kind: "text", role: "system", text: `\n  \u2717 Login failed: ${msg}\n` },
+          ]);
+        }
+        return;
+      }
+
+      // /logout — clear Astrolexis OAuth session + subscription cache
+      if (lower === "/logout") {
+        setCompleted((prev) => [...prev, { kind: "text", role: "user", text: userInput }]);
+        try {
+          const { getAuthSessionManager } = await import("../../core/auth/session");
+          const { invalidateSubscriptionCache } = await import(
+            "../../core/subscription"
+          );
+          const manager = getAuthSessionManager();
+          await manager.logout("astrolexis");
+          invalidateSubscriptionCache();
+          const { existsSync, unlinkSync } = await import("node:fs");
+          const { kcodePath } = await import("../../core/paths");
+          const cachePath = kcodePath("subscription-cache.json");
+          if (existsSync(cachePath)) unlinkSync(cachePath);
+          setCompleted((prev) => [
+            ...prev,
+            {
+              kind: "text",
+              role: "system",
+              text: "\n  \u2713 Logged out of Astrolexis. Cached subscription cleared.\n",
+            },
+          ]);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          setCompleted((prev) => [
+            ...prev,
+            { kind: "text", role: "system", text: `\n  \u2717 Logout failed: ${msg}\n` },
+          ]);
+        }
+        return;
+      }
+
       // /license — status | activate <path> | deactivate
       if (lower.startsWith("/license")) {
         setCompleted((prev) => [...prev, { kind: "text", role: "user", text: userInput }]);


### PR DESCRIPTION
## Replaces the JWT license flow with OAuth PKCE against astrolexis.space

### End-user UX
\`\`\`
$ kcode
> /login
⚡ Opening browser for Astrolexis login...
(user logs in / signs up on astrolexis.space, clicks Authorize)
✓ Logged in to astrolexis.
  Tier: pro / Status: active / Expires: 2027-04-16 (365 days)
\`\`\`

No JWT files. No paste-the-token. No hardware fingerprints. No admin keypair management. Revocation is instant on the server side.

## Client-side changes (this PR)

1. **New provider** \`astrolexis\` in \`PROVIDER_CONFIGS\` (oauth-flow.ts). Reuses existing PKCE machinery.

2. **New module** \`src/core/subscription.ts\`:
   - \`getSubscription()\` with 1h mem cache → disk cache → live fetch
   - Stale disk cache used on network failures (paying user keeps working offline)
   - \`hasProSubscription()\` quick-check
   - \`formatSubscription()\` for TUI display
   - Env override \`KCODE_SUBSCRIPTION_URL\` for staging

3. **isPro() gains Priority 0**: check Astrolexis OAuth subscription first, fall back to existing JWT/key paths (existing installs keep working).

4. **Two new TUI slash commands**: \`/login\` and \`/logout\`.

## Backend contract (NOT in this PR — astrolexis.space must expose)
\`\`\`
GET  /oauth/authorize   PKCE flow, redirect to login/signup
POST /oauth/token       code → access_token + refresh_token
GET  /api/subscription  Bearer → {tier, features, seats, status, expiresAt, customer}
\`\`\`

## Test plan
- [x] 6 new tests in \`subscription.test.ts\` (no-token, stale cache, fresh cache, format variants)
- [x] v2.10.103 deployed
- [x] \`/login\` and \`/logout\` visible in slash autocomplete and \`/help\`

Once the astrolexis.space backend is live, \`/login\` will complete the PKCE flow against those endpoints without further code changes.

Co-Authored-By: Kulvex Code <contact@astrolexis.space>