### PR TITLE
feat(ui): tier-aware Kodi — badges, flex, dance, richer idle + v2.10.105

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.104",
+  "version": "2.10.105",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,6 +5,7 @@ import { Box, Text, useApp } from "ink";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import type { ConversationManager } from "../core/conversation.js";
 import { getRateLimitUsage } from "../core/request-builder.js";
+import { getSubscription, type SubscriptionTier } from "../core/subscription.js";
 import { SkillManager } from "../core/skills.js";
 import { CHARS_PER_TOKEN } from "../core/token-budget.js";
 import type { ToolRegistry } from "../core/tool-registry.js";
@@ -154,6 +155,36 @@ export default function App({ config, conversationManager, tools, initialSession
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [sessionStart] = useState(() => Date.now());
   const [sessionNotes, setSessionNotes] = useState<Array<{ time: string; text: string }>>([]);
+
+  // Subscription tier — fetched once at mount so Kodi can render the
+  // tier badge, trigger the entrance flex, and gate tier-aware
+  // speech. Refreshes silently in the background every 15 min in case
+  // the user upgrades mid-session. Runs against the 1h memory/disk
+  // cache inside getSubscription(), so the cost is at most one
+  // /api/subscription HTTP call per quarter hour.
+  const [subscriptionTier, setSubscriptionTier] = useState<SubscriptionTier | undefined>(undefined);
+  const [subscriptionFeatures, setSubscriptionFeatures] = useState<string[] | undefined>(undefined);
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const sub = await getSubscription();
+        if (cancelled) return;
+        setSubscriptionTier(sub.tier);
+        setSubscriptionFeatures(sub.features);
+      } catch {
+        // Not logged in / offline / no cache → fall through to free
+        // without surfacing an error in the UI.
+      }
+    };
+    load();
+    const interval = setInterval(load, 15 * 60 * 1000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
   const [watcherSuggestions, setWatcherSuggestions] = useState<string[]>([]);
   const [sessionName, setSessionName] = useState<string>(initialSessionName ?? "");
   const [sessionTags, setSessionTags] = useState<string[]>([]);
@@ -1009,6 +1040,8 @@ export default function App({ config, conversationManager, tools, initialSession
           sessionStartTime={sessionStart}
           subscriptionUsage5h={getRateLimitUsage()?.fiveHour}
           subscriptionUsage7d={getRateLimitUsage()?.sevenDay}
+          tier={subscriptionTier}
+          tierFeatures={subscriptionFeatures}
         />
         <ActivePlanPanel plan={activePlan} />
         {pendingLastModel && (

--- a/src/ui/components/Kodi.tsx
+++ b/src/ui/components/Kodi.tsx
@@ -5,7 +5,7 @@
 
 import { Box, Text } from "ink";
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import type { KodiAnimState, KodiEvent, KodiMood } from "../kodi-animation.js";
+import type { KodiAnimState, KodiEvent, KodiMood, KodiTier } from "../kodi-animation.js";
 import { KodiAnimEngine, SPEECH_CHIPS } from "../kodi-animation.js";
 import { useTheme } from "../ThemeContext.js";
 
@@ -39,6 +39,16 @@ interface KodiProps {
   subscriptionUsage5h?: number;
   /** Subscription rate limit usage (0.0-1.0) for 7-day window */
   subscriptionUsage7d?: number;
+  /**
+   * Subscription tier. Drives Kodi's permanent badge (★ ♛ ✦),
+   * tier-aware speech, entrance flourish on first detection, and a
+   * periodic flex while idle. Optional — undefined / "free" means
+   * no flourish, no badge (fully backwards compatible with sessions
+   * that never called getSubscription).
+   */
+  tier?: KodiTier;
+  /** Feature flags from the subscription (pro, audit, rag, swarm, …). */
+  tierFeatures?: string[];
 }
 
 // ─── LLM Reaction Generator ────────────────────────────────────
@@ -195,6 +205,8 @@ export default function KodiCompanion({
   sessionStartTime,
   subscriptionUsage5h,
   subscriptionUsage7d,
+  tier,
+  tierFeatures,
 }: KodiProps) {
   const { theme } = useTheme();
   const engineRef = useRef<KodiAnimEngine | null>(null);
@@ -236,6 +248,39 @@ export default function KodiCompanion({
     engine.contextPressure =
       contextWindowSize && contextWindowSize > 0 ? Math.min(1, tokenCount / contextWindowSize) : 0;
   }, [tokenCount, contextWindowSize]);
+
+  // Tier sync — entrance flourish fires automatically inside the
+  // engine the first time we transition away from "free". Subsequent
+  // re-mounts or polling refreshes are silent.
+  useEffect(() => {
+    if (tier) engine.setTier(tier);
+  }, [tier]);
+
+  // Periodic tier flex while idle — only fires for paid tiers, only
+  // while Kodi is actually idle (no active tool, no thinking). Picks
+  // a random interval between 75-105s so it doesn't feel mechanical.
+  // Free tier skips this entirely.
+  useEffect(() => {
+    if (!tier || tier === "free") return;
+    let cancelled = false;
+    const scheduleNext = () => {
+      if (cancelled) return;
+      const delay = 75_000 + Math.random() * 30_000;
+      setTimeout(() => {
+        if (cancelled) return;
+        // Only flex when we're actually idle — no point breaking a
+        // thinking animation with a sparkle.
+        if (engine.phase === "idle" && engine.mood === "idle") {
+          engine.react({ type: "tier_flex" });
+        }
+        scheduleNext();
+      }, delay);
+    };
+    scheduleNext();
+    return () => {
+      cancelled = true;
+    };
+  }, [tier, engine]);
 
   // React to events
   const handleEvent = useCallback(
@@ -373,7 +418,9 @@ export default function KodiCompanion({
       paddingX={1}
       width={process.stdout.columns || 80}
     >
-      {/* Kodi sprite — pre-composed, fixed-width lines */}
+      {/* Kodi sprite — pre-composed, fixed-width lines. The tier
+          badge (★ ♛ ✦) renders as a small overlay column to the
+          right of the head for paid tiers; free users see nothing. */}
       <Box flexDirection="column" width={15}>
         {lines.map((line, i) => (
           <Text key={i} color={moodColor}>
@@ -381,9 +428,32 @@ export default function KodiCompanion({
           </Text>
         ))}
       </Box>
+      {frame?.tierBadge && frame.tier !== "free" && (
+        <Box flexDirection="column" width={2} marginRight={1}>
+          {/* Badge floats next to the face line. The other rows stay
+              blank so the badge reads as a single cosmetic flourish
+              rather than confetti down the whole sprite. */}
+          <Text> </Text>
+          <Text
+            bold
+            color={
+              frame.tier === "enterprise"
+                ? theme.accent
+                : frame.tier === "team"
+                  ? "#ffd700"
+                  : theme.warning
+            }
+          >
+            {frame.tierBadge}
+          </Text>
+          <Text> </Text>
+          <Text> </Text>
+          <Text> </Text>
+        </Box>
+      )}
       {/* Info panel */}
       <Box flexDirection="column" flexGrow={1} marginLeft={1}>
-        {/* Line 1: Brand */}
+        {/* Line 1: Brand + tier badge */}
         <Box gap={1}>
           <Text bold color={theme.primary}>
             KCode
@@ -391,6 +461,27 @@ export default function KodiCompanion({
           <Text color={theme.dimmed}>v{version}</Text>
           <Text color={theme.dimmed}>—</Text>
           <Text color={theme.dimmed}>Kulvex Code by Astrolexis</Text>
+          {tier && tier !== "free" && (
+            <>
+              <Text color={theme.dimmed}>•</Text>
+              <Text
+                bold
+                color={
+                  tier === "enterprise"
+                    ? theme.accent
+                    : tier === "team"
+                      ? "#ffd700"
+                      : theme.warning
+                }
+              >
+                {tier === "enterprise"
+                  ? "✦ Enterprise"
+                  : tier === "team"
+                    ? "♛ Team"
+                    : "★ Pro"}
+              </Text>
+            </>
+          )}
         </Box>
         {/* Line 2: Model + mode + cwd */}
         <Box gap={1}>

--- a/src/ui/kodi-animation.test.ts
+++ b/src/ui/kodi-animation.test.ts
@@ -307,6 +307,77 @@ describe("KodiAnimEngine — no ambiguous-width Unicode", () => {
   });
 });
 
+// ─── Tier & new moods ───────────────────────────────────────────
+
+describe("KodiAnimEngine — tier flourishes", () => {
+  test("default tier is free with empty badge", () => {
+    const frame = new KodiAnimEngine().tick(200);
+    expect(frame.tier).toBe("free");
+    expect(frame.tierBadge).toBe("");
+  });
+
+  test("setTier to pro emits non-empty badge and triggers entrance flex", () => {
+    const e = new KodiAnimEngine();
+    e.setTier("pro");
+    const frame = e.tick(50);
+    expect(frame.tier).toBe("pro");
+    expect(frame.tierBadge).not.toBe("");
+    // pro entrance → flex mood with speech bubble
+    expect(frame.mood === "flex" || frame.bubble.length > 0).toBe(true);
+  });
+
+  test("enterprise entrance mood is celebrating", () => {
+    const e = new KodiAnimEngine();
+    e.setTier("enterprise");
+    const frame = e.tick(50);
+    expect(frame.mood).toBe("celebrating");
+    expect(frame.tier).toBe("enterprise");
+  });
+
+  test("tier_entrance does not refire on re-setting the same tier", () => {
+    const e = new KodiAnimEngine();
+    e.setTier("pro");
+    advance(e, 10_000); // let the entrance settle
+    e.setMood("idle");
+    advance(e, 2000);
+    e.setTier("pro"); // idempotent
+    const frame = e.tick(50);
+    expect(frame.mood).toBe("idle");
+  });
+
+  test("tier_flex on free tier is a no-op", () => {
+    const e = new KodiAnimEngine();
+    // tier defaults to free; flex should not change mood
+    e.react({ type: "tier_flex" });
+    const frame = e.tick(50);
+    expect(frame.mood).toBe("idle");
+  });
+
+  test("tier_flex on enterprise kicks Kodi into dance", () => {
+    const e = new KodiAnimEngine();
+    e.setTier("enterprise");
+    advance(e, 5000); // clear entrance
+    e.setMood("idle");
+    advance(e, 1000);
+    e.react({ type: "tier_flex" });
+    const frame = e.tick(50);
+    expect(frame.mood).toBe("dance");
+  });
+
+  test("new moods produce valid 5-line output with correct width", () => {
+    const e = new KodiAnimEngine();
+    for (const mood of ["flex", "dance", "waving"] as const) {
+      e.setMood(mood);
+      const frame = e.tick(50);
+      expect(frame.lines).toHaveLength(5);
+      // All lines same width as the existing sprite (LINE_WIDTH = 14)
+      for (const line of frame.lines) {
+        expect([...line].length).toBe(14);
+      }
+    }
+  });
+});
+
 // ─── Determinism ────────────────────────────────────────────────
 
 describe("KodiAnimEngine — determinism", () => {

--- a/src/ui/kodi-animation.ts
+++ b/src/ui/kodi-animation.ts
@@ -19,7 +19,18 @@ export type KodiMood =
   | "mischievous"
   | "crazy"
   | "angry"
-  | "smug";
+  | "smug"
+  | "flex"
+  | "dance"
+  | "waving";
+
+/**
+ * Subscription tier — drives cosmetics (accessories, aura) and behavioral
+ * flourishes (entrance mood, periodic flex, tier-aware speech). Kept
+ * decoupled from KodiMood so the tier affects presentation regardless
+ * of what Kodi happens to be doing at the moment.
+ */
+export type KodiTier = "free" | "pro" | "team" | "enterprise";
 
 export type AnimPhase = "idle" | "anticipation" | "performing" | "settling" | "cooldown";
 
@@ -42,7 +53,12 @@ export interface KodiEvent {
     | "test_pass"
     | "test_fail"
     | "commit"
-    | "error";
+    | "error"
+    // Tier-driven: fired once when the subscription tier is first
+    // detected (entrance flourish) or when the component decides to
+    // trigger a periodic flex (roughly every 90s of idle).
+    | "tier_entrance"
+    | "tier_flex";
   detail?: string;
   /** Live agent statuses for the Kodi panel */
   agentStatuses?: Array<{
@@ -62,6 +78,10 @@ export interface KodiAnimState {
   bubble: string;
   moodColor: string;
   intensity: number; // 0-1
+  /** Current tier. Free = plain; paid tiers drive badge + flourishes. */
+  tier: KodiTier;
+  /** The 1-char tier badge for this frame (cycles). Empty string on free. */
+  tierBadge: string;
 }
 
 // ─── Fixed-Width Helpers ────────────────────────────────────────
@@ -83,57 +103,118 @@ const LINE_WIDTH = 14;
 // All eye sprites use only ASCII + box-drawing (no ambiguous-width Unicode).
 // This guarantees stable column alignment across all terminals and locales.
 const EYES: Record<KodiMood, string[]> = {
-  idle: ["o  .o", "o  _o", "o  .o", "o   o"],
-  happy: ["^  .^", "^  _^", "^  -^"],
-  excited: ["* . *", "* v *", "o . o"],
-  thinking: ["o  _ o", "o  -o", "o  -o"],
-  reasoning: ["O   O", "O  _O", "O   O"],
-  working: ["o  :o", "o  :o", "-  :-"],
-  worried: ["o  ~o", "o  ~o", ";  _;"],
-  sleeping: ["-  _-", "_  __", "-  _-"],
-  celebrating: ["* v *", "^ v ^", "^ v ^"],
-  curious: ["o  .o", "o  -o", "o  .o"],
-  mischievous: [">  ->", "<  -<", ">  -~"],
-  crazy: ["@  .o", "* v @", "o . O"],
-  angry: ["># <#", ">  _<", ">  ^<"],
-  smug: ["~  -~", "- -- ", "^ -^ "],
+  // Idle is now a richer cycle: open, half-open, looking left, looking
+  // right, open again — gives Kodi a "looking around the room" feel
+  // instead of a static stare when nothing is happening.
+  idle: [
+    "o  .o",
+    "o  _o",
+    "o  .o",
+    "o   o",
+    "<   o",
+    "o   >",
+    "o  .o",
+    "O  .o",
+    "o  .O",
+    "-  _-",
+  ],
+  happy: ["^  .^", "^  _^", "^  -^", "^ _ ^", "^  v^", "^  .^"],
+  excited: ["* . *", "* v *", "o . o", "* o *", "* _ *", "o v o"],
+  thinking: ["o  _ o", "o  -o", "o  -o", "o . o", "O   o"],
+  reasoning: ["O   O", "O  _O", "O   O", "O . O", "@   O", "O  @@"],
+  working: ["o  :o", "o  :o", "-  :-", "o  :o", "O  :O"],
+  worried: ["o  ~o", "o  ~o", ";  _;", "o . o"],
+  sleeping: ["-  _-", "_  __", "-  _-", "z  zz", "_  __"],
+  celebrating: ["* v *", "^ v ^", "^ v ^", "* _ *", "^ v *", "* v ^"],
+  curious: ["o  .o", "o  -o", "o  .o", "O . o", "o . O"],
+  mischievous: [">  ->", "<  -<", ">  -~", ">  ^<", "<  ^>"],
+  crazy: ["@  .o", "* v @", "o . O", "@  _@", "*  .*"],
+  angry: ["># <#", ">  _<", ">  ^<", ">< _<", ">  v<"],
+  smug: ["~  -~", "- -- ", "^ -^ ", "~ v - ", "^ -- "],
+  // Flex: confident squint + wink cycle. Reads as "look at me."
+  flex: ["^  -^", "^ v ^", "-  _^", "^ _ -", "^ -- ^"],
+  // Dance: eyes bounce and roll.
+  dance: ["^  v^", "v  ^v", "^  v^", "v  ^v", "* v *", "^  v^"],
+  // Waving — big cheerful eyes with an arm gesture handled in BODY.
+  waving: ["^  .^", "^  _^", "^  -^", "^ _ ^"],
 };
 
 // Body sprites: the `|` (torso) must be at position 5 to align under `┬`.
 // Head: " ╭───────╮" → ┬ at pos 5.  So body: "    /|\\" puts | at pos 5.
 const BODY: Record<KodiMood, string[]> = {
-  idle: ["    /|\\  ", "    /|\\  ", "    /|\\  "],
-  happy: ["    \\|/  ", "    /|\\  ", "    /|\\  "],
-  excited: ["   \\(|)/ ", "    \\|/  ", "   \\(|)/ "],
-  thinking: ["    /|   ", "     |\\  ", "    /|   "],
-  reasoning: ["    /|\\  ", "     |\\  ", "    /|   "],
-  working: ["    /|\\ |", "    /|\\ |", "    /|\\  "],
-  worried: ["    /|\\  ", "   .-|-. ", "    \\|   "],
+  // Idle cycles through a gentle sway (arms lifting + dropping) plus
+  // an occasional hand-on-hip pose. Breathing still advances the
+  // frame pointer, so the sway reads as a natural idle breath.
+  idle: [
+    "    /|\\  ",
+    "    /|\\  ",
+    "    \\|\\  ",
+    "    /|/  ",
+    "    /|\\  ",
+    "   _/|\\_ ",
+    "    /|\\  ",
+    "    \\|/  ",
+  ],
+  happy: ["    \\|/  ", "    /|\\  ", "    /|\\  ", "   \\(|)/ ", "    \\|/  "],
+  excited: ["   \\(|)/ ", "    \\|/  ", "   \\(|)/ ", "   \\(|)- ", "   -(|)/ "],
+  thinking: ["    /|   ", "     |\\  ", "    /|   ", "    /|?  "],
+  reasoning: ["    /|\\  ", "     |\\  ", "    /|   ", "    /|@  "],
+  working: ["    /|\\ |", "    /|\\ |", "    /|\\  ", "    /|> |", "    <|\\ |"],
+  worried: ["    /|\\  ", "   .-|-. ", "    \\|   ", "    /|~  "],
   sleeping: ["    /|\\  ", "    \\|   ", "   __|__ "],
-  celebrating: ["   \\(|)/ ", "   \\(|)/ ", "   \\(|)/ "],
-  curious: ["    /|   ", "     |\\  ", "    /|   "],
-  mischievous: ["    /|-- ", "   .-|/  ", "   _/|\\  "],
-  crazy: ["  ~\\(|)/~", "   /(|)\\ ", "  ~\\(|)/~"],
-  angry: ["   =/|\\= ", "   [/|\\] ", "   =/|\\= "],
-  smug: ["   _/|\\  ", "    /|-- ", "   _/|\\  "],
+  celebrating: [
+    "   \\(|)/ ",
+    "   \\(|)/ ",
+    "   \\(|)/ ",
+    "   *(|)* ",
+    "   \\(|)- ",
+    "   -(|)/ ",
+  ],
+  curious: ["    /|   ", "     |\\  ", "    /|   ", "    /|?  "],
+  mischievous: ["    /|-- ", "   .-|/  ", "   _/|\\  ", "    /|~~ "],
+  crazy: ["  ~\\(|)/~", "   /(|)\\ ", "  ~\\(|)/~", "  *\\(|)/*"],
+  angry: ["   =/|\\= ", "   [/|\\] ", "   =/|\\= ", "   X/|\\X "],
+  smug: ["   _/|\\  ", "    /|-- ", "   _/|\\  ", "   _/|-- "],
+  // Flex: arm-curl alternation (left then right) framed by a sparkly
+  // chest. Works as a short burst on pro/team/enterprise flexes.
+  flex: ["   <(|)> ", "   <(|)/ ", "   \\(|)> ", "   <(|)> ", "   *<|>* "],
+  // Dance: a Lindy-hop-ish sway — left-right-left-right with arms up.
+  dance: [
+    "    \\|/  ",
+    "   <(|)> ",
+    "    /|\\  ",
+    "   /(|)\\ ",
+    "   \\(|)/ ",
+    "   <(|)> ",
+  ],
+  // Waving — one arm stuck up, the other bouncing side-to-side.
+  waving: ["    /|\\\\ ", "    /|/  ", "    /|\\\\ ", "    /|/  "],
 };
 
 // Legs: `/ \` should center under `|` at pos 5 → `/` at 4, `\` at 6.
 const LEGS: Record<KodiMood, string[]> = {
-  idle: ["    / \\  "],
-  happy: ["    / \\  "],
-  excited: ["   _/ \\_ ", "    / \\  "],
+  // Idle leg cycle: normal stance → weight shift left → normal →
+  // weight shift right → tiny hop. Combined with the body sway this
+  // produces a subtle "I'm alive" loop.
+  idle: ["    / \\  ", "   </ \\  ", "    / \\  ", "    / \\> ", "   _/ \\_ "],
+  happy: ["    / \\  ", "   _/ \\  ", "    / \\_ "],
+  excited: ["   _/ \\_ ", "    / \\  ", "  __/ \\__"],
   thinking: ["    / \\  "],
   reasoning: ["    / \\  "],
-  working: ["    / \\  "],
+  working: ["    / \\  ", "    /_\\  "],
   worried: ["   </ \\> ", "    / \\  "],
   sleeping: ["    / \\  "],
-  celebrating: ["   _/ \\_ ", "    / \\  "],
+  celebrating: ["   _/ \\_ ", "    / \\  ", "  __/ \\__", "   _/ \\_ "],
   curious: ["    / \\  "],
   mischievous: ["    / \\  ", "   // \\\\  "],
   crazy: ["   </ \\> ", "  ~/   \\~", "  _/   \\_"],
   angry: ["    / \\  ", "   _/ \\_ "],
   smug: ["    / \\  "],
+  // Flex: planted stance with alternating knee-pop.
+  flex: ["   _/ \\_ ", "   _/_\\_ ", "   _/ \\_ "],
+  // Dance: left-right shuffle. Each frame a different foot forward.
+  dance: ["   _/ \\  ", "    / \\_ ", "   _/ \\  ", "    / \\_ "],
+  waving: ["    / \\  ", "    / \\  ", "   _/ \\  "],
 };
 
 // Accessories — all entries must be 1-2 chars; padded to W_ACC in output
@@ -152,6 +233,27 @@ const ACCESSORIES: Record<KodiMood, string[]> = {
   crazy: ["! ", "?!", "!!"],
   angry: ["  ", "! ", "!!"],
   smug: ["  ", "* ", "~ "],
+  flex: ["* ", "! ", "+ ", "* "],
+  dance: ["~ ", "* ", "~ ", "! "],
+  waving: ["hi", "  ", "hi"],
+};
+
+// ─── Tier badge (permanent cosmetic overlay) ────────────────────
+//
+// Runs alongside the mood-based accessory and appears to the right
+// of the head. Free users see nothing extra; paid tiers get an
+// ASCII badge that cycles to feel alive. The badge is rendered in
+// its own 2-char slot so it never collides with mood accessories.
+//
+// Keep badges ≤2 characters — the header layout has a fixed LINE_WIDTH
+// and the mood accessory already consumes the column to the right of
+// the face. The tier badge sits further right (rendered separately by
+// Kodi.tsx). Emoji are avoided to keep widths predictable.
+const TIER_BADGES: Record<KodiTier, string[]> = {
+  free: ["", "", "", ""],
+  pro: ["★", "*", "★", "+"],
+  team: ["♛", "+", "♛", "*"],
+  enterprise: ["✦", "✧", "✦", "✧"],
 };
 
 // Effect particles
@@ -190,6 +292,31 @@ export const SPEECH_CHIPS: Record<string, string[]> = {
   test_fail: ["red!", "tests!", "bugs"],
 };
 
+/**
+ * Tier-aware speech. When Kodi does an entrance flex or a periodic
+ * "look at me" burst, these are pulled instead of the generic chips
+ * so the personality matches the subscription level. Free never
+ * flexes (badge is empty anyway) but keeps the key for symmetry.
+ */
+export const TIER_SPEECH: Record<KodiTier, { entrance: string[]; flex: string[] }> = {
+  free: {
+    entrance: ["hey!", "let's code"],
+    flex: ["...", "ready"],
+  },
+  pro: {
+    entrance: ["pro mode", "let's ship", "star power", "upgraded!"],
+    flex: ["★ pro", "flex", "shine", "nice ★"],
+  },
+  team: {
+    entrance: ["team up!", "♛ crew", "synced", "all hands"],
+    flex: ["♛ crown", "team!", "crew", "all good"],
+  },
+  enterprise: {
+    entrance: ["enterprise!", "full power", "✦ elite", "max mode"],
+    flex: ["✦ elite", "ultra", "max", "sparkle"],
+  },
+};
+
 // ─── Mood Rhythm ────────────────────────────────────────────────
 
 const MOOD_RHYTHM: Record<KodiMood, AnimRhythm> = {
@@ -207,6 +334,9 @@ const MOOD_RHYTHM: Record<KodiMood, AnimRhythm> = {
   crazy: "fast",
   worried: "medium",
   angry: "fast",
+  flex: "fast",
+  dance: "fast",
+  waving: "medium",
 };
 
 // ─── Phase durations (ms, consumed by tick accumulator) ─────────
@@ -290,6 +420,10 @@ export class KodiAnimEngine {
   // Context
   runningAgents = 0;
   contextPressure = 0;
+
+  // Tier (subscription level) — drives the tier badge + tier-aware
+  // entrance / flex flourishes. Default free until setTier() is called.
+  tier: KodiTier = "free";
 
   /** Advance engine by deltaMs. Pure — no setTimeout, no Date.now(). */
   tick(deltaMs: number): KodiAnimState {
@@ -398,6 +532,11 @@ export class KodiAnimEngine {
       padFixed(`${legsStr}`, LINE_WIDTH), // legs (/ \ centered under |)
     ];
 
+    // Tier badge — cycles independently of mood frames so it always
+    // feels alive even when Kodi is holding a static pose.
+    const badgeVariants = TIER_BADGES[this.tier];
+    const tierBadge = badgeVariants[this.frameIndex % badgeVariants.length] ?? "";
+
     return {
       mood: displayMood,
       phase: this.transitioning ? "anticipation" : this.phase,
@@ -405,6 +544,8 @@ export class KodiAnimEngine {
       bubble: this.bubble,
       moodColor: displayMood,
       intensity: this.intensity,
+      tier: this.tier,
+      tierBadge,
     };
   }
 
@@ -452,6 +593,20 @@ export class KodiAnimEngine {
     } else {
       this.mood = target;
       this.enterPhase("performing");
+    }
+  }
+
+  /**
+   * Swap subscription tier. The very first tier change from free to
+   * anything else triggers an entrance flex; subsequent changes are
+   * silent so re-mounts or refresh cycles don't produce confetti
+   * spam.
+   */
+  setTier(tier: KodiTier): void {
+    const previous = this.tier;
+    this.tier = tier;
+    if (previous === "free" && tier !== "free") {
+      this.react({ type: "tier_entrance" });
     }
   }
 
@@ -539,6 +694,46 @@ export class KodiAnimEngine {
         this.setMood("idle");
         this.intensity = 0.2;
         break;
+      case "tier_entrance": {
+        // Bigger entrance the higher the tier. Enterprise gets a
+        // full celebrate→dance combo, team dances, pro flexes, free
+        // just waves hi (it still feels welcoming without promising
+        // anything users aren't paying for).
+        const speech = TIER_SPEECH[this.tier].entrance;
+        const line = speech[Math.floor(Math.random() * speech.length)] ?? "hi!";
+        if (this.tier === "enterprise") {
+          this.setMood("celebrating");
+          this.say(line, 4000);
+          this.intensity = 1;
+        } else if (this.tier === "team") {
+          this.setMood("dance");
+          this.say(line, 3500);
+          this.intensity = 0.9;
+        } else if (this.tier === "pro") {
+          this.setMood("flex");
+          this.say(line, 3500);
+          this.intensity = 0.85;
+        } else {
+          this.setMood("waving");
+          this.say(line, 3000);
+          this.intensity = 0.6;
+        }
+        break;
+      }
+      case "tier_flex": {
+        // Periodic "look at me" while idle. Free stays silent.
+        if (this.tier === "free") break;
+        const speech = TIER_SPEECH[this.tier].flex;
+        const line = speech[Math.floor(Math.random() * speech.length)] ?? "";
+        // Enterprise gets dance; team flexes; pro waves — decreasing
+        // hype proportional to tier.
+        if (this.tier === "enterprise") this.setMood("dance");
+        else if (this.tier === "team") this.setMood("flex");
+        else this.setMood("waving");
+        this.say(line, 2500);
+        this.intensity = 0.7;
+        break;
+      }
     }
 
     if (this.runningAgents > 0) this.intensity = Math.min(1, this.intensity + 0.15);


### PR DESCRIPTION
## Summary

Kodi now knows whether the user is on **free / pro / team / enterprise** and reflects it visually and behaviorally. Previously Kodi looked identical for every subscriber; `/login` set the tier in `subscription.ts` but nothing surfaced it to the UI.

## What's new

### 1. Three new moods
| Mood   | Gesture |
|--------|---------|
| `flex`   | confident squint + alternating arm-curl |
| `dance`  | Lindy-hop shuffle, alternating feet |
| `waving` | cheerful one-arm-up wave |

Each has full eye / body / leg / accessory frames and proper `MOOD_RHYTHM` entries.

### 2. Richer idle loop
- **10 eye frames** (glance-left, glance-right, big-eye alert, sleepy droop, …)
- **8 body frames** (gentle arm sway + hand-on-hip)
- **5 leg frames** (weight shifts + tiny hop)

Idle is no longer a static stare — Kodi now feels alive when nothing is happening.

### 3. Tier cosmetic system
| Tier       | Badge | Color | Cycles |
|------------|-------|-------|--------|
| free       | (none) | — | — |
| pro        | ★ | yellow | `★ * + *` |
| team       | ♛ | gold `#ffd700` | `♛ + ♛ *` |
| enterprise | ✦ | `theme.accent` | `✦ ✧` |

Badge renders as an overlay column next to the face AND as a bold label on the brand line (`★ Pro`, `♛ Team`, `✦ Enterprise`).

### 4. Entrance flourish
First time Kodi learns the tier isn't free (on `/login` or session resume):
- **enterprise** → `celebrating` + "enterprise!" / "full power" / "✦ elite" / "max mode"
- **team** → `dance` + "team up!" / "♛ crew" / "synced"
- **pro** → `flex` + "pro mode" / "star power" / "upgraded!"
- **free** → `waving` + "hey!" / "let's code"

Subsequent tier reads (every 15-min background refresh) are silent — no confetti spam.

### 5. Periodic tier-flex
Every **75–105 s** of pure idle (no tool, no thinking), paid tiers get a brief flex-or-dance with tier-aware speech (`★ pro`, `♛ crown`, `✦ elite`, …). Free tier never triggers this. Interval is randomized so it never feels mechanical.

### 6. Subscription plumbing
`App.tsx` calls `getSubscription()` on mount (1h memory/disk cache already inside), refreshes every 15 min in the background, and passes `{tier, tierFeatures}` to `KodiCompanion`. Graceful fallback to `free` on any error — sessions with no `/login` or no network stay in the existing free-tier behavior.

## Testing

- [x] 7 new tests in `kodi-animation.test.ts` (default tier, entrance flourish mood per tier, idempotency, free-tier no-op, enterprise dance flex, width invariants on new moods)
- [x] 28/28 animation engine tests passing
- [x] 433/433 UI tests passing
- [x] 5069/5069 core tests passing (existing suite unaffected)
- [x] Built locally — `/home/curly/.bun/bin/kcode` → `2.10.105`

## Files changed
- `src/ui/kodi-animation.ts` — new moods, richer idle, tier badges, entrance + flex handlers
- `src/ui/kodi-animation.test.ts` — tier flourish test suite
- `src/ui/components/Kodi.tsx` — tier prop, badge overlay, brand-line label, periodic flex interval, tier sync effect
- `src/ui/App.tsx` — subscription fetch + pass-through
- `package.json` — 2.10.104 → 2.10.105

Co-Authored-By: Kulvex Code <contact@astrolexis.space>