### PR TITLE
feat(kodi): advisor emits advice-only + fluff filter + v2.10.111

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.110",
+  "version": "2.10.111",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/ui/components/Kodi.advisor.test.ts
+++ b/src/ui/components/Kodi.advisor.test.ts
@@ -1,89 +1,114 @@
-// Phase 2 — advisor-mode parsers and trigger filter.
+// Phase 2 — advisor parser and trigger filter.
 //
-// Covers parseKodiAdvisorJson's tolerance to messy small-model
-// outputs (code fences, trailing prose, missing fields) and
-// shouldCallAdvisor's event filtering so the advisor stays quiet
-// during mechanical tool flow.
+// The advisor only emits `advice` (mood + speech stay on the
+// deterministic engine path). parseKodiAdvisorJson must:
+//   - tolerate markdown fences and preamble prose from small models,
+//   - drop null / "null" / fluff advice,
+//   - truncate to 120 chars,
+//   - return null when nothing usable remains.
+//
+// shouldCallAdvisor gates LLM calls to events with real info content.
 
 import { describe, expect, test } from "bun:test";
-import { parseKodiAdvisorJson, shouldCallAdvisor, type KodiReaction } from "./Kodi";
+import { parseKodiAdvisorJson, shouldCallAdvisor } from "./Kodi";
 
 describe("parseKodiAdvisorJson — happy path", () => {
-  test("parses a clean JSON object", () => {
-    const raw = '{"mood":"worried","speech":"cyclic?","advice":"a.ts imports b.ts imports a.ts"}';
-    const r = parseKodiAdvisorJson(raw) as KodiReaction;
-    expect(r).not.toBeNull();
-    expect(r.mood).toBe("worried");
-    expect(r.speech).toBe("cyclic?");
-    expect(r.advice).toBe("a.ts imports b.ts imports a.ts");
-  });
-
-  test("truncates speech to 14 chars", () => {
-    const raw = '{"mood":"happy","speech":"wayyyyyy too long for the bubble","advice":null}';
+  test("parses a specific actionable advice", () => {
+    const raw = '{"advice":"src/core/models.ts: missing import of Opus 4.7 constant"}';
     const r = parseKodiAdvisorJson(raw);
     expect(r).not.toBeNull();
-    expect(r!.speech!.length).toBeLessThanOrEqual(14);
+    expect(r!.advice).toBe("src/core/models.ts: missing import of Opus 4.7 constant");
   });
 
   test("truncates advice to 120 chars", () => {
-    const long = "x".repeat(500);
-    const raw = `{"mood":"happy","speech":"ok","advice":"${long}"}`;
+    const raw = `{"advice":"${"x".repeat(500)}"}`;
     const r = parseKodiAdvisorJson(raw);
     expect(r).not.toBeNull();
     expect(r!.advice!.length).toBeLessThanOrEqual(120);
   });
+
+  test("trims leading/trailing whitespace", () => {
+    const raw = '{"advice":"   src/a.ts line 42   "}';
+    const r = parseKodiAdvisorJson(raw);
+    expect(r!.advice).toBe("src/a.ts line 42");
+  });
 });
 
 describe("parseKodiAdvisorJson — tolerant to small-model messiness", () => {
-  test("strips markdown fences", () => {
-    const raw = '```json\n{"mood":"excited","speech":"lgtm","advice":null}\n```';
+  test("strips labeled markdown fences", () => {
+    const raw = '```json\n{"advice":"test file expects Opus 4.7"}\n```';
     const r = parseKodiAdvisorJson(raw);
     expect(r).not.toBeNull();
-    expect(r!.mood).toBe("excited");
-    expect(r!.speech).toBe("lgtm");
+    expect(r!.advice).toBe("test file expects Opus 4.7");
   });
 
   test("strips unlabeled fences", () => {
-    const raw = '```\n{"mood":"happy","speech":"ok"}\n```';
+    const raw = '```\n{"advice":"check src/a.ts import order"}\n```';
     const r = parseKodiAdvisorJson(raw);
-    expect(r!.mood).toBe("happy");
+    expect(r!.advice).toBe("check src/a.ts import order");
   });
 
   test("extracts JSON from preamble prose", () => {
-    const raw = 'Sure! Here is my response: {"mood":"smug","speech":"nice","advice":null}';
+    const raw = 'Sure! Here is my response: {"advice":"Qwen tokenizer mismatch in models.ts:42"}';
     const r = parseKodiAdvisorJson(raw);
-    expect(r!.mood).toBe("smug");
+    expect(r!.advice).toBe("Qwen tokenizer mismatch in models.ts:42");
+  });
+});
+
+describe("parseKodiAdvisorJson — fluff filter", () => {
+  test("rejects 'consider X' hedge", () => {
+    const raw = '{"advice":"consider refactoring src/core/kodi.ts"}';
+    expect(parseKodiAdvisorJson(raw)).toBeNull();
   });
 
-  test("null advice is dropped (not included as a string)", () => {
-    const raw = '{"mood":"happy","speech":"ok","advice":null}';
-    const r = parseKodiAdvisorJson(raw);
-    expect(r!.advice).toBeUndefined();
+  test("rejects 'maybe check' hedge", () => {
+    const raw = '{"advice":"maybe check if the file exists"}';
+    expect(parseKodiAdvisorJson(raw)).toBeNull();
   });
 
-  test('string "null" as advice is also dropped', () => {
-    // Small models sometimes emit the literal word
-    const raw = '{"mood":"happy","speech":"ok","advice":"null"}';
-    const r = parseKodiAdvisorJson(raw);
-    expect(r!.advice).toBeUndefined();
+  test("rejects 'should X' hedge", () => {
+    const raw = '{"advice":"you should split conversation.ts"}';
+    expect(parseKodiAdvisorJson(raw)).toBeNull();
   });
 
-  test("invalid mood falls through — advisor keeps using current mood", () => {
-    const raw = '{"mood":"bogus_mood_name","speech":"ok","advice":null}';
-    const r = parseKodiAdvisorJson(raw);
-    expect(r!.mood).toBeUndefined();
-    expect(r!.speech).toBe("ok");
+  test("rejects 'ensure' hedge", () => {
+    const raw = '{"advice":"ensure everything works as expected"}';
+    expect(parseKodiAdvisorJson(raw)).toBeNull();
   });
 
-  test("new moods (flex, dance, waving) are accepted", () => {
-    for (const m of ["flex", "dance", "waving"]) {
-      const r = parseKodiAdvisorJson(`{"mood":"${m}","speech":"hi"}`);
-      expect(r!.mood).toBe(m);
-    }
+  test("rejects 'might want to' hedge", () => {
+    const raw = '{"advice":"you might want to run tests"}';
+    expect(parseKodiAdvisorJson(raw)).toBeNull();
+  });
+
+  test("rejects 'try to' hedge", () => {
+    const raw = '{"advice":"try to check the import"}';
+    expect(parseKodiAdvisorJson(raw)).toBeNull();
+  });
+
+  test("rejects 'recommended' hedge", () => {
+    const raw = '{"advice":"it is recommended to split the file"}';
+    expect(parseKodiAdvisorJson(raw)).toBeNull();
   });
 });
 
 describe("parseKodiAdvisorJson — rejection", () => {
+  test("null advice is rejected", () => {
+    expect(parseKodiAdvisorJson('{"advice":null}')).toBeNull();
+  });
+
+  test("string 'null' advice is rejected", () => {
+    expect(parseKodiAdvisorJson('{"advice":"null"}')).toBeNull();
+  });
+
+  test("empty advice string is rejected", () => {
+    expect(parseKodiAdvisorJson('{"advice":""}')).toBeNull();
+  });
+
+  test("whitespace-only advice is rejected", () => {
+    expect(parseKodiAdvisorJson('{"advice":"   "}')).toBeNull();
+  });
+
   test("returns null on non-JSON garbage", () => {
     expect(parseKodiAdvisorJson("I don't know how to respond.")).toBeNull();
   });
@@ -92,13 +117,12 @@ describe("parseKodiAdvisorJson — rejection", () => {
     expect(parseKodiAdvisorJson("")).toBeNull();
   });
 
-  test("returns null when all fields are missing or invalid", () => {
-    const raw = '{"mood":"invalid","speech":"","advice":null}';
-    expect(parseKodiAdvisorJson(raw)).toBeNull();
+  test("returns null on malformed JSON", () => {
+    expect(parseKodiAdvisorJson("{unbalanced")).toBeNull();
   });
 
-  test("returns null on malformed JSON even if text contains braces", () => {
-    expect(parseKodiAdvisorJson("{unbalanced")).toBeNull();
+  test("returns null when advice field is missing", () => {
+    expect(parseKodiAdvisorJson('{"other":"field"}')).toBeNull();
   });
 });
 

--- a/src/ui/components/Kodi.tsx
+++ b/src/ui/components/Kodi.tsx
@@ -68,27 +68,40 @@ Rules:
 - You can use unicode symbols sparingly: ⚡ ✨ 🔥 💀 ☕ etc.`;
 
 // Advisor prompt used when Kodi's dedicated abliterated server is
-// reachable on port 10092. The small model (Qwen 1.5B / Gemma 1B)
-// produces a single JSON object that drives THREE things in one shot:
-// a mood swap, a speech bubble (≤14 chars — fits next to the face),
-// and an optional concrete advice line. No advice is far better than
-// generic fluff, so the prompt makes "null" the default for advice.
-const KODI_ADVISOR_SYSTEM = `You are Kodi, a tiny developer-advisor ASCII mascot inside the KCode terminal assistant.
+// reachable on port 10092. Kept SHORT — small models (Qwen 1.5B,
+// Gemma 1B) degrade sharply with long system prompts.
+//
+// Scope decision (from smoke-testing Qwen 2.5 Coder 1.5B abliterated
+// against real events): the advisor ONLY generates `advice`. Mood
+// stays deterministic in the engine (engine.react(event) already
+// picks a well-tuned mood per event type), and the existing
+// SPEECH_CHIPS for the bubble are more coherent than anything a
+// 1.5B model will produce in ≤14 chars. Narrowing the advisor to
+// a single field also means smaller schema, faster generation,
+// and fewer token budget knobs to tune.
+const KODI_ADVISOR_SYSTEM = `You are Kodi, a dev advisor mascot.
+Output ONE JSON object: {"advice": "..."}.
+advice: ONE specific actionable tip with exact file/fn/error pattern, ≤90 chars. If nothing specific to say, advice must be null.
+PROHIBITED in advice: "consider", "maybe", "should", "recommended", "ensure", "might want to". These produce fluff — emit null instead.`;
 
-You observe coding events and respond with a SINGLE JSON object:
-
-{"mood": "...", "speech": "...", "advice": "..."}
-
-Fields:
-- mood: ONE of idle, happy, excited, thinking, reasoning, working, worried, celebrating, curious, mischievous, crazy, angry, smug, flex, dance, waving
-- speech: bubble text, MAX 14 characters. Terse. Conversational.
-- advice: ONE concrete actionable hint (file path, function name, error pattern), MAX 90 characters. If you don't have a real, specific insight, set to null.
-
-Rules:
-- Output ONLY the JSON object. No prose. No markdown fences. No preamble.
-- advice must be SPECIFIC. Bad: "consider refactoring". Good: "src/a.ts imports b.ts which imports a.ts → cyclic".
-- Never repeat yourself across turns. Mix moods.
-- If the event is trivial (tool read finished, idle ping) emit a cheerful mood+speech and advice: null.`;
+/**
+ * JSON schema used for constrained generation on the Kodi server.
+ * llama.cpp's response_format + json_schema rejects tokens that
+ * violate the schema at generation time, so `advice` is guaranteed
+ * to be string|null when we parse. Small, fast, predictable.
+ */
+const KODI_ADVISOR_SCHEMA = {
+  name: "kodi_reaction",
+  strict: true,
+  schema: {
+    type: "object",
+    additionalProperties: false,
+    required: ["advice"],
+    properties: {
+      advice: { type: ["string", "null"] },
+    },
+  },
+};
 
 let _llmBaseUrl: string | null = null;
 let _pendingRequest: AbortController | null = null;
@@ -129,39 +142,35 @@ async function getLlmBaseUrl(): Promise<string> {
 }
 
 export interface KodiReaction {
-  /** Optional mood override from the advisor model. */
-  mood?: KodiMood;
-  /** Bubble text (truncated to ≤14 chars for display). */
-  speech?: string;
   /** Actionable advice (truncated to ≤120 chars for display). */
   advice?: string;
 }
 
-const VALID_MOODS: readonly string[] = [
-  "idle",
-  "happy",
-  "excited",
-  "thinking",
-  "reasoning",
-  "working",
-  "worried",
-  "sleeping",
-  "celebrating",
-  "curious",
-  "mischievous",
-  "crazy",
-  "angry",
-  "smug",
-  "flex",
-  "dance",
-  "waving",
-] as const;
+/** Anti-fluff filter. If the model ignores the PROHIBITED instruction
+ * and still emits "consider X" or "maybe check Y" we treat it as no
+ * advice — those lines never help a developer and they crowd out
+ * legitimate signal. Case-insensitive match against a handful of
+ * hedge words that reliably correlate with generic content. */
+const FLUFF_PATTERNS: readonly RegExp[] = [
+  /\bconsider\b/i,
+  /\bmaybe\b/i,
+  /\bshould\b/i,
+  /\brecommended?\b/i,
+  /\bmight want to\b/i,
+  /\bensure\b/i,
+  /\btry to\b/i,
+];
+
+function isFluff(advice: string): boolean {
+  return FLUFF_PATTERNS.some((re) => re.test(advice));
+}
 
 /**
  * Tolerant JSON parser for the advisor's output. Small models often
  * wrap in markdown fences or prepend prose — we strip both and
- * extract the first {...} block. Fields are validated individually
- * so a malformed `mood` doesn't invalidate the whole reaction.
+ * extract the first {...} block. Advice that smells like generic
+ * fluff (consider X, maybe Y) is dropped even if the model bypassed
+ * the PROHIBITED clause in the prompt.
  */
 export function parseKodiAdvisorJson(raw: string): KodiReaction | null {
   const cleaned = raw
@@ -179,23 +188,27 @@ export function parseKodiAdvisorJson(raw: string): KodiReaction | null {
   }
   if (!obj || typeof obj !== "object") return null;
   const o = obj as Record<string, unknown>;
-  const reaction: KodiReaction = {};
-  if (typeof o.mood === "string" && VALID_MOODS.includes(o.mood)) {
-    reaction.mood = o.mood as KodiMood;
+  if (
+    typeof o.advice !== "string" ||
+    !o.advice.trim() ||
+    o.advice.trim().toLowerCase() === "null"
+  ) {
+    return null;
   }
-  if (typeof o.speech === "string" && o.speech.trim()) {
-    reaction.speech = o.speech.trim().slice(0, 14);
-  }
-  if (typeof o.advice === "string" && o.advice.trim() && o.advice.trim().toLowerCase() !== "null") {
-    reaction.advice = o.advice.trim().slice(0, 120);
-  }
-  // Require at least one usable field — all-empty means the model
-  // produced garbage and we should fall back to deterministic Kodi.
-  if (!reaction.mood && !reaction.speech && !reaction.advice) return null;
-  return reaction;
+  const cleanedAdvice = o.advice.trim();
+  if (isFluff(cleanedAdvice)) return null;
+  return { advice: cleanedAdvice.slice(0, 120) };
 }
 
 async function generateReaction(context: string): Promise<KodiReaction | null> {
+  // Advisor is Kodi-server-only. No fallback to the main coding
+  // model: using the user's expensive Claude/Opus tokens to produce
+  // a single bubble hint would be a pointless cost. If the Kodi
+  // server isn't running, the deterministic engine (engine.react
+  // + SPEECH_CHIPS) handles everything.
+  const kodiUrl = await resolveKodiBaseUrl();
+  if (!kodiUrl) return null;
+
   const now = Date.now();
   if (now - _lastLlmCall < LLM_COOLDOWN_MS) return null;
   if (_pendingRequest) _pendingRequest.abort();
@@ -204,45 +217,38 @@ async function generateReaction(context: string): Promise<KodiReaction | null> {
   const controller = new AbortController();
   _pendingRequest = controller;
 
-  // Prefer Kodi's dedicated abliterated server when it's up. The
-  // Kodi server runs fully local on port 10092, doesn't compete
-  // with the main model, and the small size means latency is fine
-  // for bubble-rendering. When the Kodi server is down (not
-  // installed, stopped, or user declined) we fall back to the main
-  // coding model — but only for plain speech, not advice.
-  const kodiUrl = await resolveKodiBaseUrl();
-  const isKodi = kodiUrl !== null;
-  const baseUrl = kodiUrl ?? (await getLlmBaseUrl());
-
   try {
-    const res = await fetch(`${baseUrl}/v1/chat/completions`, {
+    const res = await fetch(`${kodiUrl}/v1/chat/completions`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       signal: controller.signal,
       body: JSON.stringify({
         messages: [
-          { role: "system", content: isKodi ? KODI_ADVISOR_SYSTEM : KODI_SYSTEM },
+          { role: "system", content: KODI_ADVISOR_SYSTEM },
           { role: "user", content: context },
         ],
-        max_tokens: isKodi ? 120 : 30,
-        temperature: isKodi ? 0.7 : 1.0,
+        max_tokens: 80,
+        // Low temperature: smoke-tested against Qwen 2.5 Coder 1.5B
+        // abliterated — at 0.7 the model drifts into generic "maybe
+        // check" advice; at 0.3 it stays anchored to the actual
+        // context and produces concrete file/error references.
+        temperature: 0.3,
         top_p: 0.95,
-        // llama.cpp accepts this hint for JSON-mode on modern builds;
-        // older builds ignore it harmlessly.
-        ...(isKodi ? { response_format: { type: "json_object" } } : {}),
+        // json_schema is enforced token-by-token on modern llama.cpp,
+        // so `advice` is guaranteed string|null downstream. Older
+        // builds ignore the schema and fall back to json_object mode,
+        // which the parser still handles fine.
+        response_format: {
+          type: "json_schema",
+          json_schema: KODI_ADVISOR_SCHEMA,
+        },
       }),
     });
     if (!res.ok) return null;
     const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
     const text = data.choices?.[0]?.message?.content?.trim();
     if (!text) return null;
-
-    if (isKodi) {
-      return parseKodiAdvisorJson(text);
-    }
-    // Main-model fallback: plain-text speech only; no mood swap, no advice.
-    if (text.length > 80) return null;
-    return { speech: text.replace(/^["']|["']$/g, "") };
+    return parseKodiAdvisorJson(text);
   } catch {
     return null;
   } finally {
@@ -480,17 +486,11 @@ export default function KodiCompanion({
         agents: runningAgents,
       });
       generateReaction(ctx).then((r) => {
-        if (!r) return;
-        if (r.speech) {
-          setLlmReaction(r.speech);
-          engine.say(r.speech, 5000);
-        }
-        if (r.mood) {
-          engine.setMood(r.mood);
-        }
-        if (r.advice) {
-          setLatestAdvice(r.advice);
-        }
+        if (!r || !r.advice) return;
+        // Mood + speech stay on the deterministic engine path —
+        // r only carries advice. Keeps the 1.5B advisor in its lane
+        // and the bubble coherent regardless of LLM quality.
+        setLatestAdvice(r.advice);
       });
     },
     [engine, toolUseCount, tokenCount, sessionElapsedMs, runningAgents],


### PR DESCRIPTION
## Summary

Live smoke-tested Phase 2 against Qwen 2.5 Coder 1.5B abliterated running on the Kodi server. Findings:

**Working well**: when the model hits on a specific pattern, advice is genuinely useful. E.g. \`tool_error\` streak on \`ENOENT: src/core/models.ts\` while editing \`src/ui/components/Kodi.tsx\` produced:

> \`src/core/models.ts: missing import of Opus 4.7 constant\`

**Failing**: mood choice (test_fail → "excited"), speech truncated mid-word ("Great news! A ", "Review the \`Op"), and most of the time advice is hedge-laden fluff ("consider running X", "ensure Y"). The 1.5B ceiling showed clearly.

## The fix

Narrow the advisor's role to its strongest signal — **advice-only**. Mood and speech stay deterministic (engine.react + SPEECH_CHIPS are reliable and well-tuned; a 1.5B model can't beat them).

| Before | After |
|--------|-------|
| \`{mood, speech, advice}\` schema | \`{advice}\` schema |
| 300-token prompt | 50-token prompt |
| Temperature 0.7 | Temperature 0.3 |
| Advisor overrode good deterministic mood | Advisor never touches mood |
| Truncated speech looked amputated | Deterministic chips ("broke!", "saved!") |
| No fluff filter | 7 hedge-word patterns reject fluff |

## Fluff filter

Seven regex patterns in \`parseKodiAdvisorJson\` reject advice that trips any of:

\`\`\`
\\bconsider\\b        \\bmaybe\\b          \\bshould\\b
\\brecommended?\\b    \\bensure\\b         \\btry to\\b
\\bmight want to\\b
\`\`\`

Model bypasses the PROHIBITED clause in the prompt more often than not — this catches the leak at parse time. Advice that hits a pattern returns \`null\` and UI shows nothing. **Silence > noise** for a mascot panel.

## Expected UX

The \`◆ advice\` line appears **rarely** in practice. Most events produce fluff that gets filtered; those turn into normal deterministic Kodi behavior. When the advice line DOES appear, it's a concrete file/function/pattern reference worth reading.

## Non-goals explicitly

- **No bigger model**. 3-7B abliterated would improve the hit rate but doubles RAM. Users who want that can wait for a future Phase 3 "Large Advisor" option.
- **No main-model fallback**. Using the user's Claude/Opus tokens to generate a bubble hint was never the plan. If the Kodi server is down, deterministic engine handles everything.

## Files changed
- \`src/ui/components/Kodi.tsx\` — schema simplification, prompt reduction, fluff filter, no-fallback policy
- \`src/ui/components/Kodi.advisor.test.ts\` — 25 tests (was 18)
- \`package.json\` — 2.10.110 → 2.10.111

## Tests
- [x] 25/25 advisor tests passing
- [x] 458/458 UI tests
- [x] Live test against running Kodi server — 3 scenarios produced fluff (correctly filtered), 1 earlier scenario produced concrete advice (correctly displayed)

Co-Authored-By: Kulvex Code <contact@astrolexis.space>