### PR TITLE
feat(kodi): Phase 2 — wire dedicated advisor into reactions + v2.10.110

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.109",
+  "version": "2.10.110",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/ui/components/Kodi.advisor.test.ts
+++ b/src/ui/components/Kodi.advisor.test.ts
@@ -1,0 +1,136 @@
+// Phase 2 — advisor-mode parsers and trigger filter.
+//
+// Covers parseKodiAdvisorJson's tolerance to messy small-model
+// outputs (code fences, trailing prose, missing fields) and
+// shouldCallAdvisor's event filtering so the advisor stays quiet
+// during mechanical tool flow.
+
+import { describe, expect, test } from "bun:test";
+import { parseKodiAdvisorJson, shouldCallAdvisor, type KodiReaction } from "./Kodi";
+
+describe("parseKodiAdvisorJson — happy path", () => {
+  test("parses a clean JSON object", () => {
+    const raw = '{"mood":"worried","speech":"cyclic?","advice":"a.ts imports b.ts imports a.ts"}';
+    const r = parseKodiAdvisorJson(raw) as KodiReaction;
+    expect(r).not.toBeNull();
+    expect(r.mood).toBe("worried");
+    expect(r.speech).toBe("cyclic?");
+    expect(r.advice).toBe("a.ts imports b.ts imports a.ts");
+  });
+
+  test("truncates speech to 14 chars", () => {
+    const raw = '{"mood":"happy","speech":"wayyyyyy too long for the bubble","advice":null}';
+    const r = parseKodiAdvisorJson(raw);
+    expect(r).not.toBeNull();
+    expect(r!.speech!.length).toBeLessThanOrEqual(14);
+  });
+
+  test("truncates advice to 120 chars", () => {
+    const long = "x".repeat(500);
+    const raw = `{"mood":"happy","speech":"ok","advice":"${long}"}`;
+    const r = parseKodiAdvisorJson(raw);
+    expect(r).not.toBeNull();
+    expect(r!.advice!.length).toBeLessThanOrEqual(120);
+  });
+});
+
+describe("parseKodiAdvisorJson — tolerant to small-model messiness", () => {
+  test("strips markdown fences", () => {
+    const raw = '```json\n{"mood":"excited","speech":"lgtm","advice":null}\n```';
+    const r = parseKodiAdvisorJson(raw);
+    expect(r).not.toBeNull();
+    expect(r!.mood).toBe("excited");
+    expect(r!.speech).toBe("lgtm");
+  });
+
+  test("strips unlabeled fences", () => {
+    const raw = '```\n{"mood":"happy","speech":"ok"}\n```';
+    const r = parseKodiAdvisorJson(raw);
+    expect(r!.mood).toBe("happy");
+  });
+
+  test("extracts JSON from preamble prose", () => {
+    const raw = 'Sure! Here is my response: {"mood":"smug","speech":"nice","advice":null}';
+    const r = parseKodiAdvisorJson(raw);
+    expect(r!.mood).toBe("smug");
+  });
+
+  test("null advice is dropped (not included as a string)", () => {
+    const raw = '{"mood":"happy","speech":"ok","advice":null}';
+    const r = parseKodiAdvisorJson(raw);
+    expect(r!.advice).toBeUndefined();
+  });
+
+  test('string "null" as advice is also dropped', () => {
+    // Small models sometimes emit the literal word
+    const raw = '{"mood":"happy","speech":"ok","advice":"null"}';
+    const r = parseKodiAdvisorJson(raw);
+    expect(r!.advice).toBeUndefined();
+  });
+
+  test("invalid mood falls through — advisor keeps using current mood", () => {
+    const raw = '{"mood":"bogus_mood_name","speech":"ok","advice":null}';
+    const r = parseKodiAdvisorJson(raw);
+    expect(r!.mood).toBeUndefined();
+    expect(r!.speech).toBe("ok");
+  });
+
+  test("new moods (flex, dance, waving) are accepted", () => {
+    for (const m of ["flex", "dance", "waving"]) {
+      const r = parseKodiAdvisorJson(`{"mood":"${m}","speech":"hi"}`);
+      expect(r!.mood).toBe(m);
+    }
+  });
+});
+
+describe("parseKodiAdvisorJson — rejection", () => {
+  test("returns null on non-JSON garbage", () => {
+    expect(parseKodiAdvisorJson("I don't know how to respond.")).toBeNull();
+  });
+
+  test("returns null on empty input", () => {
+    expect(parseKodiAdvisorJson("")).toBeNull();
+  });
+
+  test("returns null when all fields are missing or invalid", () => {
+    const raw = '{"mood":"invalid","speech":"","advice":null}';
+    expect(parseKodiAdvisorJson(raw)).toBeNull();
+  });
+
+  test("returns null on malformed JSON even if text contains braces", () => {
+    expect(parseKodiAdvisorJson("{unbalanced")).toBeNull();
+  });
+});
+
+describe("shouldCallAdvisor — gate", () => {
+  test("fires on commit / test_pass / test_fail / compaction", () => {
+    expect(shouldCallAdvisor({ type: "commit" }, 0)).toBe(true);
+    expect(shouldCallAdvisor({ type: "test_pass" }, 0)).toBe(true);
+    expect(shouldCallAdvisor({ type: "test_fail" }, 0)).toBe(true);
+    expect(shouldCallAdvisor({ type: "compaction" }, 0)).toBe(true);
+  });
+
+  test("fires on turn_end + error + agent outcomes", () => {
+    expect(shouldCallAdvisor({ type: "turn_end" }, 0)).toBe(true);
+    expect(shouldCallAdvisor({ type: "error" }, 0)).toBe(true);
+    expect(shouldCallAdvisor({ type: "agent_done" }, 0)).toBe(true);
+    expect(shouldCallAdvisor({ type: "agent_failed" }, 0)).toBe(true);
+  });
+
+  test("tool_error only fires after a 3-error streak", () => {
+    expect(shouldCallAdvisor({ type: "tool_error" }, 0)).toBe(false);
+    expect(shouldCallAdvisor({ type: "tool_error" }, 2)).toBe(false);
+    expect(shouldCallAdvisor({ type: "tool_error" }, 3)).toBe(true);
+    expect(shouldCallAdvisor({ type: "tool_error" }, 5)).toBe(true);
+  });
+
+  test("stays silent on mechanical events", () => {
+    expect(shouldCallAdvisor({ type: "tool_start" }, 0)).toBe(false);
+    expect(shouldCallAdvisor({ type: "tool_done" }, 0)).toBe(false);
+    expect(shouldCallAdvisor({ type: "thinking" }, 0)).toBe(false);
+    expect(shouldCallAdvisor({ type: "streaming" }, 0)).toBe(false);
+    expect(shouldCallAdvisor({ type: "idle" }, 0)).toBe(false);
+    expect(shouldCallAdvisor({ type: "agent_spawn" }, 0)).toBe(false);
+    expect(shouldCallAdvisor({ type: "agent_progress" }, 0)).toBe(false);
+  });
+});

