### PR TITLE
feat(kodi): door teleport + musings + fluff meta-filter + v2.10.116

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.115",
+  "version": "2.10.116",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/ui/components/Kodi.tsx
+++ b/src/ui/components/Kodi.tsx
@@ -146,12 +146,17 @@ export interface KodiReaction {
   advice?: string;
 }
 
-/** Anti-fluff filter. If the model ignores the PROHIBITED instruction
- * and still emits "consider X" or "maybe check Y" we treat it as no
- * advice — those lines never help a developer and they crowd out
- * legitimate signal. Case-insensitive match against a handful of
- * hedge words that reliably correlate with generic content. */
+/** Anti-fluff filter. Two categories of reject:
+ *   1. Hedge words — generic advice ("consider X", "maybe check Y")
+ *   2. Meta-chatter — model-as-chatbot babble ("please provide more
+ *      context", "I don't have enough information"). These surface
+ *      when the advisor LLM falls back on its assistant persona
+ *      instead of observing the event, and are spectacularly useless
+ *      as a mascot bubble. Observed live from Qwen 2.5 Coder 1.5B
+ *      abliterated on sparse contexts.
+ */
 const FLUFF_PATTERNS: readonly RegExp[] = [
+  // Hedge words
   /\bconsider\b/i,
   /\bmaybe\b/i,
   /\bshould\b/i,
@@ -159,6 +164,15 @@ const FLUFF_PATTERNS: readonly RegExp[] = [
   /\bmight want to\b/i,
   /\bensure\b/i,
   /\btry to\b/i,
+  // Meta-chatter / assistant persona leakage
+  /\bplease (?:provide|clarify|specify|share)\b/i,
+  /\bi don'?t have (?:enough|any|sufficient)\b/i,
+  /\bcould you (?:clarify|specify|provide)\b/i,
+  /\bi (?:can|would) (?:help|assist|be happy)\b/i,
+  /\bmore (?:context|information|details) (?:or|please|would)\b/i,
+  /\bspecific question\b/i,
+  /\bfeel free to\b/i,
+  /\blet me know\b/i,
 ];
 
 function isFluff(advice: string): boolean {
@@ -554,6 +568,79 @@ export default function KodiCompanion({
     return () => clearInterval(id);
   }, [sessionStartTime, contextWindowSize, tokenCount, toolUseCount]);
 
+  // ── Musings — passing thoughts ──
+  // Every 3-5 min of continuous idle, ask the LLM for a short
+  // thought and show it as a bubble. Not tied to any event. This is
+  // what makes Kodi feel like an independent tamagotchi instead of
+  // just an event-reactor. Hard-gated on Kodi server availability,
+  // so free/declined users see nothing here.
+  useEffect(() => {
+    let cancelled = false;
+    let pending: ReturnType<typeof setTimeout> | null = null;
+    const scheduleNext = () => {
+      if (cancelled) return;
+      const delay = 180_000 + Math.random() * 120_000; // 3-5 min
+      pending = setTimeout(async () => {
+        pending = null;
+        if (cancelled) return;
+        // Only muse when Kodi is actually idle — never step on a
+        // reaction or advisor line in flight.
+        if (engine.phase !== "idle" || engine.mood !== "idle") {
+          scheduleNext();
+          return;
+        }
+        try {
+          const { askForMusing } = await import("../kodi-autonomy.js");
+          const thought = await askForMusing(engine.personality);
+          if (cancelled) return;
+          if (thought) {
+            engine.setMood("thinking");
+            engine.say(thought, 5500);
+          }
+        } catch {
+          /* swallow */
+        }
+        scheduleNext();
+      }, delay);
+    };
+    scheduleNext();
+    return () => {
+      cancelled = true;
+      if (pending) {
+        clearTimeout(pending);
+        pending = null;
+      }
+    };
+  }, [engine]);
+
+  // ── Door teleport — swap panel sides ──
+  // Every 5-8 min, Kodi plays the "I went through a door and came
+  // out on the other side of the info panel" trick. Pure deterministic
+  // trigger (no LLM needed) — the engine's teleportThroughDoor()
+  // handles the whole animation + side flip.
+  useEffect(() => {
+    let cancelled = false;
+    let pending: ReturnType<typeof setTimeout> | null = null;
+    const scheduleNext = () => {
+      if (cancelled) return;
+      const delay = 300_000 + Math.random() * 180_000; // 5-8 min
+      pending = setTimeout(() => {
+        pending = null;
+        if (cancelled) return;
+        engine.teleportThroughDoor();
+        scheduleNext();
+      }, delay);
+    };
+    scheduleNext();
+    return () => {
+      cancelled = true;
+      if (pending) {
+        clearTimeout(pending);
+        pending = null;
+      }
+    };
+  }, [engine]);
+
   // Update elapsed time every 10s
   useEffect(() => {
     if (!sessionStartTime) return;
@@ -761,9 +848,17 @@ export default function KodiCompanion({
   ];
   const bubble = frame?.bubble ?? "";
 
+  // Side drives which end of the panel Kodi sits on. The engine
+  // flips this at the midpoint of a door-teleport animation so the
+  // second half of the door frame already shows on the new side —
+  // creating the "Kodi went through a door and came out on the
+  // other side of the info text" effect the user asked for.
+  const panelSide: "row" | "row-reverse" =
+    frame?.side === "right" ? "row-reverse" : "row";
+
   return (
     <Box
-      flexDirection="row"
+      flexDirection={panelSide}
       borderStyle="round"
       borderColor={theme.dimmed}
       paddingX={1}
@@ -781,7 +876,9 @@ export default function KodiCompanion({
       <Box flexDirection="column" width={15 + 6}>
         {lines.map((line, i) => (
           <Text key={i} color={moodColor}>
-            {" ".repeat(Math.max(0, walkPosition + 3))}
+            {frame?.inDoor
+              ? ""
+              : " ".repeat(Math.max(0, walkPosition + 3))}
             {line}
           </Text>
         ))}

--- a/src/ui/kodi-animation.test.ts
+++ b/src/ui/kodi-animation.test.ts
@@ -378,6 +378,61 @@ describe("KodiAnimEngine — tier flourishes", () => {
   });
 });
 
+// ─── Door teleport ──────────────────────────────────────────────
+
+describe("KodiAnimEngine — door teleport", () => {
+  test("default side is left, not in door", () => {
+    const frame = new KodiAnimEngine().tick(0);
+    expect(frame.side).toBe("left");
+    expect(frame.inDoor).toBe(false);
+  });
+
+  test("teleportThroughDoor flips side at halfway", () => {
+    const engine = new KodiAnimEngine();
+    expect(engine.side).toBe("left");
+    engine.teleportThroughDoor();
+    // Shortly after: still left, in door
+    advance(engine, 500);
+    expect(engine.tick(0).inDoor).toBe(true);
+    expect(engine.side).toBe("left");
+    // Past halfway: side flipped, still in door
+    advance(engine, 400);
+    expect(engine.side).toBe("right");
+    expect(engine.tick(0).inDoor).toBe(true);
+    // After full 1500ms: out of door, right side
+    advance(engine, 800);
+    expect(engine.tick(0).inDoor).toBe(false);
+    expect(engine.side).toBe("right");
+  });
+
+  test("double teleport is a no-op when one is already running", () => {
+    const engine = new KodiAnimEngine();
+    engine.teleportThroughDoor();
+    advance(engine, 100);
+    const sideAtStart = engine.side;
+    engine.teleportThroughDoor(); // should be ignored
+    advance(engine, 2000);
+    // Exactly one flip happened.
+    expect(engine.side).not.toBe(sideAtStart);
+  });
+
+  test("door frame has uniform width across all 5 lines", () => {
+    const engine = new KodiAnimEngine();
+    engine.teleportThroughDoor();
+    const frame = engine.tick(100);
+    expect(frame.inDoor).toBe(true);
+    const widths = frame.lines.map((l) => [...l].length);
+    expect(new Set(widths).size).toBe(1);
+  });
+
+  test("teleport shows 'poof!' bubble", () => {
+    const engine = new KodiAnimEngine();
+    engine.teleportThroughDoor();
+    const frame = engine.tick(50);
+    expect(frame.bubble).toBe("poof!");
+  });
+});
+
 // ─── Determinism ────────────────────────────────────────────────
 
 describe("KodiAnimEngine — determinism", () => {

--- a/src/ui/kodi-animation.ts
+++ b/src/ui/kodi-animation.ts
@@ -96,7 +96,24 @@ export interface KodiAnimState {
   tier: KodiTier;
   /** The 1-char tier badge for this frame (cycles). Empty string on free. */
   tierBadge: string;
+  /** Which side of the info panel Kodi is on. Flips via teleport. */
+  side: "left" | "right";
+  /** True during a door teleport; renderer uses to suppress walk offset. */
+  inDoor: boolean;
 }
+
+/**
+ * Door frame — rendered during a teleport. Keeps the 14-char
+ * LINE_WIDTH so the rest of the layout doesn't reflow mid-animation.
+ * Small Kodi face peeking out of the door.
+ */
+const DOOR_FRAME: [string, string, string, string, string] = [
+  " ╔═══════╗   ",
+  " ║ ^. .^ ║   ",
+  " ║       ║   ",
+  " ║   o   ║   ",
+  " ╚═══════╝   ",
+];
 
 // ─── Fixed-Width Helpers ────────────────────────────────────────
 
@@ -522,10 +539,41 @@ export class KodiAnimEngine {
   // for the whole session. Default "focused" stays out of the way.
   personality: KodiPersonality = "focused";
 
+  // Panel side — "left" is the normal position (sprite left, info
+  // right). "right" flips via flexDirection=row-reverse so Kodi
+  // appears on the OTHER side of the info text. Autonomy can flip
+  // this via teleportThroughDoor() for a playful "tamagotchi left
+  // the room" moment.
+  side: "left" | "right" = "left";
+
+  // Door animation timer. When >0, the tick() output swaps the
+  // normal sprite for a door frame, disables breathing / blink /
+  // frame-cycling, and flips `side` the moment it hits zero.
+  private doorTimer = 0;
+  private doorFlipped = false;
+
   /** Advance engine by deltaMs. Pure — no setTimeout, no Date.now(). */
   tick(deltaMs: number): KodiAnimState {
     this.tickCount++;
     const rhythm = this.getEffectiveRhythm();
+
+    // ── Door teleport ──
+    // When doorTimer is active, Kodi is "in the door". At the
+    // halfway point we flip side so the second half of the animation
+    // already renders from the new side. At zero we finalize.
+    if (this.doorTimer > 0) {
+      this.doorTimer -= deltaMs;
+      if (!this.doorFlipped && this.doorTimer <= 750) {
+        this.side = this.side === "left" ? "right" : "left";
+        this.doorFlipped = true;
+      }
+      if (this.doorTimer <= 0) {
+        this.doorTimer = 0;
+        this.doorFlipped = false;
+      }
+      // Short-circuit: return the door frame directly; other timers
+      // are still decremented below by falling through.
+    }
 
     // ── Phase timer ──
     if (this.phaseTimer !== Infinity) {
@@ -634,16 +682,38 @@ export class KodiAnimEngine {
     const badgeVariants = TIER_BADGES[this.tier];
     const tierBadge = badgeVariants[this.frameIndex % badgeVariants.length] ?? "";
 
+    // During a door teleport, swap the composed body lines for the
+    // door frame. Everything else (mood / tier badge / bubble) keeps
+    // its own semantics — the door is purely visual.
+    const inDoor = this.doorTimer > 0;
+    const finalLines = inDoor ? [...DOOR_FRAME] : lines;
+
     return {
       mood: displayMood,
       phase: this.transitioning ? "anticipation" : this.phase,
-      lines,
+      lines: finalLines as [string, string, string, string, string],
       bubble: this.bubble,
       moodColor: displayMood,
       intensity: this.intensity,
       tier: this.tier,
       tierBadge,
+      side: this.side,
+      inDoor,
     };
+  }
+
+  /**
+   * Trigger a door teleport. Kodi freezes into the door frame for
+   * 1.5s, flips to the other side of the info panel at the halfway
+   * mark (so the second half of the animation already renders from
+   * the new side), and emerges. Useful for autonomy ("open a door
+   * and appear on the other side of the info text").
+   */
+  teleportThroughDoor(): void {
+    if (this.doorTimer > 0) return; // already mid-teleport
+    this.doorTimer = 1500;
+    this.doorFlipped = false;
+    this.say("poof!", 1500);
   }
 
   // ── Phase Machine ──

--- a/src/ui/kodi-autonomy.ts
+++ b/src/ui/kodi-autonomy.ts
@@ -365,7 +365,11 @@ export async function renderObservation(obs: KodiObservation): Promise<string> {
   if (
     !advice ||
     typeof advice !== "string" ||
-    /\b(consider|maybe|should|recommended?|ensure|might want to|try to)\b/i.test(advice)
+    // Hedge words: generic-advice leak
+    /\b(consider|maybe|should|recommended?|ensure|might want to|try to)\b/i.test(advice) ||
+    // Meta-chatter: assistant-persona leak ("please provide more
+    // context", "let me know if you'd like me to help", etc.)
+    /\b(please (?:provide|clarify|specify|share)|i don'?t have (?:enough|any|sufficient)|could you (?:clarify|specify|provide)|i (?:can|would) (?:help|assist|be happy)|more (?:context|information|details) (?:or|please|would)|specific question|feel free to|let me know)\b/i.test(advice)
   ) {
     return obs.detail;
   }
@@ -394,6 +398,54 @@ const PERSONALITY_SYSTEM = `You are Kodi's brain. Pick ONE personality for this 
 Output: {"personality": "..."}.
 Options: sarcastic, hyped, tired, curious, focused, mischievous.
 Mix it up — don't always pick the same one.`;
+
+// ─── Musings — passing thoughts ────────────────────────────────
+
+const MUSING_SCHEMA = {
+  name: "kodi_musing",
+  strict: true,
+  schema: {
+    type: "object",
+    additionalProperties: false,
+    required: ["thought"],
+    properties: {
+      thought: { type: "string", maxLength: 60 },
+    },
+  },
+};
+
+const MUSING_SYSTEM = `You are Kodi, a tiny terminal mascot having an idle thought while a developer codes. Output {"thought": "..."}.
+The thought should be ≤50 chars, first-person, a bit weird, curious, or philosophical. A thought bubble, not advice.
+Examples of good thoughts: "wonder what tabs vs spaces tastes like", "is main.ts lonely?", "what if functions had feelings".
+PROHIBITED: "consider", "maybe", "should", "you", "I can help", "let me know", meta-chatter about the user or the task.`;
+
+/**
+ * Ask the advisor for a passing thought. Not tied to any event —
+ * this fires on a slow timer so Kodi periodically "thinks" out loud.
+ * Returns null if unreachable or filtered out.
+ */
+export async function askForMusing(
+  personality: KodiPersonality,
+): Promise<string | null> {
+  const raw = await callKodi(
+    MUSING_SYSTEM,
+    `Personality: ${personality}. Have a passing thought.`,
+    MUSING_SCHEMA,
+    30,
+  );
+  const parsed = tryParseJson<{ thought?: string }>(raw);
+  const thought = parsed?.thought;
+  if (
+    !thought ||
+    typeof thought !== "string" ||
+    !thought.trim() ||
+    // Strip meta-chatter / assistant-persona leakage from thoughts
+    /\b(consider|maybe|should|you|please|let me know|feel free|provide)\b/i.test(thought)
+  ) {
+    return null;
+  }
+  return thought.trim().slice(0, 50);
+}
 
 /** Ask the LLM to pick a personality for the session. Falls back to
  * a random pick if the server is unreachable. Safe to await early in


### PR DESCRIPTION
## Summary

User wanted Kodi to feel like an "intelligent tamagotchi" — walking and thinking on its own, opening a door and appearing on the other side of the info text. Also caught a bug: the advice line was showing assistant-persona leakage ("Please provide more context or a specific question...").

## 1. Fluff filter — meta-chatter patterns

The existing filter caught hedges but not assistant-persona leakage. Live reproducer surfaced: advice line read "Please provide more context or a specific question for me to assist with." That's chatbot reflex, not an observation.

Added 8 patterns matching the 1.5B's fallback patterns:
- \`please (provide|clarify|specify|share)\`
- \`i don't have (enough|any|sufficient)\`
- \`could you (clarify|specify|provide)\`
- \`i (can|would) (help|assist|be happy)\`
- \`more (context|information|details) (or|please|would)\`
- \`specific question\`, \`feel free to\`, \`let me know\`

Applied to both \`Kodi.tsx\` (advice) and \`kodi-autonomy.ts\` (observations).

## 2. Door teleport

Engine: new \`side: "left"|"right"\`, \`doorTimer\`, \`teleportThroughDoor()\`.

Animation (1500ms total):
1. Sprite swaps for 5-line \`DOOR_FRAME\` (ASCII door with peeking face)
2. At 750ms: side flips — second half already renders from new side
3. Bubble: "poof!"

Render in \`Kodi.tsx\` uses \`flexDirection: "row" | "row-reverse"\`. Yoga handles the swap natively — no manual position math. This is exactly the "Kodi stepped through a door and appeared on the other side of the info text" effect requested.

Autonomy fires teleport every **5-8 min** (randomized, no LLM call needed).

## 3. Musings

Every **3-5 min** of idle, Kodi asks the advisor for a passing thought via strict schema (\`{thought: ≤60 chars}\`).

Prompt primed with examples so the 1.5B produces thoughts not advice:

> "wonder what tabs vs spaces tastes like"
> "is main.ts lonely?"
> "what if functions had feelings"

Live tested against Qwen 2.5 Coder 1.5B abliterated (curious personality):

> "why is the sky blue?"
> "what if I could see the world from a different perspective?"
> "what's happening in the universe?"

Latency 225-1100ms. When musing passes filter, engine goes to \`thinking\` mood with the thought as bubble for 5.5s.

## Timeline visualization

```
t=0                               t=3-5min              t=5-8min        t=6-10min
 │                                  │                     │                 │
 │  [Kodi walks left-right]         │                     │                 │
 │  [Events fire reactions]         │                     │                 │
 │                                  │                     │                 │
 │                             💭 "why is the sky      🚪 teleport!    💭 "what if
 │                                 blue?"                 poof!             tabs..."
 │                                                        │
 │                                                   [Kodi now on
 │                                                    RIGHT side of
 │                                                    info panel]
```

## Tests
- [x] 5 new door-teleport tests (side bounds, halfway flip, idempotency, width, bubble)
- [x] 51 total engine + autonomy tests passing
- [x] 481/481 UI tests

Co-Authored-By: Kulvex Code <contact@astrolexis.space>