### PR TITLE
fix(web-engine): Python terminal prompt mis-fired Next.js scaffold + v2.10.115

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.114",
+  "version": "2.10.115",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/conversation.ts
+++ b/src/core/conversation.ts
@@ -845,7 +845,17 @@ export class ConversationManager {
         const isModification = /\b(?:make|hazlo|fix|arregla|change|cambia|update|actualiza|add|agrega|remove|quita|improve|mejora|refactor|move|mueve|delete|borra|resize|collaps|expand|drag)\b/i.test(userMessage)
           && !/\b(?:create|crea|build|construye|scaffold|genera|new|nueva?o?)\b/i.test(userMessage);
 
-        const isWebRequest = !isModification && /\b(?:website|web\s*(?:site|app|page)|landing|dashboard|blog|portfolio|store|shop|tienda|sitio\s*web|p[aá]gina\s*web|saas|e-?commerce|trading|social|chat|crm|kanban|lms|course|education|iot|monitor|analytics|admin\s*panel|feed|board|panel|platform)\b/i.test(userMessage);
+        // Explicit non-web stack mention nukes the web-engine path even
+        // if keywords like "dashboard" or "monitor" appear elsewhere
+        // in the prompt. A prompt that says "Python 3.11+ terminal
+        // dashboard" or "Rust CLI monitor" should always go to the LLM
+        // — the Next.js auto-scaffold would be user-hostile noise.
+        // Checked BEFORE isWebRequest so nothing downstream fires.
+        const mentionsNonWebStack = /\b(?:python|rust|go(?:lang)?|c\+\+|ruby|elixir|erlang|zig|haskell|scala)\b/i.test(userMessage)
+          || /\b(?:cli|terminal|tui|curses|textual|rich|typer|click|ink|tauri)\b/i.test(userMessage)
+          || /\b(?:pip\s+install|pyinstaller|cargo|gradle|maven|gem\s+install)\b/i.test(userMessage);
+
+        const isWebRequest = !isModification && !mentionsNonWebStack && /\b(?:website|web\s*(?:site|app|page)|landing|dashboard|blog|portfolio|store|shop|tienda|sitio\s*web|p[aá]gina\s*web|saas|e-?commerce|trading|social|chat|crm|kanban|lms|course|education|iot|monitor|analytics|admin\s*panel|feed|board|panel|platform)\b/i.test(userMessage);
 
         if (task.type === "implement" && !isModification) {
           const { detectCodeEngine, runCodeEngine } = await import("./code-engine-router.js");

--- a/src/core/web-engine/detector.test.ts
+++ b/src/core/web-engine/detector.test.ts
@@ -1,0 +1,81 @@
+// Regression coverage for detectWebIntent — specifically the false
+// positives that sent a Python+textual terminal prompt to the
+// Next.js trading-dashboard scaffold.
+
+import { describe, expect, test } from "bun:test";
+import { detectWebIntent } from "./detector";
+
+describe("detectWebIntent — false-positive regressions", () => {
+  test("Python + textual + ticker prompt does NOT pick trading-dashboard", () => {
+    // Reproducer from the btctop incident: a 3k-char prompt with
+    // 'textual', 'terminal', 'htop', AND the word 'ticker' used
+    // as a panel name. Pre-fix, this matched `ticker` alone and
+    // triggered the Next.js template. Post-fix, `ticker` requires
+    // a currency-type qualifier, so trading-dashboard stays cold.
+    const prompt = `Build a Python 3.11+ terminal dashboard called btctop — a real-time Bitcoin
+monitor styled like htop. TECH STACK: textual, httpx. PANELS include a
+price ticker panel. NON-GOALS: no wallet, no trading.`;
+    const intent = detectWebIntent(prompt);
+    expect(intent.siteType).not.toBe("trading-dashboard");
+  });
+
+  test("'news ticker' on a landing page does NOT pick trading-dashboard", () => {
+    const intent = detectWebIntent(
+      "Build a landing page for a news site with a news ticker across the top",
+    );
+    expect(intent.siteType).not.toBe("trading-dashboard");
+  });
+
+  test("'price ticker' on a python CLI does NOT pick trading-dashboard", () => {
+    const intent = detectWebIntent(
+      "Python CLI that shows a price ticker for BTC and ETH in the terminal",
+    );
+    expect(intent.siteType).not.toBe("trading-dashboard");
+  });
+
+  test("photo portfolio website does NOT pick trading-dashboard", () => {
+    // Pre-fix, 'portfolio' alone matched. Post-fix it needs "portfolio
+    // tracker" / "portfolio dashboard" / "portfolio manager".
+    const intent = detectWebIntent(
+      "Build a photo portfolio website to showcase my work",
+    );
+    expect(intent.siteType).not.toBe("trading-dashboard");
+  });
+});
+
+describe("detectWebIntent — actual trading apps still match", () => {
+  test("explicit trading dashboard is picked up", () => {
+    const intent = detectWebIntent(
+      "Build a trading dashboard with candlestick charts and an order book",
+    );
+    expect(intent.siteType).toBe("trading-dashboard");
+  });
+
+  test("stock ticker web app matches trading-dashboard", () => {
+    const intent = detectWebIntent(
+      "Build a web app with a stock ticker and portfolio tracker",
+    );
+    expect(intent.siteType).toBe("trading-dashboard");
+  });
+
+  test("spanish bolsa/acciones still matches", () => {
+    const intent = detectWebIntent(
+      "Un sitio web para la bolsa con gráficos de acciones",
+    );
+    expect(intent.siteType).toBe("trading-dashboard");
+  });
+
+  test("crypto ticker matches", () => {
+    const intent = detectWebIntent(
+      "Website with a crypto ticker for BTC, ETH and a portfolio dashboard",
+    );
+    expect(intent.siteType).toBe("trading-dashboard");
+  });
+
+  test("portfolio tracker matches", () => {
+    const intent = detectWebIntent(
+      "Build a portfolio tracker for my stocks",
+    );
+    expect(intent.siteType).toBe("trading-dashboard");
+  });
+});

--- a/src/core/web-engine/detector.ts
+++ b/src/core/web-engine/detector.ts
@@ -31,7 +31,15 @@ const SITE_RULES: SiteRule[] = [
   {
     type: "trading-dashboard",
     patterns: [
-      /\b(?:trading|stock|wallstreet|wall\s*street|candlestick|ticker|financial\s+dashboard|market\s+(?:dashboard|heatmap)|portfolio\s+tracker|order\s*book)\b/i,
+      // Bare `trading` and `stock` matched too broadly — prompts like
+      // "NON-GOALS: no trading" or "a photo portfolio site" falsely
+      // tripped the Next.js trading template. Now requires a compound
+      // with a web-indicator noun so only actual trading-web prompts
+      // pick this up. `ticker` same story — needs a currency qualifier.
+      /\b(?:trading|stock)\s+(?:dashboard|platform|app|site|web|system|tool)\b/i,
+      /\b(?:wallstreet|wall\s*street|candlestick|financial\s+dashboard|market\s+(?:dashboard|heatmap)|order\s*book)\b/i,
+      /\b(?:stock|crypto|forex|currency)\s+ticker\b/i,
+      /\b(?:portfolio\s+(?:tracker|dashboard|manager))\b/i,
       /\b(?:bolsa|acciones|mercado\s+(?:financiero|de\s+valores))\b/i,
     ],
     defaultStack: "nextjs",


### PR DESCRIPTION
## The bug

User pasted a 3.3KB prompt explicitly asking for a **Python 3.11+ + textual terminal** Bitcoin monitor (btctop). kcode auto-scaffolded a **Next.js trading-dashboard** with 17 files, \`0 LLM\` — completely ignoring the prompt's content.

\`\`\`
✅ trading-dashboard — 17 files (17 machine, 0 LLM)
📁 /home/curly/projects/btctop/base
✅ Next.js server started (PID: 3070462)
\`\`\`

## Two independent bugs

### 1. Detector regex was too greedy

\`detector.ts:34\`'s trading-dashboard rule matched:
- Bare \`ticker\` — triggered on "Price ticker" (a panel NAME in the prompt), also "news ticker", any real-time data stream
- Bare \`trading\` — triggered even in negative context: the prompt had "NON-GOALS: no trading" and that matched
- Bare \`stock\` / \`portfolio\` — would match "photo stock site" / "photo portfolio site"

**Fix**: require compound patterns.
| Old | New |
|-----|-----|
| \`trading\` alone | \`trading (dashboard\|platform\|app\|site\|web\|system\|tool)\` |
| \`stock\` alone | \`stock (dashboard\|platform\|app\|...)\` + \`stock ticker\` branch |
| \`ticker\` alone | \`(stock\|crypto\|forex\|currency) ticker\` |
| \`portfolio\` alone | \`portfolio (tracker\|dashboard\|manager)\` |

### 2. isWebRequest had no stack-awareness

\`conversation.ts:848\` fired the web engine on any prompt containing "dashboard", "monitor", "panel" etc. — even when the prompt explicitly said \`Python\`, \`CLI\`, \`terminal\`, \`textual\`. A prompt that starts with "Build a Python 3.11+ terminal dashboard" would still go to the Next.js engine.

**Fix**: new \`mentionsNonWebStack\` short-circuit that vetoes the web engine when any of these tokens appear:

\`python\`, \`rust\`, \`go(lang)\`, \`c++\`, \`ruby\`, \`elixir\`, \`erlang\`, \`zig\`, \`haskell\`, \`scala\`, \`cli\`, \`terminal\`, \`tui\`, \`curses\`, \`textual\`, \`rich\`, \`typer\`, \`click\`, \`ink\`, \`tauri\`, \`pip install\`, \`pyinstaller\`, \`cargo\`, \`gradle\`, \`maven\`, \`gem install\`

## Tests

9 new regression tests in \`detector.test.ts\`:
- **False positive coverage** (must NOT match trading-dashboard):
  - Python + textual + ticker prompt (the exact incident reproducer)
  - news ticker on a landing page
  - price ticker on a python CLI
  - photo portfolio website
- **Positive coverage** (must still match trading-dashboard):
  - explicit trading dashboard
  - stock ticker web app
  - spanish bolsa/acciones
  - crypto ticker
  - portfolio tracker

244 core web-engine + conversation tests passing.

## User recovery

The user's actual Python scaffold (\`pyproject.toml\` + \`src/btctop/\`) WAS generated correctly by the LLM after the engine mis-fired — just had 17 spurious Next.js files in \`base/\` that were already cleaned up manually.

Co-Authored-By: Kulvex Code <contact@astrolexis.space>