--- a/src/ui/components/Kodi.tsx
+++ b/src/ui/components/Kodi.tsx
@@ -67,10 +67,54 @@ Rules:
 - You can use *actions* like *flexes* or *hides behind monitor*
 - You can use unicode symbols sparingly: ⚡ ✨ 🔥 💀 ☕ etc.`;
 
+// Advisor prompt used when Kodi's dedicated abliterated server is
+// reachable on port 10092. The small model (Qwen 1.5B / Gemma 1B)
+// produces a single JSON object that drives THREE things in one shot:
+// a mood swap, a speech bubble (≤14 chars — fits next to the face),
+// and an optional concrete advice line. No advice is far better than
+// generic fluff, so the prompt makes "null" the default for advice.
+const KODI_ADVISOR_SYSTEM = `You are Kodi, a tiny developer-advisor ASCII mascot inside the KCode terminal assistant.
+
+You observe coding events and respond with a SINGLE JSON object:
+
+{"mood": "...", "speech": "...", "advice": "..."}
+
+Fields:
+- mood: ONE of idle, happy, excited, thinking, reasoning, working, worried, celebrating, curious, mischievous, crazy, angry, smug, flex, dance, waving
+- speech: bubble text, MAX 14 characters. Terse. Conversational.
+- advice: ONE concrete actionable hint (file path, function name, error pattern), MAX 90 characters. If you don't have a real, specific insight, set to null.
+
+Rules:
+- Output ONLY the JSON object. No prose. No markdown fences. No preamble.
+- advice must be SPECIFIC. Bad: "consider refactoring". Good: "src/a.ts imports b.ts which imports a.ts → cyclic".
+- Never repeat yourself across turns. Mix moods.
+- If the event is trivial (tool read finished, idle ping) emit a cheerful mood+speech and advice: null.`;
+
 let _llmBaseUrl: string | null = null;
 let _pendingRequest: AbortController | null = null;
 let _lastLlmCall = 0;
 const LLM_COOLDOWN_MS = 5000;
+
+/** Cached "is Kodi server up?" result. Rechecked every KODI_PROBE_MS
+ * because the server can start/stop mid-session via /kodi-advisor. */
+let _kodiUrlCache: { url: string | null; at: number } | null = null;
+const KODI_PROBE_MS = 10_000;
+
+async function resolveKodiBaseUrl(): Promise<string | null> {
+  const now = Date.now();
+  if (_kodiUrlCache && now - _kodiUrlCache.at < KODI_PROBE_MS) {
+    return _kodiUrlCache.url;
+  }
+  try {
+    const { getKodiBaseUrl } = await import("../../core/kodi-model.js");
+    const url = await getKodiBaseUrl();
+    _kodiUrlCache = { url, at: now };
+    return url;
+  } catch {
+    _kodiUrlCache = { url: null, at: now };
+    return null;
+  }
+}
 
 async function getLlmBaseUrl(): Promise<string> {
   if (_llmBaseUrl) return _llmBaseUrl;
@@ -84,7 +128,74 @@ async function getLlmBaseUrl(): Promise<string> {
   }
 }
 
-async function generateReaction(context: string): Promise<string | null> {
+export interface KodiReaction {
+  /** Optional mood override from the advisor model. */
+  mood?: KodiMood;
+  /** Bubble text (truncated to ≤14 chars for display). */
+  speech?: string;
+  /** Actionable advice (truncated to ≤120 chars for display). */
+  advice?: string;
+}
+
+const VALID_MOODS: readonly string[] = [
+  "idle",
+  "happy",
+  "excited",
+  "thinking",
+  "reasoning",
+  "working",
+  "worried",
+  "sleeping",
+  "celebrating",
+  "curious",
+  "mischievous",
+  "crazy",
+  "angry",
+  "smug",
+  "flex",
+  "dance",
+  "waving",
+] as const;
+
+/**
+ * Tolerant JSON parser for the advisor's output. Small models often
+ * wrap in markdown fences or prepend prose — we strip both and
+ * extract the first {...} block. Fields are validated individually
+ * so a malformed `mood` doesn't invalidate the whole reaction.
+ */
+export function parseKodiAdvisorJson(raw: string): KodiReaction | null {
+  const cleaned = raw
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```\s*$/i, "")
+    .trim();
+  // Extract the outermost JSON object even if there's trailing text.
+  const match = cleaned.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  let obj: unknown;
+  try {
+    obj = JSON.parse(match[0]);
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== "object") return null;
+  const o = obj as Record<string, unknown>;
+  const reaction: KodiReaction = {};
+  if (typeof o.mood === "string" && VALID_MOODS.includes(o.mood)) {
+    reaction.mood = o.mood as KodiMood;
+  }
+  if (typeof o.speech === "string" && o.speech.trim()) {
+    reaction.speech = o.speech.trim().slice(0, 14);
+  }
+  if (typeof o.advice === "string" && o.advice.trim() && o.advice.trim().toLowerCase() !== "null") {
+    reaction.advice = o.advice.trim().slice(0, 120);
+  }
+  // Require at least one usable field — all-empty means the model
+  // produced garbage and we should fall back to deterministic Kodi.
+  if (!reaction.mood && !reaction.speech && !reaction.advice) return null;
+  return reaction;
+}
+
+async function generateReaction(context: string): Promise<KodiReaction | null> {
   const now = Date.now();
   if (now - _lastLlmCall < LLM_COOLDOWN_MS) return null;
   if (_pendingRequest) _pendingRequest.abort();
@@ -93,31 +204,82 @@ async function generateReaction(context: string): Promise<string | null> {
   const controller = new AbortController();
   _pendingRequest = controller;
 
+  // Prefer Kodi's dedicated abliterated server when it's up. The
+  // Kodi server runs fully local on port 10092, doesn't compete
+  // with the main model, and the small size means latency is fine
+  // for bubble-rendering. When the Kodi server is down (not
+  // installed, stopped, or user declined) we fall back to the main
+  // coding model — but only for plain speech, not advice.
+  const kodiUrl = await resolveKodiBaseUrl();
+  const isKodi = kodiUrl !== null;
+  const baseUrl = kodiUrl ?? (await getLlmBaseUrl());
+
   try {
-    const baseUrl = await getLlmBaseUrl();
     const res = await fetch(`${baseUrl}/v1/chat/completions`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       signal: controller.signal,
       body: JSON.stringify({
         messages: [
-          { role: "system", content: KODI_SYSTEM },
+          { role: "system", content: isKodi ? KODI_ADVISOR_SYSTEM : KODI_SYSTEM },
           { role: "user", content: context },
         ],
-        max_tokens: 30,
-        temperature: 1.0,
+        max_tokens: isKodi ? 120 : 30,
+        temperature: isKodi ? 0.7 : 1.0,
         top_p: 0.95,
+        // llama.cpp accepts this hint for JSON-mode on modern builds;
+        // older builds ignore it harmlessly.
+        ...(isKodi ? { response_format: { type: "json_object" } } : {}),
       }),
     });
     if (!res.ok) return null;
     const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
     const text = data.choices?.[0]?.message?.content?.trim();
-    if (!text || text.length > 80) return null;
-    return text.replace(/^["']|["']$/g, "");
+    if (!text) return null;
+
+    if (isKodi) {
+      return parseKodiAdvisorJson(text);
+    }
+    // Main-model fallback: plain-text speech only; no mood swap, no advice.
+    if (text.length > 80) return null;
+    return { speech: text.replace(/^["']|["']$/g, "") };
   } catch {
     return null;
   } finally {
     if (_pendingRequest === controller) _pendingRequest = null;
+  }
+}
+
+/**
+ * Gate: decide whether an incoming KodiEvent warrants an LLM call.
+ * Mechanical events (tool_start for reads, streaming, thinking
+ * mid-generation) would flood Kodi with noise — we skip them and
+ * only wake the advisor on moments with real information content:
+ * test outcomes, commits, tool errors, compaction, turn boundaries,
+ * agent lifecycle events, and explicit errors.
+ *
+ * consecutiveErrorCount lets the caller escalate: a single tool
+ * failure is routine, but 3+ in a row means the user is stuck and
+ * Kodi might see a pattern.
+ */
+export function shouldCallAdvisor(
+  event: KodiEvent,
+  consecutiveErrorCount: number,
+): boolean {
+  switch (event.type) {
+    case "test_pass":
+    case "test_fail":
+    case "commit":
+    case "compaction":
+    case "agent_done":
+    case "agent_failed":
+    case "turn_end":
+    case "error":
+      return true;
+    case "tool_error":
+      return consecutiveErrorCount >= 3;
+    default:
+      return false;
   }
 }
 
@@ -212,6 +374,14 @@ export default function KodiCompanion({
   const engineRef = useRef<KodiAnimEngine | null>(null);
   const [frame, setFrame] = useState<KodiAnimState | null>(null);
   const [llmReaction, setLlmReaction] = useState<string | null>(null);
+  // Most recent advice string from the Kodi advisor, displayed as a
+  // dim line under the info grid. Persists across events until a new
+  // advice replaces it, OR a tier_entrance / tier_flex event clears it.
+  const [latestAdvice, setLatestAdvice] = useState<string | null>(null);
+  // Rolling count of consecutive tool_error events — drives the
+  // shouldCallAdvisor gate. Reset on any non-error event so a
+  // success between two failures doesn't trip the "3 in a row" gate.
+  const consecutiveErrorsRef = useRef(0);
   const lastToolMilestone = useRef(0);
   const lastTokenMilestone = useRef(0);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -288,6 +458,20 @@ export default function KodiCompanion({
       eventCountRef.current++;
       engine.react(event);
 
+      // Track consecutive tool errors for the advisor gate.
+      if (event.type === "tool_error") {
+        consecutiveErrorsRef.current += 1;
+      } else if (event.type !== "thinking" && event.type !== "streaming") {
+        // Only "meaningful" events reset the counter — a thinking or
+        // streaming interstitial shouldn't wipe a building error streak.
+        consecutiveErrorsRef.current = 0;
+      }
+
+      // Gate: only wake the advisor on events with real information
+      // content. Mechanical tool_start / streaming pings never reach
+      // the LLM, so the advisor stays quiet during happy-path flow.
+      if (!shouldCallAdvisor(event, consecutiveErrorsRef.current)) return;
+
       // Try LLM reaction (non-blocking)
       const ctx = buildContext(event, {
         tools: toolUseCount,
@@ -296,9 +480,16 @@ export default function KodiCompanion({
         agents: runningAgents,
       });
       generateReaction(ctx).then((r) => {
-        if (r) {
-          setLlmReaction(r);
-          engine.say(r, 5000);
+        if (!r) return;
+        if (r.speech) {
+          setLlmReaction(r.speech);
+          engine.say(r.speech, 5000);
+        }
+        if (r.mood) {
+          engine.setMood(r.mood);
+        }
+        if (r.advice) {
+          setLatestAdvice(r.advice);
         }
       });
     },
@@ -601,8 +792,18 @@ export default function KodiCompanion({
             <Text color={theme.dimmed}> </Text>
           )}
         </Box>
-        {/* Line 6: spacer */}
-        <Text> </Text>
+        {/* Line 6: Advisor line — concrete actionable tip from the
+            Kodi advisor model, truncated to the panel width. Hidden
+            when there's no advice in scope (free / pro / team or
+            enterprise users who haven't installed the model). */}
+        {latestAdvice ? (
+          <Box>
+            <Text color={theme.dimmed}>◆ </Text>
+            <Text color={theme.dimmed}>{latestAdvice}</Text>
+          </Box>
+        ) : (
+          <Text> </Text>
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary

Phase 2 wires the Kodi Advisor model (installed via #76) into actual Kodi reactions. The model that was sitting idle on port 10092 now drives mood, speech, and a new advice line.

## Flow

1. User triggers a coding event (test fails, commit lands, 3+ tool errors in a row, turn ends, …)
2. \`shouldCallAdvisor(event, errorStreak)\` gates the call — mechanical events stay silent
3. If Kodi's dedicated server is running, use it with the JSON-output prompt; otherwise fall back to the main model with plain-text prompt
4. Parse the tolerant JSON \`{mood, speech, advice}\`
5. Apply mood to the engine, speech to the bubble, advice to a new dim line under the info grid

## The advice line

Renders as \`◆ src/a.ts imports b.ts which imports a.ts\` in dim theme color, truncated to 120 chars. Persists across events until a new advice replaces it.

The prompt explicitly rejects generic advice. Bad: \`"consider refactoring"\`. Good: \`"src/a.ts imports b.ts which imports a.ts → cyclic"\`. The prompt instructs the model to emit \`advice: null\` (dropped by parser) when it has no real insight.

## Fallback chain

| Kodi server | Main model | Result |
|-------------|------------|--------|
| ✓ running   | —          | Full JSON: mood + speech + advice |
| ✗ down      | ✓ any      | Plain speech only (current behavior) |
| ✗ down      | ✗ none     | Deterministic Kodi (existing state machine) |

All three paths are non-blocking — the UI never waits on the advisor.

## Trigger filter

Fires on: \`test_pass\`, \`test_fail\`, \`commit\`, \`compaction\`, \`turn_end\`, \`error\`, \`agent_done\`, \`agent_failed\`, \`tool_error\` (after 3-streak).

Silent on: \`tool_start\`, \`tool_done\`, \`thinking\`, \`streaming\`, \`idle\`, \`agent_spawn\`, \`agent_progress\`.

## Files changed
- \`src/ui/components/Kodi.tsx\` — refactor (KodiReaction type, parseKodiAdvisorJson, shouldCallAdvisor, dual-path generateReaction, advice render line, consecutive-error tracker)
- \`src/ui/components/Kodi.advisor.test.ts\` — 18 new tests
- \`package.json\` — 2.10.109 → 2.10.110

## Tests
- [x] 18/18 new advisor tests passing
- [x] 451/451 UI tests
- [ ] Live smoke-test with the Kodi server running (user-level verification)

## Phase 3 (later, out of scope)
- /stats counter for advisor request rate + latency
- Session advice log at ~/.kcode/kodi-advice.log
- Keyboard shortcut to expand truncated advice
- User-tunable triggers in settings.kodiAdvisor.triggers

Co-Authored-By: Kulvex Code <contact@astrolexis.space>