### PR TITLE
fix: hookify YAML frontmatter prototype pollution (js-008) + v2.10.106

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.105",
+  "version": "2.10.106",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/hookify.test.ts
+++ b/src/core/hookify.test.ts
@@ -1,0 +1,119 @@
+// Hookify — YAML frontmatter parser tests.
+//
+// Focus: prototype pollution defense. Rule files come from plugins,
+// the marketplace, and user-authored files — any of which can be
+// attacker-controlled. A frontmatter key like `__proto__: {…}` would
+// previously write to Object.prototype via `meta[key] = …` on a
+// plain `{}` object. These tests pin down that reserved keys are
+// silently dropped and that normal parsing still works.
+
+import { describe, expect, test } from "bun:test";
+import { parseFrontmatter } from "./hookify";
+
+describe("hookify parseFrontmatter — prototype pollution", () => {
+  // Core invariant: after parsing any attacker-crafted frontmatter,
+  // a brand-new object literal `{}` must NOT have any attacker-
+  // injected properties. That's the real blast radius of a
+  // prototype pollution and the only assertion that matters. We
+  // deliberately avoid `toHaveProperty("__proto__")` because that
+  // walks the prototype chain and `__proto__` is always present.
+
+  function ownKeys(o: object): string[] {
+    return Object.getOwnPropertyNames(o);
+  }
+
+  test("__proto__: scalar value does not pollute Object.prototype", () => {
+    const md = `---
+name: malicious
+__proto__: polluted_via_scalar
+---
+body`;
+    const parsed = parseFrontmatter(md)!;
+    expect(parsed).not.toBeNull();
+    // No new property appeared on a fresh {}.
+    expect(({} as Record<string, unknown>).polluted_via_scalar).toBeUndefined();
+    // The reserved key is NOT an own property of meta.
+    expect(ownKeys(parsed.meta)).not.toContain("__proto__");
+    // Non-reserved sibling key still parses.
+    expect(parsed.meta.name).toBe("malicious");
+  });
+
+  test("constructor key in frontmatter is dropped as an own key", () => {
+    const md = `---
+name: malicious
+constructor: hijacked
+---
+body`;
+    const parsed = parseFrontmatter(md)!;
+    expect(ownKeys(parsed.meta)).not.toContain("constructor");
+    // The prototype-chain `constructor` is still the real Object.
+    expect(parsed.meta.constructor).toBe(Object.prototype.constructor);
+    expect(parsed.meta.name).toBe("malicious");
+  });
+
+  test("prototype key is dropped", () => {
+    const md = `---
+name: rule
+prototype: evil
+---
+body`;
+    const parsed = parseFrontmatter(md)!;
+    expect(ownKeys(parsed.meta)).not.toContain("prototype");
+    expect(parsed.meta.name).toBe("rule");
+  });
+
+  test("__proto__ as an array key does not pollute and sibling keys still parse", () => {
+    const md = `---
+__proto__:
+  - field: evil
+    operator: equals
+    pattern: x
+name: still_fine
+---
+body`;
+    const parsed = parseFrontmatter(md)!;
+    expect(ownKeys(parsed.meta)).not.toContain("__proto__");
+    // Confirm no pollution leaked to Object.prototype.
+    expect(({} as Record<string, unknown>).field).toBeUndefined();
+    expect(parsed.meta.name).toBe("still_fine");
+  });
+});
+
+describe("hookify parseFrontmatter — normal parsing still works", () => {
+  test("parses basic scalar frontmatter", () => {
+    const md = `---
+name: my-rule
+enabled: true
+event: bash
+action: warn
+---
+message body here`;
+    const parsed = parseFrontmatter(md)!;
+    expect(parsed.meta.name).toBe("my-rule");
+    expect(parsed.meta.enabled).toBe(true);
+    expect(parsed.meta.event).toBe("bash");
+    expect(parsed.meta.action).toBe("warn");
+    expect(parsed.body).toBe("message body here");
+  });
+
+  test("parses condition arrays", () => {
+    const md = `---
+name: test
+conditions:
+  - field: command
+    operator: contains
+    pattern: rm
+---
+body`;
+    const parsed = parseFrontmatter(md)!;
+    expect(Array.isArray(parsed.meta.conditions)).toBe(true);
+    const conds = parsed.meta.conditions as Array<Record<string, string>>;
+    expect(conds[0]!.field).toBe("command");
+    expect(conds[0]!.operator).toBe("contains");
+    expect(conds[0]!.pattern).toBe("rm");
+  });
+
+  test("returns null when no frontmatter block", () => {
+    expect(parseFrontmatter("just a body")).toBeNull();
+  });
+});

