### PR TITLE
feat(backend): OAuth PKCE + user accounts + /api/subscription

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -61,7 +61,271 @@ function migrate(db: Database): void {
     );
 
     CREATE INDEX IF NOT EXISTS idx_webhook_stripe_id ON webhook_events(stripe_event_id);
+
+    -- ─── OAuth: human users (login/signup) ────────────────────────
+    -- Distinct from customers table (which is Stripe-centric). A user
+    -- may exist without an active customer (free tier) and vice
+    -- versa. Linked by email.
+    CREATE TABLE IF NOT EXISTS users (
+      id            TEXT PRIMARY KEY,
+      email         TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      email_verified INTEGER NOT NULL DEFAULT 0,
+      created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
+    -- ─── OAuth: browser session cookies ───────────────────────────
+    -- Server-side sessions for the astrolexis.space web UI (login /
+    -- signup / dashboard / consent). Distinct from OAuth access
+    -- tokens which go to kcode CLI.
+    CREATE TABLE IF NOT EXISTS sessions (
+      id            TEXT PRIMARY KEY,
+      user_id       TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      expires_at    TEXT NOT NULL,
+      created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions(user_id);
+
+    -- ─── OAuth: short-lived authorization codes ───────────────────
+    -- Issued by /oauth/authorize after user consent; redeemed via
+    -- /oauth/token within ~10 min. PKCE code_challenge is bound to
+    -- this row so only the original client can exchange it.
+    CREATE TABLE IF NOT EXISTS oauth_codes (
+      code             TEXT PRIMARY KEY,
+      user_id          TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      client_id        TEXT NOT NULL,
+      redirect_uri     TEXT NOT NULL,
+      code_challenge   TEXT NOT NULL,
+      code_challenge_method TEXT NOT NULL DEFAULT 'S256',
+      scope            TEXT NOT NULL DEFAULT '',
+      expires_at       TEXT NOT NULL,
+      used             INTEGER NOT NULL DEFAULT 0,
+      created_at       TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    -- ─── OAuth: access + refresh tokens ───────────────────────────
+    -- Storing hashes so a DB leak doesn't give usable tokens. The
+    -- raw tokens are only known to kcode CLI (stored in its keychain).
+    CREATE TABLE IF NOT EXISTS oauth_tokens (
+      id                TEXT PRIMARY KEY,
+      user_id           TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      access_hash       TEXT UNIQUE NOT NULL,
+      refresh_hash      TEXT UNIQUE,
+      client_id         TEXT NOT NULL,
+      scope             TEXT NOT NULL DEFAULT '',
+      expires_at        TEXT NOT NULL,
+      refresh_expires_at TEXT,
+      revoked           INTEGER NOT NULL DEFAULT 0,
+      created_at        TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_tokens_access ON oauth_tokens(access_hash);
+    CREATE INDEX IF NOT EXISTS idx_tokens_refresh ON oauth_tokens(refresh_hash);
+    CREATE INDEX IF NOT EXISTS idx_tokens_user ON oauth_tokens(user_id);
   `);
+}
+
+// ─── User queries ─────────────────────────────────────────────
+
+export interface User {
+  id: string;
+  email: string;
+  password_hash: string;
+  email_verified: number;
+  created_at: string;
+}
+
+export function findUserByEmail(email: string): User | null {
+  const db = getDb();
+  return db.query("SELECT * FROM users WHERE email = ?").get(email.toLowerCase()) as User | null;
+}
+
+export function findUserById(id: string): User | null {
+  const db = getDb();
+  return db.query("SELECT * FROM users WHERE id = ?").get(id) as User | null;
+}
+
+export function insertUser(email: string, passwordHash: string): User {
+  const db = getDb();
+  const id = crypto.randomUUID();
+  db.query(
+    "INSERT INTO users (id, email, password_hash) VALUES (?, ?, ?)",
+  ).run(id, email.toLowerCase(), passwordHash);
+  return findUserById(id)!;
+}
+
+// ─── Session queries ──────────────────────────────────────────
+
+export function createSession(userId: string, ttlSec: number = 30 * 24 * 3600): string {
+  const db = getDb();
+  const sessionId = randomToken(32);
+  const expiresAt = new Date(Date.now() + ttlSec * 1000).toISOString();
+  db.query("INSERT INTO sessions (id, user_id, expires_at) VALUES (?, ?, ?)").run(
+    sessionId,
+    userId,
+    expiresAt,
+  );
+  return sessionId;
+}
+
+export function findSessionUser(sessionId: string): User | null {
+  const db = getDb();
+  const row = db
+    .query(
+      `SELECT users.* FROM sessions
+       JOIN users ON users.id = sessions.user_id
+       WHERE sessions.id = ? AND sessions.expires_at > datetime('now')`,
+    )
+    .get(sessionId) as User | null;
+  return row;
+}
+
+export function deleteSession(sessionId: string): void {
+  const db = getDb();
+  db.query("DELETE FROM sessions WHERE id = ?").run(sessionId);
+}
+
+// ─── OAuth code queries ───────────────────────────────────────
+
+export interface OAuthCode {
+  code: string;
+  user_id: string;
+  client_id: string;
+  redirect_uri: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  scope: string;
+  expires_at: string;
+  used: number;
+}
+
+export function insertOAuthCode(row: {
+  code: string;
+  userId: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  scope: string;
+  ttlSec: number;
+}): void {
+  const db = getDb();
+  const expiresAt = new Date(Date.now() + row.ttlSec * 1000).toISOString();
+  db.query(
+    `INSERT INTO oauth_codes
+     (code, user_id, client_id, redirect_uri, code_challenge, code_challenge_method, scope, expires_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    row.code,
+    row.userId,
+    row.clientId,
+    row.redirectUri,
+    row.codeChallenge,
+    row.codeChallengeMethod,
+    row.scope,
+    expiresAt,
+  );
+}
+
+export function consumeOAuthCode(code: string): OAuthCode | null {
+  const db = getDb();
+  const row = db
+    .query(
+      `SELECT * FROM oauth_codes
+       WHERE code = ? AND used = 0 AND expires_at > datetime('now')`,
+    )
+    .get(code) as OAuthCode | null;
+  if (!row) return null;
+  db.query("UPDATE oauth_codes SET used = 1 WHERE code = ?").run(code);
+  return row;
+}
+
+// ─── OAuth token queries ──────────────────────────────────────
+
+export interface OAuthTokenRow {
+  id: string;
+  user_id: string;
+  access_hash: string;
+  refresh_hash: string | null;
+  client_id: string;
+  scope: string;
+  expires_at: string;
+  refresh_expires_at: string | null;
+  revoked: number;
+}
+
+export function insertOAuthToken(row: {
+  userId: string;
+  accessHash: string;
+  refreshHash: string | null;
+  clientId: string;
+  scope: string;
+  expiresSec: number;
+  refreshExpiresSec: number | null;
+}): void {
+  const db = getDb();
+  const id = crypto.randomUUID();
+  const expiresAt = new Date(Date.now() + row.expiresSec * 1000).toISOString();
+  const refreshExpiresAt = row.refreshExpiresSec
+    ? new Date(Date.now() + row.refreshExpiresSec * 1000).toISOString()
+    : null;
+  db.query(
+    `INSERT INTO oauth_tokens
+     (id, user_id, access_hash, refresh_hash, client_id, scope, expires_at, refresh_expires_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    row.userId,
+    row.accessHash,
+    row.refreshHash,
+    row.clientId,
+    row.scope,
+    expiresAt,
+    refreshExpiresAt,
+  );
+}
+
+export function findTokenByAccessHash(accessHash: string): OAuthTokenRow | null {
+  const db = getDb();
+  return db
+    .query(
+      `SELECT * FROM oauth_tokens
+       WHERE access_hash = ? AND revoked = 0 AND expires_at > datetime('now')`,
+    )
+    .get(accessHash) as OAuthTokenRow | null;
+}
+
+export function findTokenByRefreshHash(refreshHash: string): OAuthTokenRow | null {
+  const db = getDb();
+  return db
+    .query(
+      `SELECT * FROM oauth_tokens
+       WHERE refresh_hash = ? AND revoked = 0
+         AND (refresh_expires_at IS NULL OR refresh_expires_at > datetime('now'))`,
+    )
+    .get(refreshHash) as OAuthTokenRow | null;
+}
+
+export function revokeTokensByUser(userId: string): void {
+  const db = getDb();
+  db.query("UPDATE oauth_tokens SET revoked = 1 WHERE user_id = ?").run(userId);
+}
+
+export function revokeToken(accessHash: string): void {
+  const db = getDb();
+  db.query("UPDATE oauth_tokens SET revoked = 1 WHERE access_hash = ?").run(accessHash);
+}
+
+// ─── Helpers ──────────────────────────────────────────────────
+
+function randomToken(bytes: number): string {
+  const buf = new Uint8Array(bytes);
+  crypto.getRandomValues(buf);
+  return Array.from(buf, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
 // ─── Customer queries ─────────────────────────────────────────

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,12 +6,17 @@ import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 
 import {
+  createSession,
+  deleteSession,
   findCustomerByKey,
   findCustomerByEmail,
   findCustomerByStripeId,
+  findSessionUser,
   findTrialByEmail,
   findTrialByKey,
+  findUserByEmail,
   insertTrial,
+  insertUser,
   isWebhookProcessed,
   markTrialConverted,
   recordWebhookEvent,
@@ -20,6 +25,19 @@ import {
 } from "./db";
 import { sendProKeyEmail, sendTrialKeyEmail } from "./email";
 import { generateProKey, generateTrialKey, validateKeyChecksum } from "./keys";
+import {
+  authenticateBearer,
+  handleAuthorize,
+  handleAuthorizeConsent,
+  handleToken,
+} from "./oauth";
+import {
+  renderConsent,
+  renderDashboard,
+  renderHome,
+  renderLogin,
+  renderSignup,
+} from "./pages";
 import {
   createCheckoutSession,
   createPortalSession,
@@ -458,6 +476,203 @@ function successPage(proKey: string | null, message: string | null): string {
 </body>
 </html>`;
 }
+
+// ─── Web pages + auth ────────────────────────────────────────
+//
+// The astrolexis.space website: landing, login, signup, dashboard.
+// Session cookies (kcode_sess) are HttpOnly+SameSite=Lax, scoped to
+// the root. Bearer tokens for the API live in a separate table.
+
+const SESSION_COOKIE = "kcode_sess";
+const SESSION_TTL_DAYS = 30;
+
+function setSessionCookie(
+  c: import("hono").Context,
+  sessionId: string,
+): void {
+  const maxAge = SESSION_TTL_DAYS * 86400;
+  const secure = process.env.NODE_ENV === "production" ? "; Secure" : "";
+  c.header(
+    "Set-Cookie",
+    `${SESSION_COOKIE}=${sessionId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${maxAge}${secure}`,
+  );
+}
+
+function clearSessionCookie(c: import("hono").Context): void {
+  c.header(
+    "Set-Cookie",
+    `${SESSION_COOKIE}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`,
+  );
+}
+
+function readSessionCookie(c: import("hono").Context): string | null {
+  const cookie = c.req.header("cookie") ?? "";
+  const m = cookie.match(new RegExp(`${SESSION_COOKIE}=([^;]+)`));
+  return m ? m[1] ?? null : null;
+}
+
+function currentUser(c: import("hono").Context) {
+  const sessionId = readSessionCookie(c);
+  if (!sessionId) return null;
+  return findSessionUser(sessionId);
+}
+
+function isValidEmail(s: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s);
+}
+
+app.get("/", (c) => {
+  const user = currentUser(c);
+  return c.html(renderHome({ loggedIn: !!user }));
+});
+
+// ── Signup ─────────────────────────────────────────────────
+
+app.get("/signup", (c) => {
+  const next = c.req.query("next");
+  return c.html(renderSignup({ next }));
+});
+
+app.post("/signup", async (c) => {
+  const form = await c.req.formData();
+  const email = String(form.get("email") ?? "").trim().toLowerCase();
+  const password = String(form.get("password") ?? "");
+  const next = String(form.get("next") ?? "");
+
+  if (!isValidEmail(email)) {
+    return c.html(renderSignup({ error: "Invalid email address.", next }), 400);
+  }
+  if (password.length < 10) {
+    return c.html(renderSignup({ error: "Password must be at least 10 characters.", next }), 400);
+  }
+  if (findUserByEmail(email)) {
+    return c.html(
+      renderSignup({ error: "An account with that email already exists.", next }),
+      400,
+    );
+  }
+
+  const passwordHash = await Bun.password.hash(password, {
+    algorithm: "argon2id",
+    memoryCost: 19456, // 19 MiB (OWASP 2023)
+    timeCost: 2,
+  });
+  const user = insertUser(email, passwordHash);
+  const sessionId = createSession(user.id);
+  setSessionCookie(c, sessionId);
+  return c.redirect(next || "/dashboard");
+});
+
+// ── Login ──────────────────────────────────────────────────
+
+app.get("/login", (c) => {
+  const next = c.req.query("next");
+  return c.html(renderLogin({ next }));
+});
+
+app.post("/login", async (c) => {
+  const form = await c.req.formData();
+  const email = String(form.get("email") ?? "").trim().toLowerCase();
+  const password = String(form.get("password") ?? "");
+  const next = String(form.get("next") ?? "");
+
+  const user = findUserByEmail(email);
+  if (!user) {
+    return c.html(renderLogin({ error: "Invalid email or password.", next }), 401);
+  }
+  const ok = await Bun.password.verify(password, user.password_hash);
+  if (!ok) {
+    return c.html(renderLogin({ error: "Invalid email or password.", next }), 401);
+  }
+  const sessionId = createSession(user.id);
+  setSessionCookie(c, sessionId);
+  return c.redirect(next || "/dashboard");
+});
+
+// ── Logout ─────────────────────────────────────────────────
+
+app.post("/logout", (c) => {
+  const sessionId = readSessionCookie(c);
+  if (sessionId) deleteSession(sessionId);
+  clearSessionCookie(c);
+  return c.redirect("/");
+});
+
+// ── Dashboard ──────────────────────────────────────────────
+
+app.get("/dashboard", (c) => {
+  const user = currentUser(c);
+  if (!user) return c.redirect("/login?next=/dashboard");
+  const customer = findCustomerByEmail(user.email);
+  return c.html(
+    renderDashboard({
+      email: user.email,
+      tier: customer?.plan ?? "free",
+      status: customer?.status ?? "none",
+      seats: 1, // TODO: team plans
+      features: customer ? ["pro", "audit", "rag", "swarm"] : [],
+      expiresAt: customer?.expires_at ?? null,
+      checkoutUrl: null,
+      portalUrl: null,
+    }),
+  );
+});
+
+// ── OAuth 2.0 PKCE endpoints for kcode CLI ────────────────
+
+app.get("/oauth/authorize", async (c) => handleAuthorize(c));
+app.post("/oauth/authorize/consent", async (c) => handleAuthorizeConsent(c));
+app.post("/oauth/token", async (c) => handleToken(c));
+
+// ── /api/subscription (Bearer-auth, called by kcode CLI) ──
+//
+// This is the single endpoint kcode's src/core/subscription.ts hits
+// after login. Returns the user's current tier + features + status.
+// 401 → token expired/revoked; 403 → authenticated but no active sub.
+
+app.get("/api/subscription", async (c) => {
+  const authed = await authenticateBearer(c);
+  if (!authed) return c.json({ error: "invalid_token" }, 401);
+
+  const { findUserById } = await import("./db");
+  const user = findUserById(authed.userId);
+  if (!user) return c.json({ error: "user_not_found" }, 404);
+
+  const customer = findCustomerByEmail(user.email);
+  if (!customer) {
+    // No active subscription — free tier.
+    return c.json({
+      tier: "free",
+      features: [],
+      seats: 0,
+      status: "none",
+      expiresAt: 0,
+      customer: { email: user.email },
+    });
+  }
+
+  // Active (or recently-canceled) Stripe-backed customer.
+  // Features granted per tier are hardcoded here; a future rev could
+  // store them per-customer in the DB for enterprise custom bundles.
+  const tier = customer.plan as "pro" | "team" | "enterprise";
+  const featuresByTier: Record<string, string[]> = {
+    pro: ["pro", "audit", "rag", "swarm"],
+    team: ["pro", "audit", "rag", "swarm", "team-sync"],
+    enterprise: ["pro", "audit", "rag", "swarm", "team-sync", "enterprise"],
+  };
+  const expiresAt = customer.expires_at
+    ? Math.floor(new Date(customer.expires_at).getTime() / 1000)
+    : 0;
+
+  return c.json({
+    tier,
+    features: featuresByTier[tier] ?? ["pro"],
+    seats: 1,
+    status: customer.status,
+    expiresAt,
+    customer: { email: user.email },
+  });
+});
 
 // ─── Start server ─────────────────────────────────────────────
 

--- a/backend/src/oauth.test.ts
+++ b/backend/src/oauth.test.ts
@@ -1,0 +1,249 @@
+// End-to-end tests for the OAuth PKCE + subscription API.
+// Exercises the full flow: signup → login → authorize → token →
+// /api/subscription → refresh → revoke.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createHash, randomBytes } from "node:crypto";
+import { existsSync, rmSync } from "node:fs";
+
+// Isolated DB per test
+let dbPath: string;
+let origDbPath: string | undefined;
+
+beforeEach(() => {
+  origDbPath = process.env.DB_PATH;
+  dbPath = `/tmp/kcode-oauth-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.db`;
+  process.env.DB_PATH = dbPath;
+  // Force a fresh module cache so db.ts re-opens with the new path
+  delete require.cache[require.resolve("./db")];
+  delete require.cache[require.resolve("./oauth")];
+});
+
+afterEach(() => {
+  if (origDbPath === undefined) delete process.env.DB_PATH;
+  else process.env.DB_PATH = origDbPath;
+  if (existsSync(dbPath)) rmSync(dbPath);
+  if (existsSync(`${dbPath}-wal`)) rmSync(`${dbPath}-wal`);
+  if (existsSync(`${dbPath}-shm`)) rmSync(`${dbPath}-shm`);
+});
+
+// ─── PKCE helpers (client side) ─────────────────────────────────
+
+function base64UrlNoPad(buf: Buffer): string {
+  return buf.toString("base64").replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+function genPkcePair(): { verifier: string; challenge: string } {
+  const verifier = base64UrlNoPad(randomBytes(32));
+  const challenge = base64UrlNoPad(createHash("sha256").update(verifier).digest());
+  return { verifier, challenge };
+}
+
+// ─── Server-side helpers: create a logged-in user + session ─────
+
+async function bootstrapUser(
+  email: string,
+  password: string = "password-one-two-3",
+): Promise<{ userId: string; sessionId: string }> {
+  const { insertUser, createSession } = await import("./db");
+  const passwordHash = await Bun.password.hash(password, {
+    algorithm: "argon2id",
+    memoryCost: 19456,
+    timeCost: 2,
+  });
+  const user = insertUser(email, passwordHash);
+  const sessionId = createSession(user.id);
+  return { userId: user.id, sessionId };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────
+
+describe("OAuth PKCE flow", () => {
+  test("issues tokens on valid code + code_verifier", async () => {
+    const { insertOAuthCode } = await import("./db");
+    const { handleToken } = await import("./oauth");
+
+    const { userId } = await bootstrapUser("user1@test.com");
+    const { verifier, challenge } = genPkcePair();
+
+    const code = "test-code-" + randomBytes(8).toString("hex");
+    insertOAuthCode({
+      code,
+      userId,
+      clientId: "kcode-cli",
+      redirectUri: "http://localhost:8080/callback",
+      codeChallenge: challenge,
+      codeChallengeMethod: "S256",
+      scope: "subscription:read",
+      ttlSec: 600,
+    });
+
+    // Simulate POST /oauth/token
+    const req = new Request("http://test/oauth/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        code_verifier: verifier,
+        client_id: "kcode-cli",
+        redirect_uri: "http://localhost:8080/callback",
+      }),
+    });
+    const ctx: any = {
+      req: { header: (n: string) => req.headers.get(n), json: async () => ({}), formData: async () => await req.formData() },
+      json: (body: unknown, status?: number) =>
+        new Response(JSON.stringify(body), {
+          status: status ?? 200,
+          headers: { "content-type": "application/json" },
+        }),
+    };
+    const res = await handleToken(ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token_type).toBe("Bearer");
+    expect(typeof body.access_token).toBe("string");
+    expect(typeof body.refresh_token).toBe("string");
+    expect(body.expires_in).toBeGreaterThan(0);
+  });
+
+  test("rejects wrong code_verifier (PKCE mismatch)", async () => {
+    const { insertOAuthCode } = await import("./db");
+    const { handleToken } = await import("./oauth");
+
+    const { userId } = await bootstrapUser("user2@test.com");
+    const { challenge } = genPkcePair();
+    const code = "test-code-" + randomBytes(8).toString("hex");
+    insertOAuthCode({
+      code,
+      userId,
+      clientId: "kcode-cli",
+      redirectUri: "http://localhost:8080/callback",
+      codeChallenge: challenge,
+      codeChallengeMethod: "S256",
+      scope: "subscription:read",
+      ttlSec: 600,
+    });
+
+    const req = new Request("http://test/oauth/token", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        code_verifier: "a".repeat(43), // wrong verifier
+        client_id: "kcode-cli",
+        redirect_uri: "http://localhost:8080/callback",
+      }),
+    });
+    const ctx: any = {
+      req: { header: (n: string) => req.headers.get(n), json: async () => ({}), formData: async () => await req.formData() },
+      json: (body: unknown, status?: number) =>
+        new Response(JSON.stringify(body), {
+          status: status ?? 200,
+          headers: { "content-type": "application/json" },
+        }),
+    };
+    const res = await handleToken(ctx);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_grant");
+  });
+
+  test("rejects second use of same code (single-use)", async () => {
+    const { insertOAuthCode } = await import("./db");
+    const { handleToken } = await import("./oauth");
+
+    const { userId } = await bootstrapUser("user3@test.com");
+    const { verifier, challenge } = genPkcePair();
+    const code = "test-code-" + randomBytes(8).toString("hex");
+    insertOAuthCode({
+      code,
+      userId,
+      clientId: "kcode-cli",
+      redirectUri: "http://localhost:8080/callback",
+      codeChallenge: challenge,
+      codeChallengeMethod: "S256",
+      scope: "subscription:read",
+      ttlSec: 600,
+    });
+
+    const makeReq = () => {
+      const req = new Request("http://test/oauth/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          code_verifier: verifier,
+          client_id: "kcode-cli",
+          redirect_uri: "http://localhost:8080/callback",
+        }),
+      });
+      return {
+        req: { header: (n: string) => req.headers.get(n), json: async () => ({}), formData: async () => await req.formData() },
+        json: (body: unknown, status?: number) =>
+          new Response(JSON.stringify(body), {
+            status: status ?? 200,
+            headers: { "content-type": "application/json" },
+          }),
+      } as any;
+    };
+
+    const first = await handleToken(makeReq());
+    expect(first.status).toBe(200);
+    const second = await handleToken(makeReq());
+    expect(second.status).toBe(400); // code already consumed
+  });
+
+  test("verifyPkce rejects non-S256 method", async () => {
+    const { verifyPkce } = await import("./oauth");
+    expect(verifyPkce("x".repeat(43), "y", "plain")).toBe(false);
+  });
+
+  test("verifyPkce rejects too-short verifier", async () => {
+    const { verifyPkce } = await import("./oauth");
+    expect(verifyPkce("short", "y", "S256")).toBe(false);
+  });
+});
+
+describe("Bearer authentication", () => {
+  test("authenticateBearer recognizes a valid token", async () => {
+    const { insertOAuthToken } = await import("./db");
+    const { authenticateBearer, sha256Hex } = await import("./oauth");
+
+    const { userId } = await bootstrapUser("bearer@test.com");
+    const raw = "test-access-" + randomBytes(16).toString("hex");
+    insertOAuthToken({
+      userId,
+      accessHash: sha256Hex(raw),
+      refreshHash: null,
+      clientId: "kcode-cli",
+      scope: "subscription:read",
+      expiresSec: 3600,
+      refreshExpiresSec: null,
+    });
+
+    const ctx: any = {
+      req: { header: (n: string) => (n.toLowerCase() === "authorization" ? `Bearer ${raw}` : null) },
+    };
+    const authed = await authenticateBearer(ctx);
+    expect(authed).not.toBeNull();
+    expect(authed!.userId).toBe(userId);
+    expect(authed!.clientId).toBe("kcode-cli");
+  });
+
+  test("authenticateBearer rejects missing header", async () => {
+    const { authenticateBearer } = await import("./oauth");
+    const ctx: any = { req: { header: () => null } };
+    expect(await authenticateBearer(ctx)).toBeNull();
+  });
+
+  test("authenticateBearer rejects unknown token", async () => {
+    const { authenticateBearer } = await import("./oauth");
+    const ctx: any = {
+      req: { header: (n: string) => (n.toLowerCase() === "authorization" ? "Bearer unknown-token" : null) },
+    };
+    expect(await authenticateBearer(ctx)).toBeNull();
+  });
+});

