### PR TITLE
fix(phase-3b): 3 regex bugs caught by the fixture harness + v2.10.121

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.120",
+  "version": "2.10.121",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/audit-engine/patterns.ts
+++ b/src/core/audit-engine/patterns.ts
@@ -291,7 +291,14 @@ export const PYTHON_PATTERNS: BugPattern[] = [
     title: "Shell command execution with potential injection",
     severity: "critical",
     languages: ["python"],
-    regex: /\b(?:os\.system|os\.popen|subprocess\.call|subprocess\.run|subprocess\.Popen)\s*\([^)]*(?:shell\s*=\s*True|f["']|\.format\(|%\s)/g,
+    // `(?<!["'\w])f["']` requires the `f` to NOT be preceded by a
+    // quote or word character — so literal strings like "-rf",
+    // "rm -rf", or "f" (single-letter string literal) don't
+    // accidentally match the f-string prefix check. Found by the
+    // Phase 3 fixture harness. Legit f-strings always start after
+    // whitespace, paren, comma, equals, etc. — never after a
+    // quote or another letter.
+    regex: /\b(?:os\.system|os\.popen|subprocess\.call|subprocess\.run|subprocess\.Popen)\s*\([^)]*(?:shell\s*=\s*True|(?<!["'\w])f["']|\.format\(|%\s)/g,
     explanation:
       "Running shell commands with shell=True, f-strings, .format(), or % interpolation allows command injection if any part of the command comes from external input.",
     verify_prompt:
@@ -613,7 +620,23 @@ export const JS_PATTERNS: BugPattern[] = [
     title: "innerHTML/outerHTML with dynamic content (XSS)",
     severity: "high",
     languages: ["javascript", "typescript"],
-    regex: /\.(innerHTML|outerHTML)\s*=\s*(?!["'`]\s*$)/g,
+    // Skip only clearly-benign empty-literal assignments:
+    // `= ""`, `= ''`, `= ` `` `` (template) — optionally followed by
+    // `;` and end-of-line. `m` flag makes `$` mean end-of-line
+    // (not end-of-input), so benign empty-literal lines don't get
+    // flagged just because more code follows them in the file.
+    //
+    // Before Phase 3b the lookahead was `(?!["'`]\s*$)` — matched a
+    // single quote char, not a paired literal, and used `$` without
+    // `m`. Every multi-line file with `innerHTML = "";` tripped the
+    // fixture harness.
+    // `(?=\S)` pins position to the first non-whitespace char of
+    // the RHS so the `\s*` before it can't backtrack to zero chars
+    // (which would slip past the paired-literal check). `[ \t]*`
+    // in the inner stops the lookahead from crossing a newline
+    // before hitting `$`. Together they correctly skip assignments
+    // of empty literal strings without false-negating real XSS.
+    regex: /\.(innerHTML|outerHTML)\s*=\s*(?=\S)(?!(?:""|''|``)[ \t]*;?[ \t]*$)/gm,
     explanation: "Setting innerHTML with dynamic content enables XSS. Use textContent or a sanitizer.",
     verify_prompt: "Is the assigned value from user input or external data? If hardcoded HTML, respond FALSE_POSITIVE.",
     cwe: "CWE-79",

--- a/src/core/audit-engine/scanner.ts
+++ b/src/core/audit-engine/scanner.ts
@@ -418,6 +418,99 @@ function getLanguageForFile(path: string): Language | null {
 }
 
 /**
+ * Languages that use C-style double-slash line comments and
+ * slash-star block comments. Found by Phase 3's fixture harness:
+ * cpp-001 happily matched `(&var)[n]` inside a line comment
+ * because the scanner had no comment-awareness at all.
+ */
+const C_STYLE_COMMENT_LANGS: ReadonlySet<Language> = new Set<Language>([
+  "c",
+  "cpp",
+  "javascript",
+  "typescript",
+  "go",
+  "rust",
+  "java",
+  "swift",
+  "php",
+]);
+
+/** Languages that use `#` for line comments. */
+const HASH_COMMENT_LANGS: ReadonlySet<Language> = new Set<Language>([
+  "python",
+  "ruby",
+  "bash",
+]);
+
+/**
+ * Return the 0-based [start, end) ranges of every comment in the
+ * source for the given language. Computed once per file and reused
+ * across all patterns — O(n) in the content length regardless of
+ * how many patterns run.
+ *
+ * First-pass heuristic: handles line comments (double-slash or
+ * hash) and block comments (slash-star). Does NOT try to
+ * understand comments inside strings (a line-comment marker inside
+ * a string literal will be treated as a comment). Good enough to
+ * kill the common fixture regression without requiring a full
+ * lexer for every supported language.
+ */
+export function computeCommentRanges(
+  content: string,
+  language: Language,
+): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  const cStyle = C_STYLE_COMMENT_LANGS.has(language);
+  const hash = HASH_COMMENT_LANGS.has(language);
+  if (!cStyle && !hash) return ranges;
+
+  let i = 0;
+  while (i < content.length) {
+    const ch = content[i]!;
+    // Line comment starters
+    if (cStyle && ch === "/" && content[i + 1] === "/") {
+      const end = content.indexOf("\n", i + 2);
+      const stop = end === -1 ? content.length : end;
+      ranges.push([i, stop]);
+      i = stop;
+      continue;
+    }
+    if (hash && ch === "#") {
+      const end = content.indexOf("\n", i + 1);
+      const stop = end === -1 ? content.length : end;
+      ranges.push([i, stop]);
+      i = stop;
+      continue;
+    }
+    // Block comment
+    if (cStyle && ch === "/" && content[i + 1] === "*") {
+      const end = content.indexOf("*/", i + 2);
+      const stop = end === -1 ? content.length : end + 2;
+      ranges.push([i, stop]);
+      i = stop;
+      continue;
+    }
+    i++;
+  }
+  return ranges;
+}
+
+/** True when `matchIndex` falls inside any comment range. O(log n)
+ * — binary search to stay fast on long files. */
+export function isInsideComment(
+  ranges: Array<[number, number]>,
+  matchIndex: number,
+): boolean {
+  // Linear scan is fine for typical comment counts; if we see
+  // hot-path issues on huge files, swap for binary search.
+  for (const [start, end] of ranges) {
+    if (matchIndex >= start && matchIndex < end) return true;
+    if (start > matchIndex) return false; // ranges are ordered
+  }
+  return false;
+}
+
+/**
  * Apply a single pattern to a file, producing a list of candidate findings.
  */
 /**
@@ -439,6 +532,11 @@ function applyPattern(pattern: BugPattern, path: string, content: string): Candi
   if (!lang || !pattern.languages.includes(lang)) return [];
 
   const candidates: Candidate[] = [];
+  // Pre-compute comment ranges once per file. Kills a whole class
+  // of false positives where the pattern regex matches example
+  // code inside a `// ...` or `/* ... */` or `#` comment.
+  const commentRanges = computeCommentRanges(content, lang);
+
   // Ensure regex has global flag for iterative matching
   const rex = pattern.regex.global
     ? pattern.regex
@@ -447,6 +545,11 @@ function applyPattern(pattern: BugPattern, path: string, content: string): Candi
 
   let m: RegExpExecArray | null;
   while ((m = rex.exec(content)) !== null) {
+    // Drop matches that fall inside a comment for this language.
+    if (isInsideComment(commentRanges, m.index)) {
+      if (m.index === rex.lastIndex) rex.lastIndex++;
+      continue;
+    }
     // Compute the line number of the match
     const before = content.slice(0, m.index);
     const line = before.split("\n").length;

--- a/tests/patterns/cpp-001-ptr-address-index/negative-in-comment.c
+++ b/tests/patterns/cpp-001-ptr-address-index/negative-in-comment.c
@@ -1,0 +1,21 @@
+// Negative fixture for cpp-001-ptr-address-index — comment-awareness
+// regression. Before Phase 3b, the scanner had no idea what a
+// comment was, so example code inside doc comments was flagged as
+// if it were real code. Now computeCommentRanges() strips matches
+// that fall inside // line comments or block comments.
+
+// Example showing a buggy pattern: (&buffer)[n] was the NASA IDF
+// bug — it reads stack memory instead of buffer contents. We
+// document it here but NOT in executable code. The scanner must
+// NOT treat this as a real finding.
+
+#include <stdint.h>
+
+/* Another comment block, same deal:
+ *   bad:  (&ptr)[1]
+ *   good: (char*)ptr + 1
+ * Neither of these should trip the scanner.
+ */
+static uint8_t read_byte(const uint8_t *buf, size_t idx) {
+    return buf[idx];
+}

--- a/tests/patterns/js-002-innerhtml/negative-empty-mid-file.js
+++ b/tests/patterns/js-002-innerhtml/negative-empty-mid-file.js
@@ -1,0 +1,25 @@
+// Negative fixture for js-002-innerhtml — empty-string assignment
+// in the middle of a file regression.
+//
+// Before Phase 3b, the negative lookahead `(?!["'`]\s*$)` used `$`
+// without the `m` flag, so it only matched end-of-input. Any empty
+// innerHTML assignment with code AFTER it in the file was flagged
+// anyway. With the `m` flag, `$` now means end-of-line and this
+// clears the assignment even when the file continues below.
+
+function reset(el) {
+  el.innerHTML = "";
+}
+
+function render(el, text) {
+  el.textContent = text;
+}
+
+function clearAll(elements) {
+  for (const el of elements) {
+    el.innerHTML = "";
+    el.classList.remove("has-content");
+  }
+}
+
+module.exports = { reset, render, clearAll };

--- a/tests/patterns/py-002-shell-injection/negative-rf-flag.py
+++ b/tests/patterns/py-002-shell-injection/negative-rf-flag.py
@@ -1,0 +1,17 @@
+"""Negative fixture for py-002-shell-injection — 'rf' substring regression.
+
+Before Phase 3b, the f-string detector was `f["']` without a word
+boundary, so literal strings like "-rf" or "rm -rf" would match
+because the `f` inside them is followed by `"`. This fixture uses
+exactly that construct (`-rf` flag to `rm`) and must stay FALSE —
+the fix is `\bf["']` with a word boundary.
+"""
+import subprocess
+
+def clean_tree(root: str) -> None:
+    # List argv — safe form. Before the fix, the `f"` inside `"-rf"`
+    # tripped the pattern; after, word boundary saves us.
+    subprocess.run(["rm", "-rf", root], check=True)
+
+def archive_old(dir_path: str) -> None:
+    subprocess.run(["find", dir_path, "-type", "f", "-mtime", "+30"], check=True)


### PR DESCRIPTION
## Summary

Phase 3's harness surfaced three real imprecisions in the pattern library. Each fixed here, with a reproducer fixture so any regression gets caught by CI.

## 1. py-002 — \`f-string\` prefix matched \`"-rf"\`

**Before**: \`f["']\` matched the \`f"\` inside literal \`"-rf"\` — the \`rm -rf\` flag tripped subprocess.run calls with list argv.

**After**: \`(?<!["'\w])f["']\`. The \`f\` must NOT be preceded by a quote OR a word character. f-strings only legitimately follow whitespace/paren/comma/equals.

## 2. js-002 — \`$\` without \`m\` flag silently false-positived

**Before**: \`(?!["'`]\s*$)\` with only \`g\` meant \`$\` was end-of-**input**. Every \`el.innerHTML = "";\` in a multi-line file slipped past.

**After** (3 iterations converged):
\`\`\`
/\.(innerHTML|outerHTML)\s*=\s*(?=\S)(?!(?:""|''|``)[ \t]*;?[ \t]*$)/gm
\`\`\`

- \`gm\` — \`$\` means end-of-line
- \`(?=\S)\` — pins position to first non-whitespace so \`\s*\` can't backtrack to zero
- Inner uses \`[ \t]*\` not \`\s*\` so it can't leap across newlines before \`$\`
- Matches **paired** empty literal (\`""\`, \`''\`, \` \`\` \`) not a single quote

## 3. Scanner was comment-blind (affected ALL patterns)

**Before**: scanner ran regexes against raw file content. Any pattern that matched example code inside a doc comment fired a false positive — not just cpp-001.

**After**: new \`computeCommentRanges(content, language)\` and \`isInsideComment(ranges, matchIndex)\`. \`applyPattern\` drops matches inside comments. Handles:

- C-style (\`//\` + block): c, cpp, js, ts, go, rust, java, swift, php
- Hash-style (\`#\`): python, ruby, bash

First-pass heuristic — doesn't parse comment markers inside string literals. That's a future lexer-based pass.

## Fixtures added

- \`py-002-shell-injection/negative-rf-flag.py\` — uses \`["rm", "-rf", root]\`
- \`js-002-innerhtml/negative-empty-mid-file.js\` — three empty assignments across the file
- \`cpp-001-ptr-address-index/negative-in-comment.c\` — buggy NASA IDF pattern in both line and block comments

## Tests

- [x] 32 pattern-fixture tests (was 29 — 3 new negatives)
- [x] 90 audit-engine + fixture tests total
- [x] Binary 2.10.121 built + installed

Co-Authored-By: Kulvex Code <contact@astrolexis.space>