### PR TITLE
feat(phase-4): SARIF output + GitHub Action — enterprise pipeline entry + v2.10.120

### DIFF
--- a/.github/workflows/kcode-self-audit.yml
+++ b/.github/workflows/kcode-self-audit.yml
@@ -1,0 +1,38 @@
+# KCode — Self Audit
+#
+# Runs KCode's own audit engine against this repository every push
+# to main + every PR. Dog-fooding proves the tool works on real
+# TypeScript / Bun code, and catches regressions in the pattern
+# library before they ship.
+#
+# Uses the local action.yml (./) instead of a pinned tag so changes
+# to the action or the audit engine are tested together.
+
+name: KCode Self Audit
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # required by upload-sarif
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run KCode audit
+        uses: ./
+        with:
+          path: .
+          # Dog-food configuration: skip LLM verification on CI because
+          # the self-audit is a sanity check, not a full audit. If the
+          # static stage passes, the pattern library is consistent.
+          skip-verify: "true"
+          # Still fail the build on critical findings — anything less
+          # and we'd miss real bugs sneaking in.
+          fail-on-severity: "critical"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,145 @@
+# KCode GitHub Action
+#
+# Runs `kcode audit` against the repository and uploads SARIF
+# results to GitHub's code scanning dashboard.
+#
+# Usage in a consumer's workflow:
+#
+#   - uses: AstrolexisAI/KCode@v1
+#     with:
+#       path: .
+#
+# The action installs Bun, pulls KCode from npm (once published)
+# or from git (interim), runs the audit with --sarif, and uploads
+# the result to GitHub via github/codeql-action/upload-sarif.
+#
+# Permissions needed on the caller side:
+#   permissions:
+#     contents: read
+#     security-events: write   # required to upload SARIF
+
+name: "KCode Audit"
+description: "Run KCode's deterministic security audit and upload SARIF to GitHub code scanning."
+author: "Astrolexis"
+
+branding:
+  icon: "shield"
+  color: "blue"
+
+inputs:
+  path:
+    description: "Path to audit (repo root by default)"
+    required: false
+    default: "."
+  model:
+    description: "Override the verification model (default: reads from settings)"
+    required: false
+  api-key:
+    description: "API key for the verification model (if not set, uses env/settings)"
+    required: false
+  skip-verify:
+    description: "Skip LLM verification — static regex stage only. Faster but higher FP rate."
+    required: false
+    default: "false"
+  max-files:
+    description: "Maximum files to scan"
+    required: false
+    default: "500"
+  fail-on-severity:
+    description: "Fail the action if any finding at or above this severity is CONFIRMED (none|low|medium|high|critical)"
+    required: false
+    default: "high"
+
+outputs:
+  sarif-path:
+    description: "Path to the generated .sarif file (relative to GITHUB_WORKSPACE)"
+    value: ${{ steps.run-audit.outputs.sarif-path }}
+  confirmed-findings:
+    description: "Number of CONFIRMED findings produced by the audit"
+    value: ${{ steps.run-audit.outputs.confirmed-findings }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: latest
+
+    - name: Install KCode
+      shell: bash
+      run: |
+        # Source-install from the action's own checkout (tagged releases
+        # ensure the binary matches the action version). Published-to-npm
+        # path is a future option.
+        cd "$GITHUB_ACTION_PATH"
+        bun install --frozen-lockfile
+        bun run build --profile=full
+        echo "$GITHUB_ACTION_PATH/release" >> "$GITHUB_PATH"
+
+    - name: Run audit
+      id: run-audit
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      env:
+        KCODE_API_KEY: ${{ inputs.api-key }}
+        KCODE_MODEL: ${{ inputs.model }}
+      run: |
+        set -o pipefail
+        FLAGS=(--sarif --json --max-files "${{ inputs.max-files }}")
+        if [ "${{ inputs.skip-verify }}" = "true" ]; then
+          FLAGS+=(--skip-verify)
+        fi
+        if [ -n "${{ inputs.model }}" ]; then
+          FLAGS+=(--model "${{ inputs.model }}")
+        fi
+
+        kcode audit . "${FLAGS[@]}" | tee kcode-audit.log
+
+        SARIF_PATH="AUDIT.sarif"
+        if [ ! -f "$SARIF_PATH" ]; then
+          # Fallback: the audit command writes alongside the markdown
+          # output. If --output was not used, the default md is
+          # AUDIT_REPORT.md, so the .sarif is AUDIT_REPORT.sarif.
+          SARIF_PATH="AUDIT_REPORT.sarif"
+        fi
+
+        echo "sarif-path=$SARIF_PATH" >> "$GITHUB_OUTPUT"
+
+        # Parse the JSON companion for the confirmed-findings output.
+        if [ -f "AUDIT_REPORT.json" ]; then
+          CONFIRMED=$(jq -r '.confirmed_findings // 0' AUDIT_REPORT.json)
+          echo "confirmed-findings=$CONFIRMED" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Upload SARIF to GitHub code scanning
+      if: always()
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ steps.run-audit.outputs.sarif-path }}
+        category: kcode
+
+    - name: Enforce fail-on-severity gate
+      if: inputs.fail-on-severity != 'none'
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      run: |
+        THRESHOLD="${{ inputs.fail-on-severity }}"
+        if [ ! -f "AUDIT_REPORT.json" ]; then
+          echo "::warning::AUDIT_REPORT.json not found — skipping gate"
+          exit 0
+        fi
+        # severity ranking: critical(4) > high(3) > medium(2) > low(1)
+        declare -A rank=([critical]=4 [high]=3 [medium]=2 [low]=1)
+        MIN_RANK=${rank[$THRESHOLD]:-3}
+
+        OFFENDERS=$(jq -r --argjson min "$MIN_RANK" '
+          ($._severity_rank // {"critical":4,"high":3,"medium":2,"low":1}) as $r
+          | [.findings[] | select(($r[.severity] // 0) >= $min)] | length
+        ' AUDIT_REPORT.json)
+
+        if [ "$OFFENDERS" -gt 0 ]; then
+          echo "::error::KCode found $OFFENDERS finding(s) at severity '$THRESHOLD' or above."
+          exit 1
+        fi
+        echo "No findings at or above '$THRESHOLD'."

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,0 +1,89 @@
+# KCode GitHub Action
+
+Drop KCode into your repository's CI to get security findings
+uploaded to **GitHub code scanning** on every PR. Results show up
+in the Security tab alongside CodeQL, Dependabot, and anything
+else your org runs.
+
+## Minimum usage
+
+```yaml
+# .github/workflows/kcode.yml
+name: KCode Security Audit
+on: [push, pull_request]
+
+jobs:
+  kcode:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # required to upload SARIF
+    steps:
+      - uses: actions/checkout@v4
+      - uses: AstrolexisAI/KCode@v1
+```
+
+That's it. KCode runs `kcode audit .` with SARIF output, uploads
+the result to GitHub, and fails the build if any **high-severity
+or above** finding is confirmed.
+
+## Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `path` | `.` | Path to audit. Use a subdir for monorepos. |
+| `model` | (settings) | Override the verification model. |
+| `api-key` | (env) | API key for the verification model. Passed via `KCODE_API_KEY`. |
+| `skip-verify` | `false` | Skip LLM verification (regex-only). Faster, higher FP rate. |
+| `max-files` | `500` | Maximum files to scan. |
+| `fail-on-severity` | `high` | Fail the action if ≥1 finding at/above this severity. `none`, `low`, `medium`, `high`, `critical`. |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `sarif-path` | Path to the generated `.sarif` file inside the workspace. |
+| `confirmed-findings` | Integer — number of CONFIRMED findings from the audit. |
+
+## Example: hybrid local + cloud verification
+
+For large repos, use local models for initial verification and
+Anthropic/OpenAI for the hard cases:
+
+```yaml
+- uses: AstrolexisAI/KCode@v1
+  with:
+    model: "mnemo:mark6-31b"
+    api-key: ${{ secrets.KCODE_LOCAL_API_KEY }}
+    fail-on-severity: high
+```
+
+## Example: fail-fast on critical, warn on high
+
+```yaml
+- uses: AstrolexisAI/KCode@v1
+  with:
+    fail-on-severity: critical
+
+- name: Summarize high-severity findings
+  if: always()
+  run: |
+    jq -r '.findings[] | select(.severity == "high") | "⚠ \(.file):\(.line) \(.pattern_id)"' AUDIT_REPORT.json || true
+```
+
+## Enterprise notes
+
+- **SARIF 2.1.0** emitted, consumable by GitHub Advanced Security,
+  Azure DevOps, SonarQube, Snyk.
+- **Partial fingerprints** included per finding, so GitHub
+  deduplicates across commits and tracks fix/regression automatically.
+- **CWE mapping** present as `properties.cwe` on each rule, so the
+  security dashboard groups findings by weakness class.
+- **Rule help URIs** point to the canonical CWE definition page.
+
+## What about self-hosted runners?
+
+The action uses `oven-sh/setup-bun@v2`, so any runner with outbound
+internet + the standard Ubuntu toolchain works. For air-gapped
+environments, vendor the action + set `api-key` / model overrides
+to point at an internal inference endpoint.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.119",
+  "version": "2.10.120",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -40,6 +40,11 @@ export function registerAuditCommand(program: Command): void {
     .option("--max-files <n>", "Max files to scan (default 500)", "500")
     .option("--skip-verify", "Skip model verification (static-only output)", false)
     .option("--json", "Also write AUDIT_REPORT.json alongside the markdown", false)
+    .option(
+      "--sarif",
+      "Also write AUDIT.sarif (SARIF v2.1.0, for GitHub Advanced Security / Azure DevOps / SonarQube)",
+      false,
+    )
     .action(async (path: string, opts: {
       output?: string;
       model?: string;
@@ -51,6 +56,7 @@ export function registerAuditCommand(program: Command): void {
       maxFiles: string;
       skipVerify: boolean;
       json: boolean;
+      sarif: boolean;
     }) => {
       const projectRoot = pathResolve(path);
       const outputPath = opts.output ?? pathResolve(projectRoot, "AUDIT_REPORT.md");
@@ -139,6 +145,18 @@ export function registerAuditCommand(program: Command): void {
         const jsonPath = outputPath.replace(/\.md$/, ".json");
         writeFileSync(jsonPath, JSON.stringify(result, null, 2));
         console.log(`${ICONS.phase} JSON data:     ${jsonPath}`);
+      }
+
+      if (opts.sarif) {
+        const { buildSarif } = await import("../../core/audit-engine/sarif-exporter");
+        const { version } = await import("../../../package.json");
+        const sarifDoc = buildSarif(result, {
+          toolVersion: String(version),
+          projectRoot,
+        });
+        const sarifPath = outputPath.replace(/\.md$/, ".sarif");
+        writeFileSync(sarifPath, JSON.stringify(sarifDoc, null, 2));
+        console.log(`${ICONS.phase} SARIF report:  ${sarifPath}`);
       }
 
       console.log("");

--- a/src/core/audit-engine/sarif-exporter.test.ts
+++ b/src/core/audit-engine/sarif-exporter.test.ts
@@ -1,0 +1,242 @@
+// SARIF exporter tests — schema-conformance + KCode→SARIF mapping.
+//
+// These tests pin the contract that enterprise consumers depend on
+// (GitHub code scanning, Azure DevOps, SonarQube). A regression here
+// breaks external pipelines silently, so we assert the exact fields
+// consumers query rather than just a rough shape.
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildSarif,
+  fingerprintFinding,
+  relativize,
+  scoreFromSeverity,
+  severityToSarif,
+} from "./sarif-exporter";
+import type { AuditResult, Finding } from "./types";
+
+// ─── Fixtures ────────────────────────────────────────────────────
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    pattern_id: "py-001-eval-exec",
+    pattern_title: "eval()/exec() with potentially untrusted input",
+    severity: "critical",
+    file: "/home/user/proj/src/handler.py",
+    line: 42,
+    matched_text: "eval(user_input)",
+    context: "40: def run(user_input):\n41:   # returns result\n42:   return eval(user_input)",
+    verification: {
+      verdict: "confirmed",
+      reasoning: "user_input reaches eval directly with no sanitization.",
+      suggested_fix: "Use ast.literal_eval or a proper expression parser.",
+    },
+    cwe: "CWE-94",
+    ...overrides,
+  };
+}
+
+function makeAudit(findings: Finding[]): AuditResult {
+  return {
+    project: "/home/user/proj",
+    timestamp: "2026-04-17T12:00:00Z",
+    languages_detected: ["python"],
+    files_scanned: 42,
+    candidates_found: 10,
+    confirmed_findings: findings.length,
+    false_positives: 7,
+    findings,
+  } as AuditResult;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+describe("severityToSarif", () => {
+  test("critical and high both become error (blocks merge)", () => {
+    expect(severityToSarif("critical")).toBe("error");
+    expect(severityToSarif("high")).toBe("error");
+  });
+
+  test("medium is warning, low is note", () => {
+    expect(severityToSarif("medium")).toBe("warning");
+    expect(severityToSarif("low")).toBe("note");
+  });
+});
+
+describe("scoreFromSeverity", () => {
+  test("produces CVSS-ish numbers that preserve ordering", () => {
+    const c = parseFloat(scoreFromSeverity("critical"));
+    const h = parseFloat(scoreFromSeverity("high"));
+    const m = parseFloat(scoreFromSeverity("medium"));
+    const l = parseFloat(scoreFromSeverity("low"));
+    expect(c).toBeGreaterThan(h);
+    expect(h).toBeGreaterThan(m);
+    expect(m).toBeGreaterThan(l);
+    expect(c).toBeLessThanOrEqual(10);
+    expect(l).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("fingerprintFinding", () => {
+  test("is deterministic for identical findings", () => {
+    const a = makeFinding();
+    const b = makeFinding();
+    expect(fingerprintFinding(a)).toBe(fingerprintFinding(b));
+  });
+
+  test("changes when pattern_id changes", () => {
+    const a = makeFinding();
+    const b = makeFinding({ pattern_id: "py-003-pickle-deserialize" });
+    expect(fingerprintFinding(a)).not.toBe(fingerprintFinding(b));
+  });
+
+  test("changes when file changes", () => {
+    const a = makeFinding();
+    const b = makeFinding({ file: "/home/user/proj/src/other.py" });
+    expect(fingerprintFinding(a)).not.toBe(fingerprintFinding(b));
+  });
+
+  test("changes when line number changes", () => {
+    const a = makeFinding();
+    const b = makeFinding({ line: 43 });
+    expect(fingerprintFinding(a)).not.toBe(fingerprintFinding(b));
+  });
+
+  test("is 32 hex chars (truncated sha256)", () => {
+    expect(fingerprintFinding(makeFinding())).toMatch(/^[0-9a-f]{32}$/);
+  });
+});
+
+describe("relativize", () => {
+  test("strips project root prefix", () => {
+    expect(relativize("/home/user/proj/src/a.ts", "/home/user/proj")).toBe(
+      "src/a.ts",
+    );
+  });
+
+  test("handles trailing slash on project root", () => {
+    expect(relativize("/home/user/proj/src/a.ts", "/home/user/proj/")).toBe(
+      "src/a.ts",
+    );
+  });
+
+  test("falls back to basename when file is outside project root", () => {
+    expect(relativize("/tmp/somewhere/else.ts", "/home/user/proj")).toBe(
+      "else.ts",
+    );
+  });
+
+  test("normalizes Windows backslashes to forward slashes", () => {
+    expect(
+      relativize("C:\\Users\\u\\proj\\src\\a.ts", "C:\\Users\\u\\proj"),
+    ).toBe("src/a.ts");
+  });
+});
+
+// ─── Full SARIF document ─────────────────────────────────────────
+
+describe("buildSarif — top-level structure", () => {
+  const audit = makeAudit([makeFinding()]);
+  const doc = buildSarif(audit, {
+    toolVersion: "2.10.119",
+    projectRoot: "/home/user/proj",
+  }) as Record<string, unknown>;
+
+  test("has the required $schema and version", () => {
+    expect(doc.$schema).toContain("sarif-schema-2.1.0");
+    expect(doc.version).toBe("2.1.0");
+  });
+
+  test("has exactly one run", () => {
+    expect(Array.isArray(doc.runs)).toBe(true);
+    expect((doc.runs as unknown[]).length).toBe(1);
+  });
+
+  test("declares KCode as the tool driver", () => {
+    const run = (doc.runs as Array<Record<string, unknown>>)[0]!;
+    const tool = run.tool as Record<string, Record<string, unknown>>;
+    expect(tool.driver.name).toBe("KCode");
+    expect(tool.driver.version).toBe("2.10.119");
+    expect(tool.driver.informationUri).toContain("github.com");
+  });
+
+  test("embeds a rule for every pattern referenced by a finding", () => {
+    const run = (doc.runs as Array<Record<string, unknown>>)[0]!;
+    const driver = (run.tool as { driver: Record<string, unknown> }).driver;
+    const rules = driver.rules as Array<Record<string, unknown>>;
+    expect(rules.length).toBeGreaterThanOrEqual(1);
+    expect(rules.find((r) => r.id === "py-001-eval-exec")).toBeDefined();
+  });
+
+  test("deduplicates rules when multiple findings share a pattern", () => {
+    const sharedAudit = makeAudit([
+      makeFinding({ line: 10 }),
+      makeFinding({ line: 20 }),
+      makeFinding({ line: 30 }),
+    ]);
+    const shared = buildSarif(sharedAudit, {
+      toolVersion: "2.10.119",
+      projectRoot: "/home/user/proj",
+    }) as Record<string, unknown>;
+    const rules = (shared.runs as Array<{ tool: { driver: { rules: unknown[] } } }>)[0]!
+      .tool.driver.rules;
+    // 3 findings → same rule → should only appear once
+    expect(rules.length).toBe(1);
+  });
+});
+
+describe("buildSarif — results", () => {
+  const audit = makeAudit([
+    makeFinding({ line: 10 }),
+    makeFinding({ line: 20, severity: "low", pattern_id: "py-018-re-no-raw-string" }),
+  ]);
+  const doc = buildSarif(audit, {
+    toolVersion: "2.10.119",
+    projectRoot: "/home/user/proj",
+  }) as Record<string, unknown>;
+  const results = (doc.runs as Array<{ results: Array<Record<string, unknown>> }>)[0]!
+    .results;
+
+  test("emits one result per finding", () => {
+    expect(results.length).toBe(2);
+  });
+
+  test("each result references its rule by id", () => {
+    expect(results[0]!.ruleId).toBe("py-001-eval-exec");
+    expect(results[1]!.ruleId).toBe("py-018-re-no-raw-string");
+  });
+
+  test("severity maps correctly per result", () => {
+    expect(results[0]!.level).toBe("error"); // critical → error
+    expect(results[1]!.level).toBe("note"); // low → note
+  });
+
+  test("location uses a project-relative URI", () => {
+    const loc = (results[0]!.locations as Array<{
+      physicalLocation: { artifactLocation: { uri: string } };
+    }>)[0]!;
+    expect(loc.physicalLocation.artifactLocation.uri).toBe("src/handler.py");
+  });
+
+  test("includes partialFingerprints for GitHub dedup", () => {
+    const fp = results[0]!.partialFingerprints as Record<string, string>;
+    expect(fp.primaryLocationLineHash).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  test("message.text includes the verifier reasoning", () => {
+    const msg = results[0]!.message as { text: string };
+    expect(msg.text).toContain("user_input reaches eval");
+  });
+});
+
+describe("buildSarif — empty audit", () => {
+  test("still produces a valid SARIF doc with zero results", () => {
+    const doc = buildSarif(makeAudit([]), {
+      toolVersion: "2.10.119",
+      projectRoot: "/home/user/proj",
+    }) as Record<string, unknown>;
+    const run = (doc.runs as Array<{ results: unknown[]; tool: { driver: { rules: unknown[] } } }>)[0]!;
+    expect(run.results).toEqual([]);
+    expect(run.tool.driver.rules).toEqual([]);
+  });
+});

--- a/src/core/audit-engine/sarif-exporter.ts
+++ b/src/core/audit-engine/sarif-exporter.ts
@@ -1,0 +1,220 @@
+// SARIF v2.1.0 exporter for the audit engine.
+//
+// SARIF (Static Analysis Results Interchange Format, OASIS standard)
+// is the canonical format for security-scanner output in enterprise
+// pipelines. GitHub Advanced Security / Azure DevOps / SonarQube /
+// Snyk all speak it. Emitting SARIF is the single-biggest unlock
+// for KCode's enterprise adoption — without it, a CISO doing a
+// pipeline eval can't plug KCode into their existing workflow.
+//
+// Spec: https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html
+// Schema: https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json
+
+import { createHash } from "node:crypto";
+import type { AuditResult, Finding, Severity } from "./types";
+import { getPatternById } from "./patterns";
+
+const SARIF_SCHEMA =
+  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json";
+const SARIF_VERSION = "2.1.0";
+
+/** SARIF severity levels. Tool output maps KCode severities below. */
+type SarifLevel = "error" | "warning" | "note" | "none";
+
+/**
+ * Map KCode's 4-level severity to SARIF's 3-level. Critical + high
+ * both become "error" because SARIF has no equivalent escalation
+ * and enterprise dashboards treat "error" as "block merge". Medium
+ * is "warning" (surface but don't block). Low is "note" (advisory).
+ */
+function severityToSarif(s: Severity): SarifLevel {
+  switch (s) {
+    case "critical":
+    case "high":
+      return "error";
+    case "medium":
+      return "warning";
+    case "low":
+      return "note";
+  }
+}
+
+/**
+ * Stable, content-addressable fingerprint for a finding. GitHub and
+ * other SARIF consumers use fingerprints to deduplicate findings
+ * across commits ("this is the same bug we saw on main") and to
+ * track fix/regression. Must be deterministic across identical
+ * findings, stable across unrelated code movement, unique per
+ * pattern+file+match-line.
+ */
+function fingerprintFinding(f: Finding): string {
+  const material = [f.pattern_id, f.file, f.line, f.matched_text.trim()].join(
+    "\x1f",
+  );
+  return createHash("sha256").update(material).digest("hex").slice(0, 32);
+}
+
+/**
+ * Build the SARIF `rules` array — one entry per pattern referenced
+ * by at least one finding. Each rule has a stable id, a short and
+ * full description, the CWE (if any), and the recommended severity.
+ */
+function buildRules(findings: Finding[]): unknown[] {
+  const patternIds = new Set(findings.map((f) => f.pattern_id));
+  const rules: unknown[] = [];
+  for (const id of patternIds) {
+    const pattern = getPatternById(id);
+    if (!pattern) continue;
+    const tags: string[] = ["security"];
+    if (pattern.cwe) tags.push(pattern.cwe);
+    rules.push({
+      id: pattern.id,
+      name: pattern.id.replace(/-/g, "_"),
+      shortDescription: { text: pattern.title },
+      fullDescription: { text: pattern.explanation },
+      defaultConfiguration: { level: severityToSarif(pattern.severity) },
+      helpUri: pattern.cwe
+        ? `https://cwe.mitre.org/data/definitions/${pattern.cwe.replace(/^CWE-/, "")}.html`
+        : undefined,
+      help: {
+        text: pattern.fix_template,
+        markdown: `**Fix:** ${pattern.fix_template}`,
+      },
+      properties: {
+        tags,
+        ...(pattern.cwe ? { cwe: pattern.cwe } : {}),
+        "security-severity": scoreFromSeverity(pattern.severity),
+      },
+    });
+  }
+  return rules;
+}
+
+/**
+ * CVSS-ish score (0-10) so GitHub's "security-severity" filter can
+ * rank findings. SARIF doesn't prescribe a formula — we pick
+ * numbers that bucket cleanly for GitHub code scanning alerts.
+ */
+function scoreFromSeverity(s: Severity): string {
+  switch (s) {
+    case "critical":
+      return "9.0";
+    case "high":
+      return "7.5";
+    case "medium":
+      return "5.0";
+    case "low":
+      return "3.0";
+  }
+}
+
+/**
+ * Convert a single finding to SARIF result format. Uses the finding's
+ * file path as a relative URI; enterprise consumers expect project-
+ * relative paths for their "open in editor" links to work.
+ */
+function buildResult(
+  finding: Finding,
+  projectRoot: string,
+): unknown {
+  const relPath = relativize(finding.file, projectRoot);
+  const reasoning = finding.verification.reasoning
+    ? `\n\nVerifier: ${finding.verification.reasoning}`
+    : "";
+  const fix = finding.verification.suggested_fix
+    ? `\n\nSuggested fix: ${finding.verification.suggested_fix}`
+    : "";
+  return {
+    ruleId: finding.pattern_id,
+    level: severityToSarif(finding.severity),
+    message: {
+      text: `${finding.pattern_title}${reasoning}${fix}`,
+    },
+    locations: [
+      {
+        physicalLocation: {
+          artifactLocation: { uri: relPath },
+          region: {
+            startLine: finding.line,
+            snippet: { text: finding.matched_text.slice(0, 200) },
+          },
+        },
+      },
+    ],
+    partialFingerprints: {
+      primaryLocationLineHash: fingerprintFinding(finding),
+    },
+  };
+}
+
+function relativize(filePath: string, projectRoot: string): string {
+  // Normalize both to forward slashes (SARIF URIs are always forward-slash).
+  const normalizedRoot = projectRoot.replace(/\\/g, "/").replace(/\/$/, "");
+  const normalizedFile = filePath.replace(/\\/g, "/");
+  if (normalizedFile.startsWith(normalizedRoot + "/")) {
+    return normalizedFile.slice(normalizedRoot.length + 1);
+  }
+  // Absolute path that doesn't live under the project root — fall
+  // back to the basename so enterprise consumers don't choke on
+  // invalid relative URIs.
+  return normalizedFile.split("/").at(-1) ?? normalizedFile;
+}
+
+export interface BuildSarifOptions {
+  /** KCode version string to embed under tool.driver.version. */
+  toolVersion: string;
+  /** Absolute path to the project root so result URIs can be made relative. */
+  projectRoot: string;
+}
+
+/**
+ * Convert an AuditResult into a SARIF v2.1.0 document. The output
+ * is JSON-serializable with JSON.stringify — no dates, no functions,
+ * no circular refs — so callers can write it with Bun.write(path,
+ * JSON.stringify(sarif, null, 2)) and be done.
+ */
+export function buildSarif(
+  audit: AuditResult,
+  opts: BuildSarifOptions,
+): unknown {
+  return {
+    $schema: SARIF_SCHEMA,
+    version: SARIF_VERSION,
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: "KCode",
+            version: opts.toolVersion,
+            informationUri: "https://github.com/AstrolexisAI/KCode",
+            semanticVersion: opts.toolVersion,
+            rules: buildRules(audit.findings),
+          },
+        },
+        invocations: [
+          {
+            executionSuccessful: true,
+            endTimeUtc: audit.timestamp,
+          },
+        ],
+        results: audit.findings.map((f) => buildResult(f, opts.projectRoot)),
+        // SARIF-specific column: language hints used by consumers to
+        // default which rule packs apply to which files.
+        properties: {
+          languagesDetected: audit.languages_detected,
+          filesScanned: audit.files_scanned,
+          candidatesFound: audit.candidates_found,
+          falsePositives: audit.false_positives,
+        },
+      },
+    ],
+  };
+}
+
+export {
+  // Re-exports for unit testing the helpers directly.
+  severityToSarif,
+  scoreFromSeverity,
+  fingerprintFinding,
+  relativize,
+};


### PR DESCRIPTION
## Summary

Phase 4 of the enterprise-maturity refactor: the **single-biggest commercial unlock**. SARIF v2.1.0 output + a GitHub Action that drops KCode into any CI in 7 lines of YAML.

## Why this matters

Enterprise security pipelines speak SARIF. GitHub Advanced Security, Azure DevOps, SonarQube, Snyk — all consume the same format. Without SARIF, KCode could never plug into those pipelines. With this PR, a CISO can evaluate KCode against their existing dashboards in ~5 minutes.

## Consumer workflow (the whole pitch)

\`\`\`yaml
# .github/workflows/kcode.yml
name: Security Audit
on: [push, pull_request]
jobs:
  kcode:
    runs-on: ubuntu-latest
    permissions:
      contents: read
      security-events: write
    steps:
      - uses: actions/checkout@v4
      - uses: AstrolexisAI/KCode@v1
\`\`\`

That's it. Findings land in the **Security tab** alongside CodeQL, Dependabot, and everything else their org runs.

## What's in the PR

### 1. SARIF exporter (\`src/core/audit-engine/sarif-exporter.ts\`)

Spec-conformant SARIF 2.1.0 emission:
- **Rules**: one per pattern referenced, with id, title, explanation, CWE helpUri, severity config, CVSS-ish security-severity score
- **Results**: one per finding, with project-relative \`artifactLocation\`, matched snippet, verifier reasoning embedded
- **Fingerprints**: stable per-finding SHA-256 hash for GitHub dedup and fix/regression tracking

Severity mapping:
| KCode | SARIF level | Security score |
|-------|-------------|----------------|
| critical | error | 9.0 |
| high | error | 7.5 |
| medium | warning | 5.0 |
| low | note | 3.0 |

### 2. CLI flag

\`\`\`bash
kcode audit . --sarif --skip-verify
# → AUDIT_REPORT.md + AUDIT_REPORT.sarif
\`\`\`

### 3. GitHub Action (\`action.yml\`)

Composite action with 5 inputs (path, model, api-key, skip-verify, max-files, fail-on-severity) and 2 outputs (sarif-path, confirmed-findings). Handles Bun install, KCode build, audit run, SARIF upload, and severity gate enforcement.

### 4. Self-audit workflow (\`.github/workflows/kcode-self-audit.yml\`)

KCode dog-feeds itself on every push/PR. Catches pattern-library regressions + proves the action works on real TypeScript.

### 5. Documentation (\`docs/github-action.md\`)

Full inputs/outputs reference, two example workflows (basic + hybrid local/cloud), enterprise notes, self-hosted runner guidance.

## Tests

- [x] **24 new tests** in sarif-exporter.test.ts (severity mapping, fingerprint determinism, relativize edge cases, top-level doc structure, rule dedup, result shape, empty audit)
- [x] All pattern-fixture harness tests still pass (53/53 with the new batch)
- [x] Binary 2.10.120 installed

## Enterprise-adoption checklist

After this PR, KCode has:
- ✅ SARIF 2.1.0 output (CISO dashboard-ready)
- ✅ GitHub Action (5-minute trial)
- ✅ Pattern regression harness (Phase 3)
- ✅ Pruned dead code (Phase 1)
- ⏳ Dual-license decision (Phase 5 — legal, not code)
- ⏳ CHANGELOG + semver discipline (next PR)

Co-Authored-By: Kulvex Code <contact@astrolexis.space>