--- a/src/core/hookify.ts
+++ b/src/core/hookify.ts
@@ -40,7 +40,14 @@ function ruleFilePath(name: string): string {
 
 // ─── YAML Frontmatter Parsing ───────────────────────────────────
 
-function parseFrontmatter(content: string): { meta: Record<string, unknown>; body: string } | null {
+// Reserved keys blocked during YAML frontmatter parse. A malicious
+// hookify rule file could write `__proto__: {…}` in frontmatter and,
+// because `meta[key]` uses bracket assignment on a plain object,
+// pollute Object.prototype for the whole process. Rules can come
+// from plugins or the marketplace so the input is not fully trusted.
+const RESERVED_META_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+export function parseFrontmatter(content: string): { meta: Record<string, unknown>; body: string } | null {
   const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
   if (!match) return null;
 
@@ -72,7 +79,9 @@ function parseFrontmatter(content: string): { meta: Record<string, unknown>; bod
     if (currentItem && currentArray && !/^\s/.test(trimmed)) {
       currentArray.push(currentItem);
       currentItem = null;
-      meta[currentKey!] = currentArray;
+      if (currentKey && !RESERVED_META_KEYS.has(currentKey)) {
+        meta[currentKey] = currentArray;
+      }
       currentArray = null;
       currentKey = null;
     }
@@ -81,6 +90,8 @@ function parseFrontmatter(content: string): { meta: Record<string, unknown>; bod
     if (kvMatch) {
       const key = kvMatch[1]!;
       const value = kvMatch[2]!.trim();
+
+      if (RESERVED_META_KEYS.has(key)) continue;
 
       if (value === "") {
         currentKey = key;
@@ -94,7 +105,7 @@ function parseFrontmatter(content: string): { meta: Record<string, unknown>; bod
 
   if (currentItem && currentArray) {
     currentArray.push(currentItem);
-    if (currentKey) meta[currentKey] = currentArray;
+    if (currentKey && !RESERVED_META_KEYS.has(currentKey)) meta[currentKey] = currentArray;
   }
 
   return { meta, body };


### PR DESCRIPTION
## Summary

Closes real finding from today's `/scan` (Gemma 4 31B audit): **js-008-prototype-pollution-bracket** at `src/core/hookify.ts:91`.

The second /scan finding, `uni-003-ssrf` at `src/ui/actions/model-config-actions.ts:218`, is a **false positive** — the URL comes from the user's own `~/.kcode/models.json` registry (managed via `kcode models add`), and the `/model` health check's entire purpose is to ping those endpoints. No untrusted input reaches the fetch. No change needed there.

## The bug

`parseFrontmatter()` built `meta` as a plain object literal and assigned `meta[key]` with `key` sourced from a `\w+` regex match on a user-authored YAML file:

```ts
const kvMatch = trimmed.match(/^(\w+):\s*(.*)$/);
// ...
meta[key] = parseYamlValue(value);  // ← key can be "__proto__"
```

`\w+` = `[A-Za-z0-9_]`, so `__proto__`, `constructor`, and `prototype` all pass. Hookify rule files can come from plugins, the marketplace, or manual authoring — all of which are untrusted inputs. A malicious file like

```yaml
---
__proto__:
  polluted: true
---
```

would execute `meta["__proto__"] = {...}` which, on a plain-prototype object, reassigns the prototype itself — polluting `Object.prototype` globally for the rest of the process lifetime.

## The fix

```ts
const RESERVED_META_KEYS = new Set(["__proto__", "constructor", "prototype"]);
```

Silently drop matches at all three write points:
1. The main `meta[key] = parseYamlValue(value)` scalar assignment
2. The empty-value-starts-array branch (`currentKey = key; currentArray = []`)
3. Both flush points for pending arrays (the mid-loop flush on non-indented line + the post-loop final flush)

Export `parseFrontmatter` so the invariant can be tested directly without touching the filesystem.

## Tests

7 new regression tests in `src/core/hookify.test.ts`:
- Scalar `__proto__` injection does not pollute `Object.prototype`
- `constructor` key is dropped as an own key; `meta.constructor` stays as `Object.prototype.constructor`
- `prototype` key is dropped
- Array-form `__proto__: \n  - field: ...` is dropped + sibling keys (`name: still_fine`) still parse
- Normal scalar frontmatter still parses (positive control)
- Condition arrays still parse (positive control)
- Missing frontmatter returns `null`

Each pollution test also asserts on a fresh `{}` that the attacker-chosen payload key is `undefined` — the real blast-radius invariant, not just `toHaveProperty("__proto__")` which walks the chain.

## Results
- [x] 7/7 new hookify tests passing
- [x] 5076/5076 core tests passing

Co-Authored-By: Kulvex Code <contact@astrolexis.space>