### PR TITLE
fix(kodi): /quit hangs because child_process pipes kept event loop alive + v2.10.112

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.111",
+  "version": "2.10.112",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/kodi-model.ts
+++ b/src/core/kodi-model.ts
@@ -21,7 +21,15 @@
 // which is the sweet spot for small models (≈1 byte/param).
 
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { freemem } from "node:os";
 import { join } from "node:path";
 import { log } from "./logger";
@@ -355,16 +363,25 @@ export async function startKodiServer(): Promise<{ port: number; pid: number }> 
 
   log.info("kodi-model", `Starting Kodi server: ${binary} ${args.join(" ")}`);
 
-  const logFd = Bun.file(KODI_LOG_FILE).writer();
+  // Open the log file as a raw fd and hand it directly to stdio.
+  // This is load-bearing: earlier versions used
+  //   stdio: ["ignore", "pipe", "pipe"]
+  //   child.stdout?.on("data", ...)
+  // which kept Bun's event loop alive with pipe readers even after
+  // child.unref() — so /quit in the TUI would hang until the Kodi
+  // server exited. With file descriptors passed in, stdout/stderr
+  // are never plumbed through the parent's event loop and the TUI
+  // can exit cleanly while the Kodi server keeps running.
+  const outFd = openSync(KODI_LOG_FILE, "a");
   const child = spawn(binary, args, {
     detached: true,
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: ["ignore", outFd, outFd],
   });
-  child.stdout?.on("data", (d) => logFd.write(d));
-  child.stderr?.on("data", (d) => logFd.write(d));
   child.on("error", (err) => {
     log.warn("kodi-model", `spawn error: ${err}`);
   });
+  // Close our fd handle — the child now owns it.
+  closeSync(outFd);
   child.unref();
 
   if (!child.pid) {


### PR DESCRIPTION
## The bug

User typed \`/quit\` in the TUI after \`/kodi-advisor → start\` and the kcode process stayed suspended indefinitely.

## Root cause

\`startKodiServer()\` in \`kodi-model.ts\` spawned llama-server with:

\`\`\`ts
stdio: ["ignore", "pipe", "pipe"]
child.stdout?.on("data", (d) => logFd.write(d))
child.stderr?.on("data", (d) => logFd.write(d))
child.unref()
\`\`\`

\`child.unref()\` only drops the ChildProcess itself from the event loop's ref count. The pipe Readables attached via \`stdout.on("data", ...)\` / \`stderr.on("data", ...)\` hold their **own** references — \`unref()\` on the child doesn't propagate. With the llama-server emitting log lines continuously, Bun's event loop was "busy" piping those through the parent's JS forever, and \`useApp().exit()\` waited for drain that would never come.

## Fix

Open the log file directly as a raw file descriptor and hand it to \`spawn\` as both stdout and stderr:

\`\`\`ts
const outFd = openSync(KODI_LOG_FILE, "a");
const child = spawn(binary, args, {
  detached: true,
  stdio: ["ignore", outFd, outFd],
});
closeSync(outFd);  // child keeps a dup'd copy via fork-exec
child.unref();
\`\`\`

No pipes on the parent side → no data listeners → no event loop references. The kernel writes llama-server's output straight to the log file. Parent can exit cleanly while the server keeps running.

Side benefit: no per-line round-trip through JS — smaller CPU overhead on the parent for high-volume server output.

## Not touched

The main model's \`llama-server.ts\` has a similar-looking pipe pattern (\`Bun.file(LOG_FILE).writer()\`). Deliberately not fixing it here because the user's report is specifically about the Kodi server added in v2.10.108. If \`/quit\` also hangs with just the main model running (no Kodi), that's a separate PR.

## Tests
- [x] 12/12 kodi-model tests passing (unchanged — this is a behavior-only fix)

Co-Authored-By: Kulvex Code <contact@astrolexis.space>