### PR TITLE
fix(kodi): drop byte-exact size check on download + v2.10.109

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.108",
+  "version": "2.10.109",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/kodi-model.ts
+++ b/src/core/kodi-model.ts
@@ -89,7 +89,7 @@ export const KODI_CANDIDATES: readonly KodiCandidate[] = [
     url:
       "https://huggingface.co/bartowski/Qwen2.5-Coder-1.5B-Instruct-abliterated-GGUF/" +
       "resolve/main/Qwen2.5-Coder-1.5B-Instruct-abliterated-Q4_K_M.gguf",
-    sizeMB: 1147, // ≈1.12 GB
+    sizeMB: 1120, // HF UI shows "1.12 GB" (decimal); informational only
     ramMB: 1500,
     note: "Default — code-specialized, uncensored, best for advising on code.",
   },
@@ -229,20 +229,24 @@ export async function downloadKodiModel(
   ensureDir(KODI_MODEL_DIR);
   const dest = candidatePath(c);
 
-  // Early-out if already downloaded at full size — avoids a pointless
-  // HEAD/Range roundtrip if the user reopened the menu by mistake.
+  // Early-out if the final file already exists. downloadFile handles
+  // partial downloads via <dest>.partial with HTTP Range resume, so
+  // if we see the non-partial path it's from a completed run. We
+  // intentionally don't size-check here — HF's UI displays decimal
+  // GB while the on-disk bytes use binary MiB, so any tolerance we
+  // pick is an arbitrary guess. If the user suspects corruption,
+  // they can delete the model via the menu.
   if (existsSync(dest)) {
-    const sizeMB = Math.round(statSync(dest).size / (1024 * 1024));
-    // Allow a 2% tolerance — filesystem block rounding, mirror size
-    // differences, etc.
-    if (Math.abs(sizeMB - c.sizeMB) < c.sizeMB * 0.02) {
-      onProgress("Already downloaded.");
-      return;
-    }
+    onProgress("Already downloaded.");
+    return;
   }
 
   log.info("kodi-model", `Downloading ${c.id} from ${c.url}`);
-  await downloadFile(c.url, dest, onProgress, c.sizeMB * 1024 * 1024);
+  // Pass no expectedSizeBytes: mirror sizes can drift (re-quantized
+  // uploads, different mirror) and a byte-exact mismatch shouldn't
+  // fail a functional download. Integrity is handled by llama.cpp
+  // on load (it'll reject malformed GGUF files).
+  await downloadFile(c.url, dest, onProgress);
   log.info("kodi-model", `Download complete: ${dest}`);
 }
 


### PR DESCRIPTION
## Summary

Fix for a size-mismatch crash reported by an enterprise user immediately after merging #76:

\`\`\`
✗ Download failed: Download size mismatch: expected 1202716672 bytes, got 1117321696 bytes
\`\`\`

## Root cause

My \`sizeMB\` constant was a bad unit conversion. HuggingFace displays "1.12 GB" (decimal) for the Qwen Coder GGUF, which I naively multiplied by 1024 to get 1147 MiB = 1,202,716,672 bytes. The actual on-disk file is 1,117,321,696 bytes (1065.5 MiB binary). \`downloadFile()\`'s strict equality size check threw on the mismatch even though every byte arrived successfully.

## Fix

1. **Stop passing \`expectedSizeBytes\`** to \`downloadFile\` from \`kodi-model.ts\`. Mirrors drift, HF re-quantizes, byte-exact matching is fragile. Integrity is enforced downstream — llama.cpp rejects malformed GGUF on load, which is the real check that matters.
2. **Simplify the early-out**: if the final file exists, trust it. The previous 2% tolerance check was wrong because HF's displayed MB ≠ on-disk MiB.
3. **Fix displayed \`sizeMB\`** for Qwen Coder: 1147 → 1120 (matches HF's UI).

## Recovery for the reporter

The failed download left \`.partial\` with all bytes downloaded. Next retry:

1. Menu still shows "not_installed" (final file was never renamed)
2. downloadFile sees the \`.partial\`, sends \`Range: bytes=1117321696-\`
3. Server returns 416 Range Not Satisfiable
4. 416 handler renames partial → dest. Done.

Just pressing \`[1]\` again in \`/kodi-advisor\` will recover cleanly.

## Tests
- [x] 12/12 kodi-model tests passing (unchanged)

Co-Authored-By: Kulvex Code <contact@astrolexis.space>