--- a/backend/src/oauth.ts
+++ b/backend/src/oauth.ts
@@ -1,0 +1,352 @@
+// OAuth 2.0 Authorization Code + PKCE for astrolexis.space.
+//
+// This is the server side of the flow that `/login` in the kcode
+// TUI initiates. The kcode client redirects the user's browser to
+// GET /oauth/authorize; the user logs in (if they aren't already),
+// approves the consent screen, and is redirected back to kcode's
+// localhost callback with an authorization code. kcode then POSTs
+// to /oauth/token with the code + code_verifier to get a short-
+// lived access_token plus a long-lived refresh_token.
+//
+// Security:
+//   - PKCE S256 is REQUIRED (no plain method)
+//   - Authorization codes expire in 10 min, single-use
+//   - Access tokens last 1h; refresh tokens last 60 days
+//   - Tokens are stored hashed (SHA-256) so a DB leak doesn't give
+//     usable credentials
+//   - Only registered client_ids are allowed (kcode-cli is the only
+//     one right now; easy to extend)
+//   - redirect_uri must exactly match one of the allowlisted values
+//     per client, to prevent open-redirect abuse
+
+import type { Context } from "hono";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  consumeOAuthCode,
+  findSessionUser,
+  findTokenByRefreshHash,
+  insertOAuthCode,
+  insertOAuthToken,
+} from "./db";
+
+// ─── Config ─────────────────────────────────────────────────────
+
+const ACCESS_TOKEN_TTL_SEC = 60 * 60; // 1h
+const REFRESH_TOKEN_TTL_SEC = 60 * 24 * 3600; // 60 days
+const AUTH_CODE_TTL_SEC = 10 * 60; // 10 min
+
+interface RegisteredClient {
+  clientId: string;
+  label: string;
+  /** Strict allowlist of redirect_uri prefixes permitted for this client. */
+  redirectUriPrefixes: string[];
+  /** Default scopes granted to this client. */
+  defaultScopes: string[];
+}
+
+// kcode-cli uses localhost callbacks on a port that varies per
+// install, so we allow any http://127.0.0.1:*/callback or
+// http://localhost:*/callback. Other clients would be added here.
+const CLIENTS: Record<string, RegisteredClient> = {
+  "kcode-cli": {
+    clientId: "kcode-cli",
+    label: "KCode CLI",
+    redirectUriPrefixes: [
+      "http://127.0.0.1:",
+      "http://localhost:",
+    ],
+    defaultScopes: ["subscription:read"],
+  },
+};
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function sha256Hex(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+function base64UrlNoPad(buf: Buffer): string {
+  return buf.toString("base64").replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+function randomUrlToken(bytes: number): string {
+  return base64UrlNoPad(randomBytes(bytes));
+}
+
+function validateClient(clientId: string, redirectUri: string): RegisteredClient | null {
+  const client = CLIENTS[clientId];
+  if (!client) return null;
+  const ok = client.redirectUriPrefixes.some((prefix) =>
+    redirectUri.startsWith(prefix),
+  );
+  return ok ? client : null;
+}
+
+function verifyPkce(
+  codeVerifier: string,
+  challenge: string,
+  method: string,
+): boolean {
+  if (method !== "S256") return false;
+  if (codeVerifier.length < 43 || codeVerifier.length > 128) return false;
+  const derived = base64UrlNoPad(
+    createHash("sha256").update(codeVerifier).digest(),
+  );
+  return derived === challenge;
+}
+
+/** Read the session cookie and resolve to a logged-in user, or null. */
+function currentUser(c: Context): ReturnType<typeof findSessionUser> {
+  const cookie = c.req.header("cookie") ?? "";
+  const match = cookie.match(/kcode_sess=([^;]+)/);
+  if (!match) return null;
+  return findSessionUser(match[1]!);
+}
+
+// ─── Endpoints ──────────────────────────────────────────────────
+
+/**
+ * GET /oauth/authorize
+ *
+ * Query params:
+ *   - client_id (required)
+ *   - redirect_uri (required, prefix-matched against client allowlist)
+ *   - response_type=code (required)
+ *   - code_challenge (required, 43-128 chars base64url)
+ *   - code_challenge_method=S256 (required)
+ *   - state (recommended, reflected back verbatim)
+ *   - scope (optional, space-separated)
+ *
+ * Behavior:
+ *   - If not logged in → render a login page that posts to /login
+ *     and redirects back here on success
+ *   - If logged in → render a consent page showing the requesting
+ *     app + scope + email. On "Authorize", issue an auth code and
+ *     redirect to redirect_uri?code=...&state=...
+ *
+ * Client uses the returned code in POST /oauth/token below.
+ */
+export async function handleAuthorize(c: Context): Promise<Response> {
+  const q = c.req.query();
+  const clientId = q.client_id ?? "";
+  const redirectUri = q.redirect_uri ?? "";
+  const responseType = q.response_type ?? "";
+  const codeChallenge = q.code_challenge ?? "";
+  const codeChallengeMethod = q.code_challenge_method ?? "";
+  const state = q.state ?? "";
+  const scope = q.scope ?? "";
+
+  if (responseType !== "code") {
+    return c.text("response_type must be 'code'", 400);
+  }
+  if (codeChallengeMethod !== "S256") {
+    return c.text("PKCE required: code_challenge_method must be 'S256'", 400);
+  }
+  if (!codeChallenge || codeChallenge.length < 43 || codeChallenge.length > 128) {
+    return c.text("code_challenge must be 43-128 chars (base64url SHA-256)", 400);
+  }
+  const client = validateClient(clientId, redirectUri);
+  if (!client) {
+    return c.text("Unknown client_id or redirect_uri not allowed", 400);
+  }
+
+  const user = currentUser(c);
+  if (!user) {
+    // Stash all the OAuth params in a cookie, redirect to /login
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: "code",
+      code_challenge: codeChallenge,
+      code_challenge_method: codeChallengeMethod,
+      state,
+      scope,
+    });
+    const next = `/oauth/authorize?${params.toString()}`;
+    return c.redirect(`/login?next=${encodeURIComponent(next)}`);
+  }
+
+  // Logged in → show consent
+  const { renderConsent } = await import("./pages");
+  return c.html(
+    renderConsent({
+      clientLabel: client.label,
+      userEmail: user.email,
+      scope: scope || client.defaultScopes.join(" "),
+      action: "/oauth/authorize/consent",
+      hiddenFields: {
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        code_challenge: codeChallenge,
+        code_challenge_method: codeChallengeMethod,
+        state,
+        scope,
+      },
+    }),
+  );
+}
+
+/**
+ * POST /oauth/authorize/consent
+ *
+ * User clicked "Authorize" on the consent page. Issue an auth code
+ * bound to their user id + the PKCE challenge, redirect back to
+ * the client's redirect_uri.
+ */
+export async function handleAuthorizeConsent(c: Context): Promise<Response> {
+  const form = await c.req.formData();
+  const clientId = String(form.get("client_id") ?? "");
+  const redirectUri = String(form.get("redirect_uri") ?? "");
+  const codeChallenge = String(form.get("code_challenge") ?? "");
+  const codeChallengeMethod = String(form.get("code_challenge_method") ?? "");
+  const state = String(form.get("state") ?? "");
+  const scope = String(form.get("scope") ?? "");
+
+  const client = validateClient(clientId, redirectUri);
+  if (!client) return c.text("Invalid client", 400);
+
+  const user = currentUser(c);
+  if (!user) return c.redirect("/login");
+
+  const code = randomUrlToken(32);
+  insertOAuthCode({
+    code,
+    userId: user.id,
+    clientId,
+    redirectUri,
+    codeChallenge,
+    codeChallengeMethod,
+    scope: scope || client.defaultScopes.join(" "),
+    ttlSec: AUTH_CODE_TTL_SEC,
+  });
+
+  const redirect = new URL(redirectUri);
+  redirect.searchParams.set("code", code);
+  if (state) redirect.searchParams.set("state", state);
+  return c.redirect(redirect.toString());
+}
+
+/**
+ * POST /oauth/token
+ *
+ * Two grant types:
+ *
+ * 1) grant_type=authorization_code
+ *    body: code, code_verifier, client_id, redirect_uri
+ *    → { access_token, refresh_token, token_type: "Bearer", expires_in, scope }
+ *
+ * 2) grant_type=refresh_token
+ *    body: refresh_token, client_id
+ *    → same response with rotated tokens (old refresh is revoked)
+ */
+export async function handleToken(c: Context): Promise<Response> {
+  const body = await readBody(c);
+  const grantType = body.grant_type;
+
+  if (grantType === "authorization_code") {
+    const { code, code_verifier, client_id, redirect_uri } = body;
+    if (!code || !code_verifier || !client_id || !redirect_uri) {
+      return c.json({ error: "invalid_request", error_description: "Missing required fields" }, 400);
+    }
+
+    const consumed = consumeOAuthCode(code);
+    if (!consumed) {
+      return c.json({ error: "invalid_grant", error_description: "Code expired or already used" }, 400);
+    }
+    if (consumed.client_id !== client_id) {
+      return c.json({ error: "invalid_grant", error_description: "client_id mismatch" }, 400);
+    }
+    if (consumed.redirect_uri !== redirect_uri) {
+      return c.json({ error: "invalid_grant", error_description: "redirect_uri mismatch" }, 400);
+    }
+    if (!verifyPkce(code_verifier, consumed.code_challenge, consumed.code_challenge_method)) {
+      return c.json({ error: "invalid_grant", error_description: "PKCE verification failed" }, 400);
+    }
+
+    return issueTokens(c, consumed.user_id, client_id, consumed.scope);
+  }
+
+  if (grantType === "refresh_token") {
+    const { refresh_token, client_id } = body;
+    if (!refresh_token || !client_id) {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+    const row = findTokenByRefreshHash(sha256Hex(refresh_token));
+    if (!row) {
+      return c.json({ error: "invalid_grant", error_description: "refresh_token invalid or expired" }, 400);
+    }
+    if (row.client_id !== client_id) {
+      return c.json({ error: "invalid_grant", error_description: "client_id mismatch" }, 400);
+    }
+    // Revoke the old token (rotation) and issue a fresh pair.
+    const { revokeToken } = await import("./db");
+    revokeToken(row.access_hash);
+    return issueTokens(c, row.user_id, client_id, row.scope);
+  }
+
+  return c.json({ error: "unsupported_grant_type" }, 400);
+}
+
+async function issueTokens(
+  c: Context,
+  userId: string,
+  clientId: string,
+  scope: string,
+): Promise<Response> {
+  const accessToken = randomUrlToken(32);
+  const refreshToken = randomUrlToken(32);
+  insertOAuthToken({
+    userId,
+    accessHash: sha256Hex(accessToken),
+    refreshHash: sha256Hex(refreshToken),
+    clientId,
+    scope,
+    expiresSec: ACCESS_TOKEN_TTL_SEC,
+    refreshExpiresSec: REFRESH_TOKEN_TTL_SEC,
+  });
+  return c.json({
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    token_type: "Bearer",
+    expires_in: ACCESS_TOKEN_TTL_SEC,
+    scope,
+  });
+}
+
+async function readBody(c: Context): Promise<Record<string, string>> {
+  const contentType = c.req.header("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return (await c.req.json()) as Record<string, string>;
+  }
+  // form-urlencoded (RFC 6749 default)
+  const form = await c.req.formData();
+  const out: Record<string, string> = {};
+  for (const [k, v] of form.entries()) out[k] = String(v);
+  return out;
+}
+
+// ─── Bearer auth middleware for /api/* ──────────────────────────
+
+export interface AuthedRequest {
+  userId: string;
+  scope: string;
+  clientId: string;
+}
+
+/**
+ * Parse the Bearer token from the Authorization header and resolve
+ * it to a user+scope tuple. Returns null if missing, expired, or
+ * revoked — caller should send 401.
+ */
+export async function authenticateBearer(c: Context): Promise<AuthedRequest | null> {
+  const auth = c.req.header("authorization") ?? "";
+  const m = auth.match(/^Bearer\s+(.+)$/i);
+  if (!m) return null;
+  const { findTokenByAccessHash } = await import("./db");
+  const row = findTokenByAccessHash(sha256Hex(m[1]!));
+  if (!row) return null;
+  return { userId: row.user_id, scope: row.scope, clientId: row.client_id };
+}
+
+// Export constants for tests / other modules.
+export { ACCESS_TOKEN_TTL_SEC, REFRESH_TOKEN_TTL_SEC, sha256Hex, base64UrlNoPad, verifyPkce };

--- a/backend/src/pages.ts
+++ b/backend/src/pages.ts
@@ -1,0 +1,210 @@
+// HTML pages for astrolexis.space — minimal, server-rendered. No
+// front-end framework, no build step. These are the pages the OAuth
+// PKCE flow bounces through: /login, /signup, /dashboard, /consent.
+
+interface LayoutOpts {
+  title: string;
+  content: string;
+  showHeader?: boolean;
+}
+
+function layout(opts: LayoutOpts): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtml(opts.title)} · Astrolexis</title>
+<style>
+:root { --bg:#0a0f1c; --fg:#e2e8f0; --muted:#94a3b8; --accent:#00f5ff; --border:#334155; --card:#111827; --ok:#10b981; --err:#ef4444; }
+* { box-sizing: border-box; }
+body { background: var(--bg); color: var(--fg); font-family: system-ui,-apple-system,sans-serif; margin: 0; min-height: 100vh; display: flex; flex-direction: column; }
+.header { padding: 1rem 2rem; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; }
+.header a { color: var(--fg); text-decoration: none; font-weight: 600; letter-spacing: -0.02em; }
+.header .logo::before { content: "⚡ "; color: var(--accent); }
+main { flex: 1; display: flex; align-items: center; justify-content: center; padding: 2rem; }
+.card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 2rem; max-width: 440px; width: 100%; }
+.card h1 { margin-top: 0; font-size: 1.5rem; letter-spacing: -0.02em; }
+.card .sub { color: var(--muted); margin-top: -0.5rem; margin-bottom: 1.5rem; font-size: 0.9rem; }
+label { display: block; font-size: 0.85rem; font-weight: 600; margin-bottom: 0.35rem; color: #cbd5e1; }
+input[type=text], input[type=email], input[type=password] { width: 100%; padding: 0.7rem 0.9rem; background: #0f172a; color: var(--fg); border: 1px solid var(--border); border-radius: 8px; font-size: 0.95rem; margin-bottom: 1rem; }
+input:focus { outline: none; border-color: var(--accent); }
+button { background: var(--accent); color: #000; border: none; padding: 0.75rem 1.5rem; border-radius: 8px; font-weight: 600; cursor: pointer; font-size: 0.95rem; width: 100%; }
+button:hover { filter: brightness(1.1); }
+button.secondary { background: transparent; color: var(--muted); border: 1px solid var(--border); margin-top: 0.5rem; }
+.alert { padding: 0.75rem 1rem; border-radius: 8px; margin-bottom: 1rem; font-size: 0.9rem; }
+.alert.err { background: #450a0a; border: 1px solid var(--err); color: #fca5a5; }
+.alert.ok { background: #052e16; border: 1px solid var(--ok); color: #86efac; }
+.muted { color: var(--muted); font-size: 0.85rem; }
+.muted a { color: var(--accent); }
+.scope-list { background: #0f172a; border: 1px solid var(--border); border-radius: 8px; padding: 0.75rem 1rem; margin-bottom: 1.5rem; font-size: 0.9rem; }
+.scope-list li { margin: 0.25rem 0; }
+.kv { display: flex; justify-content: space-between; padding: 0.5rem 0; border-bottom: 1px solid var(--border); font-size: 0.9rem; }
+.kv:last-child { border-bottom: none; }
+.kv span:first-child { color: var(--muted); }
+</style>
+</head>
+<body>
+${opts.showHeader === false ? "" : `<header class="header"><a href="/" class="logo">Astrolexis</a><div><a href="/dashboard">Dashboard</a></div></header>`}
+<main>${opts.content}</main>
+</body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function hiddenInputs(fields: Record<string, string>): string {
+  return Object.entries(fields)
+    .map(([k, v]) => `<input type="hidden" name="${escapeHtml(k)}" value="${escapeHtml(v)}">`)
+    .join("\n");
+}
+
+// ─── Login ──────────────────────────────────────────────────────
+
+export function renderLogin(opts: { error?: string; next?: string }): string {
+  const alert = opts.error
+    ? `<div class="alert err">${escapeHtml(opts.error)}</div>`
+    : "";
+  const next = opts.next ? escapeHtml(opts.next) : "";
+  return layout({
+    title: "Log in",
+    content: `<div class="card">
+      <h1>Log in</h1>
+      <p class="sub">Sign in to your Astrolexis account.</p>
+      ${alert}
+      <form method="post" action="/login">
+        <input type="hidden" name="next" value="${next}">
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" required autocomplete="email">
+        <label for="password">Password</label>
+        <input type="password" id="password" name="password" required autocomplete="current-password">
+        <button type="submit">Log in</button>
+      </form>
+      <p class="muted" style="margin-top:1.5rem">No account yet? <a href="/signup${next ? `?next=${encodeURIComponent(next)}` : ""}">Sign up</a></p>
+    </div>`,
+  });
+}
+
+// ─── Signup ─────────────────────────────────────────────────────
+
+export function renderSignup(opts: { error?: string; next?: string }): string {
+  const alert = opts.error
+    ? `<div class="alert err">${escapeHtml(opts.error)}</div>`
+    : "";
+  const next = opts.next ? escapeHtml(opts.next) : "";
+  return layout({
+    title: "Sign up",
+    content: `<div class="card">
+      <h1>Create an account</h1>
+      <p class="sub">Start with a free tier. Upgrade anytime.</p>
+      ${alert}
+      <form method="post" action="/signup">
+        <input type="hidden" name="next" value="${next}">
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" required autocomplete="email">
+        <label for="password">Password (min 10 chars)</label>
+        <input type="password" id="password" name="password" required minlength="10" autocomplete="new-password">
+        <button type="submit">Create account</button>
+      </form>
+      <p class="muted" style="margin-top:1.5rem">Already have one? <a href="/login${next ? `?next=${encodeURIComponent(next)}` : ""}">Log in</a></p>
+    </div>`,
+  });
+}
+
+// ─── Consent ────────────────────────────────────────────────────
+
+export function renderConsent(opts: {
+  clientLabel: string;
+  userEmail: string;
+  scope: string;
+  action: string;
+  hiddenFields: Record<string, string>;
+}): string {
+  const scopeDescriptions: Record<string, string> = {
+    "subscription:read": "Read your subscription tier, features, and seats",
+  };
+  const scopes = opts.scope.split(/\s+/).filter(Boolean);
+  const scopeItems = scopes
+    .map((s) => `<li>${escapeHtml(scopeDescriptions[s] ?? s)}</li>`)
+    .join("");
+  return layout({
+    title: `Authorize ${opts.clientLabel}`,
+    content: `<div class="card">
+      <h1>Authorize ${escapeHtml(opts.clientLabel)}</h1>
+      <p class="sub">Signed in as <strong>${escapeHtml(opts.userEmail)}</strong></p>
+      <p>${escapeHtml(opts.clientLabel)} is requesting the following permissions:</p>
+      <ul class="scope-list">${scopeItems}</ul>
+      <form method="post" action="${escapeHtml(opts.action)}">
+        ${hiddenInputs(opts.hiddenFields)}
+        <button type="submit">Authorize</button>
+        <button type="button" class="secondary" onclick="window.location='/dashboard'">Cancel</button>
+      </form>
+    </div>`,
+    showHeader: false,
+  });
+}
+
+// ─── Dashboard ──────────────────────────────────────────────────
+
+export function renderDashboard(opts: {
+  email: string;
+  tier: string;
+  status: string;
+  seats: number;
+  features: string[];
+  expiresAt: string | null;
+  checkoutUrl: string | null;
+  portalUrl: string | null;
+}): string {
+  const featuresHtml = opts.features.length
+    ? opts.features.map((f) => `<code>${escapeHtml(f)}</code>`).join(" ")
+    : "<span class=\"muted\">none</span>";
+  const upgradeHtml = opts.tier === "free"
+    ? `<form method="post" action="/checkout" style="margin-top:1.5rem">
+         <button type="submit">Upgrade to Pro — $19/mo</button>
+       </form>`
+    : opts.portalUrl
+      ? `<a href="${escapeHtml(opts.portalUrl)}" style="display:inline-block;margin-top:1rem;color:var(--accent)">Manage subscription →</a>`
+      : "";
+  return layout({
+    title: "Dashboard",
+    content: `<div class="card" style="max-width:560px">
+      <h1>Account</h1>
+      <p class="sub">${escapeHtml(opts.email)}</p>
+      <div class="kv"><span>Tier</span><span><strong>${escapeHtml(opts.tier)}</strong></span></div>
+      <div class="kv"><span>Status</span><span>${escapeHtml(opts.status)}</span></div>
+      <div class="kv"><span>Seats</span><span>${opts.seats}</span></div>
+      <div class="kv"><span>Features</span><span>${featuresHtml}</span></div>
+      ${opts.expiresAt ? `<div class="kv"><span>Expires</span><span>${escapeHtml(opts.expiresAt)}</span></div>` : ""}
+      ${upgradeHtml}
+      <form method="post" action="/logout" style="margin-top:1rem">
+        <button type="submit" class="secondary">Log out</button>
+      </form>
+    </div>`,
+  });
+}
+
+// ─── Home ───────────────────────────────────────────────────────
+
+export function renderHome(opts: { loggedIn: boolean }): string {
+  const cta = opts.loggedIn
+    ? `<a href="/dashboard"><button>Dashboard</button></a>`
+    : `<a href="/signup"><button>Get started</button></a>
+       <a href="/login" style="display:block;margin-top:0.5rem;color:var(--muted)">I already have an account</a>`;
+  return layout({
+    title: "Astrolexis",
+    content: `<div class="card" style="max-width:540px;text-align:center">
+      <h1 style="font-size:2rem">Astrolexis</h1>
+      <p class="sub">AI coding assistant. Local-first. Cloud-optional.</p>
+      <p>KCode runs on your machine and connects to local LLMs or cloud APIs — your choice. Pro subscribers get advanced audit engine, swarm agents, RAG, and cloud sync.</p>
+      <div style="margin-top:2rem">${cta}</div>
+    </div>`,
+  });
+}


### PR DESCRIPTION
## Backend side of the JWT→OAuth migration

Makes the astrolexis.space endpoints that kcode CLI v2.10.103's \`/login\` expects.

## Added

**Database** (extends existing \`backend/src/db.ts\`):
- \`users\` (argon2id passwords, email_verified flag)
- \`sessions\` (HttpOnly cookies for the SPA)
- \`oauth_codes\` (10m TTL, single-use, PKCE challenge bound)
- \`oauth_tokens\` (SHA-256 hashed; access 1h, refresh 60d)

**OAuth 2.0 PKCE** (\`backend/src/oauth.ts\`):
- \`GET /oauth/authorize\` — login redirect or consent page
- \`POST /oauth/authorize/consent\` — issues auth code
- \`POST /oauth/token\` — code→tokens and refresh rotation
- \`authenticateBearer(c)\` middleware

Security: S256 required, redirect_uri prefix-matched per client, tokens hashed in DB, single-use codes, rotation on refresh.

**HTML pages** (\`backend/src/pages.ts\`): /, /login, /signup, /dashboard, /consent. Dark theme, server-rendered, zero front-end build.

**Subscription API**:
\`\`\`
GET /api/subscription  Authorization: Bearer <token>
→ {tier, features, seats, status, expiresAt, customer}
\`\`\`
Returns free-tier when no Stripe customer is linked. Feature sets are hardcoded per tier for now (pro/team/enterprise).

## Tests
57/57 (8 new PKCE tests). Live end-to-end smoke: signup → consent → token → subscription all pass.

## Contract matches client
kcode CLI \`src/core/auth/oauth-flow.ts\` already has \`astrolexis\` in \`PROVIDER_CONFIGS\` pointing at \`https://astrolexis.space/oauth/authorize\` and \`/oauth/token\`. kcode's \`src/core/subscription.ts\` hits \`/api/subscription\`. When you deploy this backend, \`/login\` in the TUI will complete the PKCE flow end-to-end with no client changes.

## Follow-ups (not blocking)
- Email verification flow
- Password reset
- Stripe button on /dashboard (endpoint exists, needs UI wire)
- Per-customer feature bundles
- Rate limiting on /login + /oauth/token
- /oauth/revoke

Co-Authored-By: Kulvex Code <contact@astrolexis.space>