### PR TITLE
docs: retroactive CHANGELOG + semver/fixture contract + v2.10.124

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,215 @@
 # Changelog
 
-All notable changes to KCode are documented here.
+All notable changes to KCode are documented here, following
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+[Semantic Versioning](https://semver.org/).
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Each release entry links to its merged PR so the history is
+navigable from here alone. When reviewing a release, read the
+**Changed** / **Fixed** / **Security** sections first — that's
+where regressions hide.
+
+## [Unreleased]
+
+(Nothing pending.)
+
+## [2.10.123] — 2026-04-17
+
+### Added
+- Pattern fixture harness expanded to **28/257 patterns** (up from
+  18). Ten new critical/high-severity entries spanning Go, Java,
+  C/C++, Python, and JS/TS. [#91]
+
+### Notes
+- Identified percent-placeholder false-positive in
+  `py-004-sql-injection` regex. Negative fixture uses `?`
+  placeholders to dodge the bug — proper Phase 3b-style fix
+  tracked for a future PR.
+
+## [2.10.122] — 2026-04-17
+
+### Added
+- Fixture coverage jumped 7 → 18. First fixture harness coverage
+  for Go (go-001, go-003) and Java (java-001, java-003). [#90]
+
+## [2.10.121] — 2026-04-17
+
+### Fixed (Phase 3b — regex bugs caught by the fixture harness)
+- `py-002-shell-injection`: bare `f["']` matched `"-rf"` substring
+  (the `f"` at end of `"-rf"`). Now `(?<!["'\w])f["']`. [#89]
+- `js-002-innerhtml`: negative lookahead used `$` without `m` flag,
+  so `innerHTML = "";` followed by more code still matched. Now
+  uses `gm`, `(?=\S)` to pin position, and `[ \t]*` instead of
+  `\s*` inside. [#89]
+
+### Added
+- **Scanner comment-awareness**. New `computeCommentRanges()` and
+  `isInsideComment()` helpers filter matches inside `//`, `/*…*/`,
+  and `#` comments. Cross-cutting fix — applies to ALL 257
+  patterns, not just the ones with fixtures. [#89]
+
+## [2.10.120] — 2026-04-17
+
+### Added (Phase 4 — enterprise pipeline entry)
+- **SARIF v2.1.0 output** via `kcode audit --sarif`. Spec-
+  conformant document with rules, results, CVSS-like
+  `security-severity`, CWE helpUri, partialFingerprints for
+  cross-commit dedup. Consumable by GitHub Advanced Security,
+  Azure DevOps, SonarQube, Snyk. [#88]
+- **GitHub Action** at `action.yml`. 7-line drop-in for consumer
+  workflows. Composite action: Bun install → KCode build →
+  `kcode audit --sarif` → upload via `github/codeql-action/
+  upload-sarif@v3` → severity-gate enforcement. [#88]
+- Self-audit workflow on every push/PR to master. [#88]
+- `docs/github-action.md` — full reference with examples.
+
+## [2.10.119] — 2026-04-17
+
+### Added (Phase 3 — pattern fixture harness)
+- `tests/patterns/<pattern-id>/` directory structure with positive
+  + negative fixtures per pattern. `tests/pattern-fixtures.test.ts`
+  asserts the invariants. Pattern library stops degrading silently
+  across refactors. Initial coverage: 7 patterns. [#87]
+- `scanPatternAgainstContent()` exported for test-friendly regex
+  invocation.
+
+## [2.10.118] — 2026-04-17
+
+### Removed (Phase 1 pruning)
+- `mobile/` (997 LOC RN + iOS stubs, single-commit bulk-add with
+  zero iterations, no production path). [#86]
+- `jetbrains-plugin/` and `nvim-kcode/` — duplicates of the
+  canonical `ide/jetbrains/` and `ide/neovim/`. Old kulvex
+  namespace, pre-Astrolexis rebrand. [#86]
+- `src/core/gpu-orchestrator*` — 1,060 LOC, 1 reference (the test
+  itself), 0 production usage. [#86]
+- `src/core/user-model*` — 333 LOC, 3 silent try/catch refs. [#86]
+- `src/core/narrative*` — 453 LOC, 6 silent try/catch refs. [#86]
+- `src/core/plugin-marketplace*` + 5 seed plugin stubs — 427 LOC
+  of unused marketplace client; seed plugins were `.md` skill
+  files with zero implementation. [#86]
+
+### Changed (Phase 1)
+- `/swarm` gated behind `KCODE_EXPERIMENTAL_SWARM=1`. [#86]
+- Web-engine auto-scaffold gated behind
+  `KCODE_EXPERIMENTAL_SCAFFOLD=1`. Fixes today's Python+textual
+  "btctop" mis-fire where a Python prompt produced 17 Next.js
+  files. [#86]
+
+## [2.10.117] — 2026-04-17
+
+### Changed
+- Kodi autonomy refactored **timer-driven → urge-driven**. Three
+  internal urges (boredom, curiosity, wanderlust) build ambiently
+  and drain on activity; Kodi acts when an urge crosses threshold,
+  not on a cron schedule. [#85]
+
+## [2.10.116] — 2026-04-17
+
+### Added
+- Kodi door teleport — appears on the opposite side of the info
+  panel with a 1.5s door-frame animation. [#84]
+- Musings — passing thoughts every 3-5 min of idle. [#84]
+
+### Fixed
+- Advisor fluff filter catches assistant-persona meta-chatter
+  ("please provide more context", "let me know"). [#84]
+
+## [2.10.115] — 2026-04-17
+
+### Fixed
+- Web-engine detector misfire: Python prompts with the word
+  "ticker" or "trading" (even in negation) triggered Next.js
+  scaffolds. Regex now requires compound patterns (`trading X`,
+  `stock ticker`, `portfolio tracker`). New `mentionsNonWebStack`
+  veto shorts the web engine on Python/Rust/Go/CLI/terminal/textual
+  prompts unconditionally. [#83]
+
+## [2.10.114] — 2026-04-17
+
+### Added (Kodi Phase 3)
+- Four autonomy layers: idle actions, walking, observations,
+  personality. Gated on the Kodi advisor server being reachable. [#82]
+
+## [2.10.113] — 2026-04-17
+
+### Fixed
+- `/quit` still slow after v2.10.112. Tier-flex `setTimeout`
+  wasn't cleared on unmount; in-flight advisor fetch had no abort
+  hook. Both clean up explicitly now. [#81]
+
+## [2.10.112] — 2026-04-17
+
+### Fixed
+- `/quit` hang caused by `startKodiServer` child_process pipes
+  keeping Bun's event loop alive even after `child.unref()`. Now
+  uses raw fds passed to `stdio` directly so no parent-side pipes
+  exist. [#80]
+
+## [2.10.111] — 2026-04-17
+
+### Changed
+- Kodi advisor emits **advice-only** (dropped `mood` and `speech`
+  from the schema). Simplified prompt, narrowed scope to the 1.5B
+  model's strongest signal. Added 7-regex fluff filter. [#79]
+
+## [2.10.110] — 2026-04-16
+
+### Added (Kodi Phase 2)
+- Wire dedicated Kodi advisor model (port 10092) into reactions.
+  Structured JSON output parsing, trigger filter on high-info
+  events only, advice line under the bubble. [#78]
+
+## [2.10.109] — 2026-04-16
+
+### Fixed
+- Kodi model download size check was byte-exact. HuggingFace
+  shows decimal GB while files are binary MiB — dropped the
+  check; `llama.cpp` validates GGUF on load anyway. [#77]
+
+## [2.10.108] — 2026-04-16
+
+### Added (Kodi Phase 1)
+- Dedicated abliterated LLM for Kodi — lifecycle (download,
+  start, stop, delete), TUI menu, enterprise first-run prompt.
+  Three candidate models (Qwen 2.5 Coder 1.5B / Qwen 2.5 1.5B /
+  Gemma 3 1B, all abliterated). Server on port 10092, CPU-only
+  by default so it never steals GPU from the main model. [#76]
+
+## [2.10.107] — 2026-04-16
+
+### Changed
+- Inline hints next to the `hookify` proto-pollution guard so the
+  audit verifier LLM doesn't need context from the top of the
+  file. [#75]
+
+## [2.10.106] — 2026-04-16
+
+### Security
+- **Prototype pollution** via `hookify` YAML frontmatter parser.
+  `meta[key] = value` where key was `\w+` allowed `__proto__`,
+  `constructor`, `prototype` to overwrite `Object.prototype`
+  globally. Added `RESERVED_META_KEYS` guard at 3 write sites.
+  7 regression tests added. [#74]
+
+## [2.10.105] — 2026-04-16
+
+### Added
+- Tier-aware Kodi: per-tier badges (★ Pro, ♛ Team, ✦ Enterprise),
+  new `flex` / `dance` / `waving` moods, richer idle cycle, tier
+  entrance flourishes, periodic tier-flex. [#73]
+
+## [2.10.104] — 2026-04-16
+
+### Fixed
+- Astrolexis OAuth endpoints — CLI pointed at
+  `https://astrolexis.space/oauth/*`, backend exposes
+  `/api/oauth/*`. 404 at `/login` step 1. Now aligned. [#72]
+- Phase-33 low-entropy detector wired into the content-stream
+  channel (not just thinking). Catches the grok-code-fast-1 loop
+  in ≤1K tokens vs ~7K pre-fix. [#72]
+
+---
 
 ## [1.8.0] - 2026-04-01
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,63 @@ bun run dev
 bun run src/index.ts
 ```
 
+## Versioning + Changelog contract
+
+KCode follows [Semantic Versioning 2.0.0](https://semver.org/):
+
+- **MAJOR** — incompatible CLI/config breakages, pattern catalog
+  restructuring, public audit-engine / SDK API changes. Rare.
+  Pre-announce in CHANGELOG at least one minor version ahead.
+- **MINOR** — new features, new patterns, new CLI flags,
+  backwards-compatible additions.
+- **PATCH** — bug fixes, pattern-precision improvements, internal
+  refactors with no observable behavior change.
+
+Current phase (2.10.x) is patch-level iteration on the
+enterprise-maturity refactor. Every shipped PR bumps patch.
+
+Versions are single-source-of-truth in `package.json`. The build
+script and CLI both read from there.
+
+### Release checklist (every PR)
+
+1. **Update `CHANGELOG.md`**. Put new entries under `[Unreleased]`,
+   or create a new version header if the PR bumps the version.
+2. **Bump `package.json`** version.
+3. **Test** the appropriate subset:
+   - Pattern catalog edit → `bun test tests/pattern-fixtures.test.ts`
+   - Audit engine core → `bun test src/core/audit-engine/`
+   - UI → `bun test src/ui/`
+   - Full → `bun test src/core/` + `bun test src/ui/`
+4. **Build** via `bun run build`.
+5. **PR body** includes the CHANGELOG entry verbatim so reviewers
+   see user-visible impact without context-switching.
+
+### Changelog style
+
+- Sections in order: **Added**, **Changed**, **Deprecated**,
+  **Removed**, **Fixed**, **Security**.
+- One line per change. Verbose rationale belongs in commit
+  messages, not the changelog.
+- Link each entry to its merged PR `[#NN]`.
+- Entries stay under `[Unreleased]` until a version bump promotes
+  them into a numbered section.
+
+### Pattern catalog changes
+
+Any edit to `src/core/audit-engine/patterns.ts` **must** come with:
+
+- At least one **positive fixture** in
+  `tests/patterns/<pattern-id>/` — code the regex MUST match.
+- At least one **negative fixture** — code the regex MUST NOT
+  match.
+- A fixture-harness run (`bun test tests/pattern-fixtures.test.ts`)
+  proving both invariants.
+
+The harness is the contract that keeps the pattern library from
+silently degrading across refactors. Skipping fixtures for a new
+pattern means the regression-safety net has a hole.
+
 ## Architecture Overview
 
 KCode is a terminal-based AI coding assistant built with Bun, TypeScript, and React/Ink. The codebase is organized as follows:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.123",
+  "version": "2.10.124",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",


### PR DESCRIPTION
20 version entries back-filled (2.10.104..2.10.123, each linked to its PR). CONTRIBUTING.md gains versioning + release + fixture contract. Enterprise audit discipline.