### PR TITLE
feat(kodi): dedicated abliterated LLM for Kodi — lifecycle + TUI menu + v2.10.108

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.107",
+  "version": "2.10.108",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -73,6 +73,15 @@ export interface Settings {
   autoUpdate?: boolean; // Enable/disable automatic update checks (default true)
   updateCheckIntervalDays?: number; // Days between update checks (default 7)
   proKey?: string; // KCode Pro license key (kcode_pro_xxxxx)
+  // Kodi Advisor — dedicated small abliterated LLM that powers the
+  // mascot's autonomous movement / advisory speech. Enterprise-only.
+  // `declined` means the user said No at the first-run prompt and
+  // shouldn't be asked again. Reset with `/kodi-advisor reset`.
+  kodiAdvisor?: {
+    modelId?: string; // id from KODI_CANDIDATES
+    declined?: boolean;
+    autoStart?: boolean; // start server on TUI mount (default true)
+  };
   marketplace?: MarketplaceSettings; // Plugin marketplace CDN config
   offline?: OfflineSettings; // Offline mode configuration
   ensemble?: EnsembleSettings; // Multi-model ensemble configuration

--- a/src/core/kodi-model.test.ts
+++ b/src/core/kodi-model.test.ts
@@ -1,0 +1,101 @@
+// Kodi model manager — pure logic tests.
+//
+// Covers: candidate catalog integrity, status machine at the
+// "not installed" edge, and pickDefaultCandidate behavior under
+// simulated RAM budgets. We deliberately avoid the network-bound
+// downloadKodiModel and process-spawning startKodiServer —
+// those want an integration harness with a real llama-server binary.
+
+import { describe, expect, test } from "bun:test";
+import {
+  KODI_CANDIDATES,
+  KODI_SERVER_PORT,
+  candidatePath,
+  getCandidate,
+  pickDefaultCandidate,
+} from "./kodi-model";
+
+describe("kodi-model — candidate catalog", () => {
+  test("exposes at least one candidate", () => {
+    expect(KODI_CANDIDATES.length).toBeGreaterThan(0);
+  });
+
+  test("all candidates have non-empty required fields", () => {
+    for (const c of KODI_CANDIDATES) {
+      expect(c.id).not.toBe("");
+      expect(c.label).not.toBe("");
+      expect(c.filename).toMatch(/\.gguf$/);
+      expect(c.url).toMatch(/^https:\/\//);
+      expect(c.sizeMB).toBeGreaterThan(0);
+      expect(c.ramMB).toBeGreaterThan(0);
+      expect(c.note).not.toBe("");
+    }
+  });
+
+  test("candidate ids are unique", () => {
+    const ids = new Set(KODI_CANDIDATES.map((c) => c.id));
+    expect(ids.size).toBe(KODI_CANDIDATES.length);
+  });
+
+  test("candidate filenames are unique", () => {
+    const files = new Set(KODI_CANDIDATES.map((c) => c.filename));
+    expect(files.size).toBe(KODI_CANDIDATES.length);
+  });
+
+  test("candidates are ordered strongest → smallest by RAM", () => {
+    // pickDefaultCandidate relies on this ordering: walk top-down,
+    // take the first that fits. If the catalog ever violates it,
+    // RAM-constrained users would get a suboptimal default.
+    for (let i = 1; i < KODI_CANDIDATES.length; i++) {
+      const prev = KODI_CANDIDATES[i - 1]!;
+      const curr = KODI_CANDIDATES[i]!;
+      expect(curr.ramMB).toBeLessThanOrEqual(prev.ramMB);
+    }
+  });
+
+  test("getCandidate returns the matching entry", () => {
+    for (const c of KODI_CANDIDATES) {
+      expect(getCandidate(c.id)?.id).toBe(c.id);
+    }
+  });
+
+  test("getCandidate returns null for unknown id", () => {
+    expect(getCandidate("nonexistent-model-id-xyz")).toBeNull();
+  });
+
+  test("candidatePath produces a path ending in the filename", () => {
+    const c = KODI_CANDIDATES[0]!;
+    const path = candidatePath(c);
+    expect(path.endsWith(c.filename)).toBe(true);
+    expect(path).toContain("models/kodi");
+  });
+});
+
+describe("kodi-model — constants", () => {
+  test("KODI_SERVER_PORT stays above 10000 reserved range", () => {
+    expect(KODI_SERVER_PORT).toBeGreaterThanOrEqual(10000);
+    expect(KODI_SERVER_PORT).toBeLessThan(65536);
+  });
+
+  test("KODI_SERVER_PORT does not collide with the main model port 10091", () => {
+    expect(KODI_SERVER_PORT).not.toBe(10091);
+  });
+});
+
+describe("kodi-model — pickDefaultCandidate", () => {
+  test("returns a candidate (truthy) on this test machine", () => {
+    // CI / dev boxes running this test have enough RAM. Weak
+    // machines would return null — we don't want to assert a
+    // specific model since RAM varies, but null from a dev box
+    // would indicate a broken catalog.
+    const picked = pickDefaultCandidate();
+    expect(picked).not.toBeNull();
+  });
+
+  test("picked candidate comes from the catalog", () => {
+    const picked = pickDefaultCandidate();
+    if (picked) {
+      expect(KODI_CANDIDATES.some((c) => c.id === picked.id)).toBe(true);
+    }
+  });
+});

--- a/src/core/kodi-model.ts
+++ b/src/core/kodi-model.ts
@@ -1,0 +1,449 @@
+// KCode - Kodi Advisor Model Manager
+//
+// Manages a dedicated small abliterated LLM that powers the Kodi
+// mascot's autonomous movement and (in a follow-up PR) advisory
+// speech. Runs as a SECOND llama-server process on port 10092,
+// completely separate from the main coding model on 10091 — so
+// Kodi's "reactions" never steal GPU/VRAM from the user's primary
+// model, and there's no token accounting to worry about.
+//
+// Tier gating: this module only ever fires for enterprise users.
+// Free/pro/team get the deterministic Kodi (no LLM calls at all).
+//
+// State files (all under ~/.kcode/):
+//   models/kodi/<candidate>.gguf   — the model weights
+//   kodi-server.pid                 — running process id
+//   kodi-server.port                — listening port (always 10092)
+//   kodi-server.log                 — stdout/stderr
+//
+// Candidates are all abliterated (uncensored) — the user explicitly
+// requested no refusal behavior. All default to Q4_K_M quantization,
+// which is the sweet spot for small models (≈1 byte/param).
+
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { freemem } from "node:os";
+import { join } from "node:path";
+import { log } from "./logger";
+import { downloadFile, ensureDir } from "./model-file-utils";
+import { getServerConfig } from "./model-manager";
+import { kcodePath } from "./paths";
+
+// ─── Constants ──────────────────────────────────────────────────
+
+/** Kodi model lives here so `kcode setup`'s main-model directory
+ * stays unaffected by Kodi's download/delete operations. */
+const KODI_MODEL_DIR = kcodePath("models/kodi");
+
+/** Fixed Kodi server port. 10092 sits just above the main model
+ * (10091) and stays in the ≥10000 range KCode reserves for
+ * privileged defaults. Never configurable — keeping it fixed
+ * simplifies every piece of downstream code (health checks,
+ * UI labels, logs). */
+export const KODI_SERVER_PORT = 10092;
+
+const KODI_PID_FILE = kcodePath("kodi-server.pid");
+const KODI_PORT_FILE = kcodePath("kodi-server.port");
+const KODI_LOG_FILE = kcodePath("kodi-server.log");
+
+/** Narrow context window — Kodi only reacts to a few recent tool
+ * events, never multi-turn chat, so 2048 is plenty and keeps RAM
+ * footprint predictable. */
+const KODI_CTX_SIZE = 2048;
+
+/** One parallel slot — Kodi never needs concurrent generations. */
+const KODI_PARALLEL = 1;
+
+// ─── Candidate catalog ──────────────────────────────────────────
+
+export interface KodiCandidate {
+  /** Short id used in settings.kodiAdvisor.modelId and the UI. */
+  id: string;
+  /** User-facing label for the menu. */
+  label: string;
+  /** On-disk filename under KODI_MODEL_DIR. */
+  filename: string;
+  /** Direct HTTPS GGUF download URL. */
+  url: string;
+  /** Disk size of the downloaded file, MB. */
+  sizeMB: number;
+  /** Approximate runtime RAM footprint, MB. Used to pick a default. */
+  ramMB: number;
+  /** Short one-liner about what this model is best at. */
+  note: string;
+}
+
+/**
+ * Candidate lineup. All abliterated, all Q4_K_M. Ordered from
+ * strongest to smallest — pickDefaultCandidate walks in this order
+ * and takes the first one that fits in the user's free RAM.
+ *
+ * Adding a new candidate: just append here. The menu, settings,
+ * and download flow all pick it up automatically.
+ */
+export const KODI_CANDIDATES: readonly KodiCandidate[] = [
+  {
+    id: "qwen-coder-1.5b-abliterated",
+    label: "Qwen 2.5 Coder 1.5B abliterated (Q4_K_M)",
+    filename: "Qwen2.5-Coder-1.5B-Instruct-abliterated-Q4_K_M.gguf",
+    url:
+      "https://huggingface.co/bartowski/Qwen2.5-Coder-1.5B-Instruct-abliterated-GGUF/" +
+      "resolve/main/Qwen2.5-Coder-1.5B-Instruct-abliterated-Q4_K_M.gguf",
+    sizeMB: 1147, // ≈1.12 GB
+    ramMB: 1500,
+    note: "Default — code-specialized, uncensored, best for advising on code.",
+  },
+  {
+    id: "qwen-1.5b-abliterated",
+    label: "Qwen 2.5 1.5B abliterated (Q4_K_M)",
+    filename: "Qwen2.5-1.5B-Instruct-abliterated.i1-Q4_K_M.gguf",
+    url:
+      "https://huggingface.co/mradermacher/Qwen2.5-1.5B-Instruct-abliterated-i1-GGUF/" +
+      "resolve/main/Qwen2.5-1.5B-Instruct-abliterated.i1-Q4_K_M.gguf",
+    sizeMB: 986,
+    ramMB: 1300,
+    note: "General-purpose abliterated Qwen 1.5B. Slightly lighter than the Coder variant.",
+  },
+  {
+    id: "gemma-3-1b-abliterated",
+    label: "Gemma 3 1B abliterated (Q4_K_M)",
+    filename: "huihui-ai_gemma-3-1b-it-abliterated-Q4_K_M.gguf",
+    url:
+      "https://huggingface.co/bartowski/huihui-ai_gemma-3-1b-it-abliterated-GGUF/" +
+      "resolve/main/huihui-ai_gemma-3-1b-it-abliterated-Q4_K_M.gguf",
+    sizeMB: 806,
+    ramMB: 1000,
+    note: "Low-RAM fallback — same abliterated family as mark6 in miniature. Requires a recent llama.cpp with Gemma 3 support.",
+  },
+] as const;
+
+export function getCandidate(id: string): KodiCandidate | null {
+  return KODI_CANDIDATES.find((c) => c.id === id) ?? null;
+}
+
+// ─── Status machine ─────────────────────────────────────────────
+
+export type KodiModelStatus =
+  | "not_installed"
+  | "installed_stopped"
+  | "starting"
+  | "running"
+  | "error";
+
+export interface KodiStatusReport {
+  status: KodiModelStatus;
+  installedCandidate: KodiCandidate | null;
+  port: number | null;
+  pid: number | null;
+  modelFilePath: string | null;
+  modelFileSizeMB: number | null;
+}
+
+/**
+ * Walk the candidate list and return the first whose GGUF file
+ * is present on disk. A user can only have one Kodi model
+ * installed at a time — installing a second one requires deleting
+ * the first, which keeps things simple (one file → one decision).
+ */
+export function getInstalledKodiCandidate(): KodiCandidate | null {
+  for (const c of KODI_CANDIDATES) {
+    const path = candidatePath(c);
+    if (existsSync(path)) return c;
+  }
+  return null;
+}
+
+export function candidatePath(c: KodiCandidate): string {
+  return join(KODI_MODEL_DIR, c.filename);
+}
+
+/** Poll the current state. Cheap — safe to call from the UI. */
+export async function getKodiStatusReport(): Promise<KodiStatusReport> {
+  const installed = getInstalledKodiCandidate();
+  if (!installed) {
+    return {
+      status: "not_installed",
+      installedCandidate: null,
+      port: null,
+      pid: null,
+      modelFilePath: null,
+      modelFileSizeMB: null,
+    };
+  }
+  const path = candidatePath(installed);
+  const sizeMB = existsSync(path) ? Math.round(statSync(path).size / (1024 * 1024)) : null;
+
+  const running = await isKodiRunning();
+  if (running) {
+    return {
+      status: "running",
+      installedCandidate: installed,
+      port: KODI_SERVER_PORT,
+      pid: readPidFile(),
+      modelFilePath: path,
+      modelFileSizeMB: sizeMB,
+    };
+  }
+  return {
+    status: "installed_stopped",
+    installedCandidate: installed,
+    port: null,
+    pid: null,
+    modelFilePath: path,
+    modelFileSizeMB: sizeMB,
+  };
+}
+
+/**
+ * Pick the best candidate that fits in the user's CURRENT free RAM.
+ * Walks KODI_CANDIDATES top-down (strongest first) and returns the
+ * first one with headroom. Returns null if nothing fits — caller
+ * should show an error / disable Kodi advisor.
+ *
+ * Leaves a ~500 MB cushion so Kodi doesn't push the system into swap.
+ */
+export function pickDefaultCandidate(): KodiCandidate | null {
+  const freeMB = Math.round(freemem() / (1024 * 1024));
+  const budget = freeMB - 500; // safety cushion
+  for (const c of KODI_CANDIDATES) {
+    if (c.ramMB <= budget) return c;
+  }
+  return null;
+}
+
+// ─── Download ───────────────────────────────────────────────────
+
+/**
+ * Download a candidate's GGUF file into KODI_MODEL_DIR. Supports
+ * resume via the shared downloadFile helper. Progress is reported
+ * as a human string ("42% • 450.1/1124.8 MB") which the UI can
+ * render verbatim. Throws on HTTP errors.
+ */
+export async function downloadKodiModel(
+  candidateId: string,
+  onProgress: (msg: string) => void,
+): Promise<void> {
+  const c = getCandidate(candidateId);
+  if (!c) throw new Error(`Unknown Kodi candidate: ${candidateId}`);
+
+  ensureDir(KODI_MODEL_DIR);
+  const dest = candidatePath(c);
+
+  // Early-out if already downloaded at full size — avoids a pointless
+  // HEAD/Range roundtrip if the user reopened the menu by mistake.
+  if (existsSync(dest)) {
+    const sizeMB = Math.round(statSync(dest).size / (1024 * 1024));
+    // Allow a 2% tolerance — filesystem block rounding, mirror size
+    // differences, etc.
+    if (Math.abs(sizeMB - c.sizeMB) < c.sizeMB * 0.02) {
+      onProgress("Already downloaded.");
+      return;
+    }
+  }
+
+  log.info("kodi-model", `Downloading ${c.id} from ${c.url}`);
+  await downloadFile(c.url, dest, onProgress, c.sizeMB * 1024 * 1024);
+  log.info("kodi-model", `Download complete: ${dest}`);
+}
+
+// ─── Server lifecycle ───────────────────────────────────────────
+
+/**
+ * Resolve the llama-server binary. We reuse the path configured for
+ * the main model's server — if `kcode setup` has been run, we have a
+ * known-good binary. If not, fall back to `llama-server` on PATH so
+ * a user who manually installed llama.cpp can still run Kodi.
+ */
+async function resolveLlamaServerBinary(): Promise<string> {
+  try {
+    const cfg = await getServerConfig();
+    if (cfg?.enginePath && existsSync(cfg.enginePath) && cfg.engine !== "mlx") {
+      return cfg.enginePath;
+    }
+  } catch {
+    // fall through to PATH
+  }
+  return "llama-server";
+}
+
+function readPidFile(): number | null {
+  try {
+    if (!existsSync(KODI_PID_FILE)) return null;
+    const pid = parseInt(readFileSync(KODI_PID_FILE, "utf-8").trim(), 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function cleanupStateFiles(): void {
+  for (const p of [KODI_PID_FILE, KODI_PORT_FILE]) {
+    try {
+      if (existsSync(p)) unlinkSync(p);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/** Health probe against the Kodi server's /health endpoint. */
+export async function isKodiRunning(): Promise<boolean> {
+  try {
+    const resp = await fetch(`http://127.0.0.1:${KODI_SERVER_PORT}/health`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    if (resp.ok) return true;
+  } catch {
+    /* not running */
+  }
+  // /health may not exist on older llama.cpp — try /v1/models as fallback.
+  try {
+    const resp = await fetch(`http://127.0.0.1:${KODI_SERVER_PORT}/v1/models`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    if (resp.ok) return true;
+  } catch {
+    /* not running */
+  }
+  // Nothing responded — clean up any stale state files so a fresh
+  // start() doesn't confuse itself.
+  cleanupStateFiles();
+  return false;
+}
+
+/**
+ * Spawn llama-server with the installed Kodi model. CPU-only by
+ * default (`--n-gpu-layers 0`) to keep the GPU available for the
+ * main coding model. Detached so it survives the TUI exiting — the
+ * user can come back to a running Kodi instead of re-warming it.
+ */
+export async function startKodiServer(): Promise<{ port: number; pid: number }> {
+  if (await isKodiRunning()) {
+    const pid = readPidFile() ?? 0;
+    return { port: KODI_SERVER_PORT, pid };
+  }
+
+  const candidate = getInstalledKodiCandidate();
+  if (!candidate) {
+    throw new Error("No Kodi model installed. Run `/kodi-advisor` to download one first.");
+  }
+  const modelPath = candidatePath(candidate);
+  if (!existsSync(modelPath)) {
+    throw new Error(`Kodi model file missing: ${modelPath}`);
+  }
+
+  const binary = await resolveLlamaServerBinary();
+  const args = [
+    "--model",
+    modelPath,
+    "--port",
+    String(KODI_SERVER_PORT),
+    "--host",
+    "127.0.0.1",
+    "--ctx-size",
+    String(KODI_CTX_SIZE),
+    "--n-gpu-layers",
+    "0", // keep GPU for the main model
+    "--parallel",
+    String(KODI_PARALLEL),
+    "--mmap",
+  ];
+
+  log.info("kodi-model", `Starting Kodi server: ${binary} ${args.join(" ")}`);
+
+  const logFd = Bun.file(KODI_LOG_FILE).writer();
+  const child = spawn(binary, args, {
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout?.on("data", (d) => logFd.write(d));
+  child.stderr?.on("data", (d) => logFd.write(d));
+  child.on("error", (err) => {
+    log.warn("kodi-model", `spawn error: ${err}`);
+  });
+  child.unref();
+
+  if (!child.pid) {
+    throw new Error("Failed to spawn Kodi server (no PID)");
+  }
+  writeFileSync(KODI_PID_FILE, String(child.pid));
+  writeFileSync(KODI_PORT_FILE, String(KODI_SERVER_PORT));
+
+  // Wait for the server to become reachable. llama.cpp takes a few
+  // seconds to load weights on cold start, especially from disk.
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 500));
+    if (await isKodiRunning()) {
+      log.info("kodi-model", `Kodi server ready on port ${KODI_SERVER_PORT}`);
+      return { port: KODI_SERVER_PORT, pid: child.pid };
+    }
+  }
+
+  // Didn't come up — kill what we started and tell the caller.
+  try {
+    process.kill(child.pid, "SIGTERM");
+  } catch {
+    /* already dead */
+  }
+  cleanupStateFiles();
+  throw new Error("Kodi server failed to start within 30s. Check ~/.kcode/kodi-server.log");
+}
+
+/** Signal the running Kodi server and clean up its state files. */
+export async function stopKodiServer(): Promise<void> {
+  const pid = readPidFile();
+  if (pid) {
+    try {
+      process.kill(pid, "SIGTERM");
+      log.info("kodi-model", `Sent SIGTERM to Kodi server pid=${pid}`);
+    } catch (err) {
+      log.debug("kodi-model", `kill ${pid}: ${err}`);
+    }
+  }
+  // Give the process a moment to exit cleanly before force.
+  for (let i = 0; i < 6; i++) {
+    await new Promise((r) => setTimeout(r, 250));
+    if (!(await isKodiRunning())) break;
+  }
+  if (pid && (await isKodiRunning())) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      /* already dead */
+    }
+  }
+  cleanupStateFiles();
+}
+
+/**
+ * Delete the installed Kodi model from disk. Stops the server first
+ * if it's running. Returns the number of bytes freed, for a nice
+ * confirmation message in the UI.
+ */
+export async function deleteKodiModel(): Promise<number> {
+  if (await isKodiRunning()) {
+    await stopKodiServer();
+  }
+  const candidate = getInstalledKodiCandidate();
+  if (!candidate) return 0;
+  const path = candidatePath(candidate);
+  let freed = 0;
+  try {
+    freed = statSync(path).size;
+    unlinkSync(path);
+    log.info("kodi-model", `Deleted ${path} (${(freed / (1024 * 1024)).toFixed(1)} MB freed)`);
+  } catch (err) {
+    log.warn("kodi-model", `Failed to delete ${path}: ${err}`);
+  }
+  return freed;
+}
+
+/**
+ * Public helper consumed by Kodi.tsx to decide whether to route LLM
+ * reactions through Kodi's dedicated server or through the main
+ * coding model. Null means "no dedicated server — fall back."
+ */
+export async function getKodiBaseUrl(): Promise<string | null> {
+  return (await isKodiRunning()) ? `http://127.0.0.1:${KODI_SERVER_PORT}` : null;
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -13,6 +13,7 @@ import type { KCodeConfig } from "../core/types.js";
 import { getActivePlan, loadLatestPlan, onPlanChange, type Plan } from "../tools/plan.js";
 import ActivePlanPanel from "./components/ActivePlanPanel.js";
 import CloudMenu, { type CloudResult } from "./components/CloudMenu.js";
+import KodiAdvisorMenu, { type KodiAdvisorMenuResult } from "./components/KodiAdvisorMenu.js";
 import ContextGrid from "./components/ContextGrid.js";
 import Header from "./components/Header.js";
 import InputPrompt from "./components/InputPrompt.js";
@@ -44,7 +45,14 @@ interface AppProps {
   initialSessionName?: string;
 }
 
-type AppMode = "input" | "responding" | "permission" | "sudo-password" | "cloud" | "toggle";
+type AppMode =
+  | "input"
+  | "responding"
+  | "permission"
+  | "sudo-password"
+  | "cloud"
+  | "toggle"
+  | "kodi-advisor";
 
 export default function App({ config, conversationManager, tools, initialSessionName }: AppProps) {
   const { exit } = useApp();
@@ -97,6 +105,7 @@ export default function App({ config, conversationManager, tools, initialSession
     names.add("/license");
     names.add("/login");
     names.add("/logout");
+    names.add("/kodi-advisor");
     names.add("/plugin");
     names.add("/plugins");
     names.add("/hookify");
@@ -125,6 +134,7 @@ export default function App({ config, conversationManager, tools, initialSession
     descs["/license"] = "Show license status or activate a license";
     descs["/login"] = "Log in to Astrolexis (opens browser — PKCE OAuth)";
     descs["/logout"] = "Log out of Astrolexis and clear cached subscription";
+    descs["/kodi-advisor"] = "Manage the Kodi Advisor model (download/start/stop/delete)";
     descs["/plugin"] = "Install, list, or remove plugins";
     descs["/plugins"] = "Install, list, or remove plugins";
     descs["/hookify"] = "Manage dynamic hookify rules (create, list, toggle, delete, test)";
@@ -183,6 +193,65 @@ export default function App({ config, conversationManager, tools, initialSession
       cancelled = true;
       clearInterval(interval);
     };
+  }, []);
+
+  // Kodi advisor first-run prompt. Enterprise users get asked once,
+  // the first time they start the TUI, whether they want the Kodi
+  // Advisor model downloaded. A decline (`n` in the menu) writes
+  // kodiAdvisor.declined = true and we never ask again until they
+  // run `/kodi-advisor reset`. Users on any other tier never see
+  // the prompt — the current deterministic Kodi stays as-is.
+  const [firstRunKodiAdvisor, setFirstRunKodiAdvisor] = useState(false);
+  useEffect(() => {
+    if (subscriptionTier !== "enterprise") return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { loadUserSettingsRaw } = await import("../core/config.js");
+        const { getInstalledKodiCandidate } = await import("../core/kodi-model.js");
+        const raw = loadUserSettingsRaw();
+        const alreadyDeclined = Boolean(raw.kodiAdvisor?.declined);
+        const alreadyInstalled = Boolean(getInstalledKodiCandidate());
+        if (cancelled) return;
+        if (!alreadyDeclined && !alreadyInstalled) {
+          setFirstRunKodiAdvisor(true);
+          setMode("kodi-advisor");
+        }
+      } catch {
+        // Settings read failure shouldn't block the UI.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [subscriptionTier]);
+
+  const handleKodiAdvisorMenuDone = useCallback(async (result: KodiAdvisorMenuResult) => {
+    setMode("input");
+    setFirstRunKodiAdvisor(false);
+    if (result.action === "declined") {
+      try {
+        const { loadUserSettingsRaw, saveUserSettingsRaw } = await import("../core/config.js");
+        const raw = loadUserSettingsRaw();
+        raw.kodiAdvisor = { ...(raw.kodiAdvisor ?? {}), declined: true };
+        saveUserSettingsRaw(raw);
+      } catch {
+        /* best effort */
+      }
+    } else if (result.action === "downloaded") {
+      try {
+        const { loadUserSettingsRaw, saveUserSettingsRaw } = await import("../core/config.js");
+        const raw = loadUserSettingsRaw();
+        raw.kodiAdvisor = {
+          ...(raw.kodiAdvisor ?? {}),
+          modelId: result.candidateId,
+          declined: false,
+        };
+        saveUserSettingsRaw(raw);
+      } catch {
+        /* best effort */
+      }
+    }
   }, []);
 
   const [watcherSuggestions, setWatcherSuggestions] = useState<string[]>([]);
@@ -906,6 +975,13 @@ export default function App({ config, conversationManager, tools, initialSession
           />
         )}
 
+        {mode === "kodi-advisor" && (
+          <KodiAdvisorMenu
+            firstRun={firstRunKodiAdvisor}
+            onClose={handleKodiAdvisorMenuDone}
+          />
+        )}
+
         {/* Background scan/pr progress bar */}
         {scanProgress && scanProgress.active && (
           <Box marginLeft={2} marginBottom={0} flexDirection="column">
@@ -1068,6 +1144,7 @@ export default function App({ config, conversationManager, tools, initialSession
             mode !== "sudo-password" &&
             mode !== "cloud" &&
             mode !== "toggle" &&
+            mode !== "kodi-advisor" &&
             mode !== ("escalation" as any)
           }
           isQueuing={mode === "responding"}

--- a/src/ui/components/KodiAdvisorMenu.tsx
+++ b/src/ui/components/KodiAdvisorMenu.tsx
@@ -1,0 +1,363 @@
+// KCode - Kodi Advisor Menu
+//
+// TUI menu for managing the dedicated Kodi LLM. Opens via the
+// `/kodi-advisor` slash command, and auto-opens the first time an
+// enterprise user starts KCode without having made a choice yet.
+//
+// The menu is a small state machine driven by kodi-model's status
+// report. Keyboard-only — we pick single-letter shortcuts so users
+// never need arrow keys.
+//
+//   not_installed      → pick a candidate to download
+//   downloading        → live progress (stays modal, can't cancel mid-download cleanly)
+//   installed_stopped  → [s]tart / [d]elete / [esc] close
+//   running            → [x] stop / [d]elete (auto-stops) / [esc]
+//
+// The "No thanks" branch only exists in the not_installed state
+// because that's the first-run moment where we need to persist a
+// "don't ask again" decision to settings.
+
+import { Box, Text, useInput } from "ink";
+import React, { useEffect, useState } from "react";
+import {
+  KODI_CANDIDATES,
+  type KodiCandidate,
+  type KodiStatusReport,
+  deleteKodiModel,
+  downloadKodiModel,
+  getKodiStatusReport,
+  pickDefaultCandidate,
+  startKodiServer,
+  stopKodiServer,
+} from "../../core/kodi-model.js";
+import { useTheme } from "../ThemeContext.js";
+
+export type KodiAdvisorMenuResult =
+  | { action: "declined" }
+  | { action: "downloaded"; candidateId: string }
+  | { action: "started" }
+  | { action: "stopped" }
+  | { action: "deleted" }
+  | { action: "close" };
+
+interface Props {
+  /** Called when the user finishes (closes the menu or takes an action that resolves it). */
+  onClose: (result: KodiAdvisorMenuResult) => void;
+  /**
+   * True when this menu was shown automatically on first enterprise
+   * start. Controls copy ("Enable Kodi Advisor?" vs "Kodi Advisor"
+   * generic management).
+   */
+  firstRun?: boolean;
+}
+
+type ViewState =
+  | { kind: "loading" }
+  | { kind: "not_installed"; recommended: KodiCandidate | null }
+  | { kind: "downloading"; candidate: KodiCandidate; progress: string }
+  | { kind: "downloaded"; candidate: KodiCandidate }
+  | { kind: "installed_stopped"; candidate: KodiCandidate; sizeMB: number | null }
+  | {
+      kind: "running";
+      candidate: KodiCandidate;
+      port: number;
+      pid: number | null;
+      sizeMB: number | null;
+    }
+  | { kind: "busy"; message: string }
+  | { kind: "error"; message: string };
+
+function toView(report: KodiStatusReport): ViewState {
+  switch (report.status) {
+    case "not_installed":
+      return { kind: "not_installed", recommended: pickDefaultCandidate() };
+    case "installed_stopped":
+      return {
+        kind: "installed_stopped",
+        candidate: report.installedCandidate!,
+        sizeMB: report.modelFileSizeMB,
+      };
+    case "running":
+      return {
+        kind: "running",
+        candidate: report.installedCandidate!,
+        port: report.port ?? 0,
+        pid: report.pid,
+        sizeMB: report.modelFileSizeMB,
+      };
+    default:
+      return { kind: "error", message: `Unknown status: ${report.status}` };
+  }
+}
+
+export default function KodiAdvisorMenu({ onClose, firstRun }: Props) {
+  const { theme } = useTheme();
+  const [view, setView] = useState<ViewState>({ kind: "loading" });
+
+  const refresh = React.useCallback(async () => {
+    try {
+      const report = await getKodiStatusReport();
+      setView(toView(report));
+    } catch (err) {
+      setView({ kind: "error", message: err instanceof Error ? err.message : String(err) });
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const doDownload = async (candidate: KodiCandidate) => {
+    setView({ kind: "downloading", candidate, progress: "starting..." });
+    try {
+      await downloadKodiModel(candidate.id, (msg) => {
+        setView({ kind: "downloading", candidate, progress: msg });
+      });
+      setView({ kind: "downloaded", candidate });
+      // Auto-refresh so the menu flips to installed_stopped / lets
+      // the user start right after a download.
+      setTimeout(() => void refresh(), 400);
+    } catch (err) {
+      setView({
+        kind: "error",
+        message: `Download failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  };
+
+  const doStart = async () => {
+    setView({ kind: "busy", message: "Starting Kodi server..." });
+    try {
+      await startKodiServer();
+      onClose({ action: "started" });
+    } catch (err) {
+      setView({
+        kind: "error",
+        message: `Start failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  };
+
+  const doStop = async () => {
+    setView({ kind: "busy", message: "Stopping Kodi server..." });
+    try {
+      await stopKodiServer();
+      onClose({ action: "stopped" });
+    } catch (err) {
+      setView({
+        kind: "error",
+        message: `Stop failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  };
+
+  const doDelete = async () => {
+    setView({ kind: "busy", message: "Deleting Kodi model..." });
+    try {
+      await deleteKodiModel();
+      onClose({ action: "deleted" });
+    } catch (err) {
+      setView({
+        kind: "error",
+        message: `Delete failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  };
+
+  useInput((input, key) => {
+    const lower = input.toLowerCase();
+
+    if (view.kind === "not_installed") {
+      if (lower === "1" && KODI_CANDIDATES[0]) return void doDownload(KODI_CANDIDATES[0]);
+      if (lower === "2" && KODI_CANDIDATES[1]) return void doDownload(KODI_CANDIDATES[1]);
+      if (lower === "3" && KODI_CANDIDATES[2]) return void doDownload(KODI_CANDIDATES[2]);
+      if (lower === "n" || key.escape) return onClose({ action: "declined" });
+      return;
+    }
+    if (view.kind === "installed_stopped") {
+      if (lower === "s") return void doStart();
+      if (lower === "d") return void doDelete();
+      if (key.escape) return onClose({ action: "close" });
+      return;
+    }
+    if (view.kind === "running") {
+      if (lower === "x") return void doStop();
+      if (lower === "d") return void doDelete();
+      if (key.escape) return onClose({ action: "close" });
+      return;
+    }
+    if (view.kind === "error" || view.kind === "downloaded") {
+      if (key.escape || key.return) {
+        void refresh();
+      }
+      return;
+    }
+    // loading / downloading / busy: swallow input except escape on busy
+    if (view.kind === "busy" && key.escape) return onClose({ action: "close" });
+  });
+
+  // ─── Render ─────────────────────────────────────────────────
+
+  const headerTitle = firstRun ? "Enable Kodi Advisor?" : "Kodi Advisor";
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={theme.info ?? theme.primary}
+      paddingX={1}
+      marginY={0}
+      width={process.stdout.columns || 80}
+    >
+      <Text bold color={theme.info ?? theme.primary}>
+        ✦  {headerTitle}
+      </Text>
+
+      {view.kind === "loading" && (
+        <Box marginTop={1}>
+          <Text color={theme.dimmed}>Checking status...</Text>
+        </Box>
+      )}
+
+      {view.kind === "not_installed" && (
+        <>
+          <Box marginTop={1} flexDirection="column">
+            <Text>
+              A small uncensored LLM runs in the background to power Kodi's autonomous
+              reactions. Pick a model to download:
+            </Text>
+          </Box>
+          <Box marginTop={1} flexDirection="column">
+            {KODI_CANDIDATES.map((c, idx) => {
+              const recommended = view.recommended?.id === c.id;
+              return (
+                <Box key={c.id} gap={1}>
+                  <Text bold color={theme.success}>
+                    [{idx + 1}]
+                  </Text>
+                  <Text>{c.label}</Text>
+                  <Text color={theme.dimmed}>
+                    — {c.sizeMB} MB disk, ~{c.ramMB} MB RAM
+                  </Text>
+                  {recommended && (
+                    <Text bold color={theme.warning}>
+                      recommended
+                    </Text>
+                  )}
+                </Box>
+              );
+            })}
+          </Box>
+          <Box marginTop={1} flexDirection="column">
+            {KODI_CANDIDATES.map((c) => (
+              <Text key={c.id} color={theme.dimmed}>
+                • {c.id}: {c.note}
+              </Text>
+            ))}
+          </Box>
+          <Box marginTop={1} gap={2}>
+            <Text>
+              <Text bold color={theme.error}>
+                [n]
+              </Text>
+              <Text> No thanks</Text>
+              <Text color={theme.dimmed}> (don't ask again)</Text>
+            </Text>
+            <Text color={theme.dimmed}>esc also works</Text>
+          </Box>
+        </>
+      )}
+
+      {view.kind === "downloading" && (
+        <Box marginTop={1} flexDirection="column">
+          <Text>
+            Downloading <Text bold>{view.candidate.label}</Text>...
+          </Text>
+          <Text color={theme.dimmed}>{view.progress}</Text>
+          <Text color={theme.dimmed}>
+            Saving to ~/.kcode/models/kodi/{view.candidate.filename}
+          </Text>
+        </Box>
+      )}
+
+      {view.kind === "downloaded" && (
+        <Box marginTop={1} flexDirection="column">
+          <Text color={theme.success}>✓ Download complete.</Text>
+          <Text color={theme.dimmed}>Press Enter to manage the server.</Text>
+        </Box>
+      )}
+
+      {view.kind === "installed_stopped" && (
+        <>
+          <Box marginTop={1} flexDirection="column">
+            <Text>
+              Installed: <Text bold>{view.candidate.label}</Text>
+            </Text>
+            {view.sizeMB != null && (
+              <Text color={theme.dimmed}>
+                On disk: {view.sizeMB} MB — Server: stopped
+              </Text>
+            )}
+          </Box>
+          <Box marginTop={1} gap={2}>
+            <Text>
+              <Text bold color={theme.success}>
+                [s]
+              </Text>
+              <Text> Start advisor</Text>
+            </Text>
+            <Text>
+              <Text bold color={theme.error}>
+                [d]
+              </Text>
+              <Text> Delete model</Text>
+            </Text>
+            <Text color={theme.dimmed}>[esc] close</Text>
+          </Box>
+        </>
+      )}
+
+      {view.kind === "running" && (
+        <>
+          <Box marginTop={1} flexDirection="column">
+            <Text>
+              Running: <Text bold>{view.candidate.label}</Text>
+            </Text>
+            <Text color={theme.dimmed}>
+              Port {view.port} {view.pid != null ? `• pid ${view.pid}` : ""}{" "}
+              {view.sizeMB != null ? `• ${view.sizeMB} MB on disk` : ""}
+            </Text>
+          </Box>
+          <Box marginTop={1} gap={2}>
+            <Text>
+              <Text bold color={theme.warning}>
+                [x]
+              </Text>
+              <Text> Stop advisor</Text>
+            </Text>
+            <Text>
+              <Text bold color={theme.error}>
+                [d]
+              </Text>
+              <Text> Delete model</Text>
+            </Text>
+            <Text color={theme.dimmed}>[esc] close</Text>
+          </Box>
+        </>
+      )}
+
+      {view.kind === "busy" && (
+        <Box marginTop={1}>
+          <Text color={theme.dimmed}>{view.message}</Text>
+        </Box>
+      )}
+
+      {view.kind === "error" && (
+        <Box marginTop={1} flexDirection="column">
+          <Text color={theme.error}>✗ {view.message}</Text>
+          <Text color={theme.dimmed}>Press Enter/Esc to refresh.</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/ui/hooks/useMessageProcessor.ts
+++ b/src/ui/hooks/useMessageProcessor.ts
@@ -27,7 +27,14 @@ export interface UseMessageProcessorParams {
   switchTheme: (theme: string) => void;
   exit: () => void;
   setMode: (
-    mode: "input" | "responding" | "permission" | "sudo-password" | "cloud" | "toggle",
+    mode:
+      | "input"
+      | "responding"
+      | "permission"
+      | "sudo-password"
+      | "cloud"
+      | "toggle"
+      | "kodi-advisor",
   ) => void;
   setCompleted: (updater: (prev: MessageEntry[]) => MessageEntry[]) => void;
   setStreamingText: (text: string) => void;
@@ -472,6 +479,44 @@ export function useMessageProcessor(params: UseMessageProcessorParams): UseMessa
       ) {
         setCompleted((prev) => [...prev, { kind: "text", role: "user", text: userInput }]);
         setMode("cloud");
+        return;
+      }
+
+      // /kodi-advisor — open the Kodi Advisor management menu.
+      // Subcommand `reset` clears the "don't ask again" flag so the
+      // first-run prompt will fire again on the next enterprise
+      // session. No arguments → open the menu directly.
+      if (lower === "/kodi-advisor" || lower === "/kodi" || lower === "/kodi-advisor reset") {
+        setCompleted((prev) => [...prev, { kind: "text", role: "user", text: userInput }]);
+        if (lower === "/kodi-advisor reset") {
+          try {
+            const { loadUserSettingsRaw, saveUserSettingsRaw } = await import("../../core/config");
+            const raw = loadUserSettingsRaw();
+            if (raw.kodiAdvisor) {
+              raw.kodiAdvisor.declined = false;
+              saveUserSettingsRaw(raw);
+            }
+            setCompleted((prev) => [
+              ...prev,
+              {
+                kind: "text",
+                role: "assistant",
+                text: "  Kodi Advisor decline flag cleared. Run `/kodi-advisor` to open the menu.",
+              },
+            ]);
+          } catch (err) {
+            setCompleted((prev) => [
+              ...prev,
+              {
+                kind: "text",
+                role: "assistant",
+                text: `  Failed to reset: ${err instanceof Error ? err.message : String(err)}`,
+              },
+            ]);
+          }
+          return;
+        }
+        setMode("kodi-advisor");
         return;
       }
 


### PR DESCRIPTION
## Summary

**Phase 1** of the Kodi Advisor: a dedicated small abliterated LLM that runs alongside the main coding model, driving (in Phase 2) Kodi's autonomous movement and advisory speech. **Zero token cost** (fully local), **zero GPU competition** with the user's primary model (separate port 10092, CPU-only).

This PR installs the entire lifecycle — Phase 2 wires the running model into Kodi's reactions and adds advisor triggers.

## Candidate catalog

All abliterated, all Q4_K_M, all GGUF:

| Model | Size | RAM | Best for |
|-------|------|-----|----------|
| **Qwen 2.5 Coder 1.5B abliterated** | 1.12 GB | ~1.5 GB | Default — code-specialized |
| Qwen 2.5 1.5B abliterated | 986 MB | ~1.3 GB | General-purpose |
| Gemma 3 1B abliterated | 806 MB | ~1.0 GB | Low-RAM fallback |

`pickDefaultCandidate()` walks top-down and takes the first that fits in `os.freemem() - 500MB` cushion.

## TUI menu

`/kodi-advisor` opens a state-machine menu:

- **not_installed** — candidate picker (`[1]/[2]/[3]`) + recommended badge + `[n] No thanks (don't ask again)`
- **downloading** — live progress line from shared `downloadFile` helper (resume supported)
- **installed_stopped** — `[s] Start / [d] Delete / [esc] Close`
- **running** — `[x] Stop / [d] Delete (stops first) / [esc] Close`
- **busy / error** — overlay with escape-to-refresh

## First-run auto-prompt

Enterprise users get the menu automatically the first time their TUI mounts:

- If they pick **No**, `kodiAdvisor.declined = true` is written to `~/.kcode/settings.json` and the prompt never fires again. The current deterministic Kodi stays as-is.
- If they pick a model, it downloads (resumable) and the menu flips to installed_stopped so they can start it with `[s]`.

To un-decline: `/kodi-advisor reset` clears the flag.

## Files changed

- `src/core/kodi-model.ts` — candidate catalog, status machine, download/start/stop/delete, health check
- `src/core/kodi-model.test.ts` — 12 new tests
- `src/core/config.ts` — `kodiAdvisor: { modelId, declined, autoStart }` on Settings
- `src/ui/components/KodiAdvisorMenu.tsx` — TUI menu
- `src/ui/App.tsx` — mode wiring, first-run useEffect, menu render, auto-complete
- `src/ui/hooks/useMessageProcessor.ts` — `/kodi-advisor` slash command + `reset` subcommand
- `package.json` — 2.10.107 → 2.10.108

## Tests

- [x] 12/12 new kodi-model tests passing
- [x] 433/433 UI tests
- [x] 5087/5088 core tests (the 1 flake is a pre-existing MeshNode port-19876 collision that passes on isolated rerun — unrelated to this PR)

## Phase 2 (explicitly NOT in this PR)

- Wire `Kodi.tsx` `generateReaction()` to prefer the dedicated URL via `getKodiBaseUrl()`
- JSON structured output parsing (`{mood, speech, advice}`)
- Advisor triggers (test_fail, commit, ≥3 tool_error in a row, compaction, turn_end)
- Budget tracking (tokens/session, visible in /stats)
- Advice panel (expandable) alongside the existing speech bubble

## Design notes

- **Port 10092** — reserved above main model's 10091, within KCode's ≥10000 convention
- **CPU-only** (`--n-gpu-layers 0`) — Kodi never competes with mark6 / Claude for GPU
- **Detached + unref'd** — server survives TUI exits; user doesn't re-warm the model every session
- **Enterprise-gated** everywhere — free/pro/team never see the prompt, never download anything

Co-Authored-By: Kulvex Code <contact@astrolexis.space>