### PR TITLE
fix(kodi): /quit delay — tier-flex timeout + in-flight fetch abort + v2.10.113

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.112",
+  "version": "2.10.113",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/ui/components/Kodi.tsx
+++ b/src/ui/components/Kodi.tsx
@@ -409,6 +409,18 @@ export default function KodiCompanion({
     return () => clearInterval(timer);
   }, [engine]);
 
+  // Abort any in-flight advisor LLM request on unmount. Without this,
+  // /quit can hang for seconds waiting for a 80-token completion
+  // that's already irrelevant (the TUI is gone).
+  useEffect(() => {
+    return () => {
+      if (_pendingRequest) {
+        _pendingRequest.abort();
+        _pendingRequest = null;
+      }
+    };
+  }, []);
+
   // Update elapsed time every 10s
   useEffect(() => {
     if (!sessionStartTime) return;
@@ -436,13 +448,20 @@ export default function KodiCompanion({
   // while Kodi is actually idle (no active tool, no thinking). Picks
   // a random interval between 75-105s so it doesn't feel mechanical.
   // Free tier skips this entirely.
+  //
+  // Load-bearing: we clearTimeout on unmount, not just flip a
+  // cancelled flag. An unfired setTimeout keeps Bun's event loop
+  // alive until it triggers — a pending flex scheduled 90s out was
+  // the biggest contributor to /quit taking seconds to exit.
   useEffect(() => {
     if (!tier || tier === "free") return;
     let cancelled = false;
+    let pendingTimer: ReturnType<typeof setTimeout> | null = null;
     const scheduleNext = () => {
       if (cancelled) return;
       const delay = 75_000 + Math.random() * 30_000;
-      setTimeout(() => {
+      pendingTimer = setTimeout(() => {
+        pendingTimer = null;
         if (cancelled) return;
         // Only flex when we're actually idle — no point breaking a
         // thinking animation with a sparkle.
@@ -455,6 +474,10 @@ export default function KodiCompanion({
     scheduleNext();
     return () => {
       cancelled = true;
+      if (pendingTimer) {
+        clearTimeout(pendingTimer);
+        pendingTimer = null;
+      }
     };
   }, [tier, engine]);
 


### PR DESCRIPTION
## Summary

Follow-up to #80. v2.10.112 fixed the pipe-leak — \`/quit\` now exits eventually but still takes seconds. Two more event-loop holders found:

## Issue 1 — Tier-flex timeout not cleared

\`\`\`ts
useEffect(() => {
  let cancelled = false;
  const scheduleNext = () => {
    setTimeout(() => {  // ← handle NOT stored
      if (cancelled) return;
      ...
    }, 75_000 + Math.random() * 30_000);
  };
  scheduleNext();
  return () => { cancelled = true; };  // ← only flips flag
}, [tier, engine]);
\`\`\`

Bun keeps the event loop alive until the scheduled timer fires. \`cancelled=true\` makes the callback a no-op but the timer (up to 105 seconds out) still exists. That alone could block \`/quit\` for 1-2 minutes on a bad draw.

**Fix**: store the handle, \`clearTimeout\` in cleanup.

## Issue 2 — In-flight advisor fetch had no unmount abort

\`generateReaction\` kicks off a fetch against the Kodi server (80-token completion, ~1-2s). The shared \`_pendingRequest\` controller is only aborted when the **next** \`generateReaction\` call starts — never on unmount.

**Fix**: new \`useEffect(() => () => _pendingRequest?.abort(), [])\` explicitly aborts any in-flight request when Kodi unmounts.

## Expected behavior after this PR

\`/quit\` exits within a fraction of a second:
- ✅ Pipe leak (v2.10.112): no parent-side pipe listeners on Kodi server
- ✅ Tier-flex timer: \`clearTimeout\` on unmount
- ✅ In-flight advisor fetch: \`abort()\` on unmount
- ✅ Subscription 15-min interval: already cleared via existing \`clearInterval\` cleanup
- ✅ Animation / elapsed / scan intervals: already cleared

## Tests
- [x] 458/458 UI tests passing

Co-Authored-By: Kulvex Code <contact@astrolexis.space>