### PR TITLE
docs(phase-2): module classification — core vs auxiliary + v2.10.125

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,10 @@ bash scripts/test-batched.sh 15    # Run tests in batches (avoids OOM on large s
 
 **CLI Flags**: `--model`, `--api-key`, `--api-base`, `--max-turns`, `--no-tools`, `--print`, `--verbose`, `--effort` (low/medium/high), `--system-prompt`, `--append-system-prompt`, `--name`, `--allowed-tools`, `--disallowed-tools`, `--session-id`, `--agent`, `--agents` (multi-agent swarm), `--no-session-persistence`, `--mcp-config`, `--tmux`, `--file`, `--from-pr`.
 
+### Module classification
+
+For the honest map of what's **core product** vs **auxiliary** (RAG, compaction, distillation, voice, world-model, etc.), see `docs/architecture/modules.md`. When editing any of the files listed as "Auxiliary" there, they already carry a header comment confirming status; PRs that promote them into the critical path should update both that comment and the doc.
+
 ### Core Engine (`src/core/`)
 
 - **`conversation.ts`** (~1430 lines) — Main conversation loop orchestrator. Delegates to extracted modules: `conversation-state.ts` (state access, usage tracking), `conversation-message-prep.ts` (budget checks, theoretical/checkpoint mode, RAG/skills injection), `conversation-streaming.ts` (SSE stream processing, tool call extraction), `conversation-post-turn.ts` (empty response retry, truncation, auto-memory, notifications), `conversation-retry.ts` (retry logic), `conversation-checkpoint.ts`, `conversation-session.ts`.

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -1,0 +1,86 @@
+# KCode — Module classification
+
+This document is the honest map of what's **core product** versus
+**auxiliary**. It exists because the codebase is large (~410k
+LOC) and reviewers — whether enterprise evaluators or new
+contributors — need to know where the product actually lives.
+
+The classification is **not** a value judgement. Auxiliary
+modules can still be useful. They're auxiliary because:
+
+- They're not required to run the core audit engine.
+- They can be removed / disabled without breaking the primary
+  value proposition.
+- They serve specialized workflows that a subset of users need.
+
+Core modules, by contrast, are on the critical path: removing any
+of them breaks the product for everyone.
+
+## Core — critical path, always enabled
+
+| Module | Path | Role |
+|--------|------|------|
+| Audit engine | `src/core/audit-engine/` | The product. Patterns, scanner, verifier, report-generator, fixer, exploit-gen, SARIF exporter. |
+| Scanner + patterns | `src/core/audit-engine/patterns.ts`, `scanner.ts` | 257 curated patterns + regex engine + comment-awareness. |
+| Conversation loop | `src/core/conversation.ts` | Orchestrates the LLM turn lifecycle. |
+| Configuration | `src/core/config.ts` | Settings hierarchy + validation. |
+| Permissions | `src/core/permissions*` | Security model + audit log. |
+| System prompt assembly | `src/core/system-prompt.ts` | 10-layer prompt composer. |
+| Tools | `src/tools/` | 46 built-in tools (Read/Write/Edit/Bash/etc.). |
+| CLI router | `src/index.ts`, `src/cli/commands/` | Commander.js entry points. |
+| Daemon / IPC | `src/core/http-server.ts`, bridge/daemon modules | Persistent background mode for IDE integrations. |
+| Backend (reference + Cloudflare) | `backend/`, `~/astrolexis-site/` | OAuth, subscription, /api/subscription. Reference implementation of the SaaS plane. |
+| Enterprise | `src/core/enterprise/` | SSO/SAML, audit export, policy enforcement. |
+| MCP client | `src/core/mcp-client.ts` | Standard interface for external tool integration. |
+
+## Auxiliary — specialized workflows, can be disabled
+
+| Module | Path | Role | Default |
+|--------|------|------|---------|
+| RAG | `src/core/rag/` | Local semantic code search. Useful for agentic dev, not required for audit. | On |
+| Compaction | `src/core/compaction*` | Context-window management strategies. | On |
+| Training / Distillation | `src/core/training/`, `src/core/distillation*` | Fine-tuning + distillation pipelines. | On |
+| Voice | `src/core/voice*` | Speech I/O. Skeletal. | On |
+| Swarm | `src/core/swarm.ts` | Multi-agent parallel execution. | **Off** — `KCODE_EXPERIMENTAL_SWARM=1` to enable |
+| Web-engine scaffold | `src/core/web-engine/` | Next.js/etc. project scaffold from a prompt. | **Off** — `KCODE_EXPERIMENTAL_SCAFFOLD=1` to enable |
+| World-model | `src/core/world-model*` | Predictive user-action model. | On |
+| Kodi mascot | `src/ui/kodi-*`, `src/ui/components/Kodi.tsx` | Animated terminal companion. Purely cosmetic. | On |
+
+## Out-of-core, tracked separately
+
+These live in the repo today but are not part of the core build
+and may move to their own repos in a future phase.
+
+| Module | Path | Future home |
+|--------|------|-------------|
+| SDK Python | `sdk/python/` | `AstrolexisAI/kcode-sdk-python` (separate repo, PyPI) |
+| SDK TypeScript | `sdk/typescript/` | `AstrolexisAI/kcode-sdk-typescript` (separate repo, npm) |
+| VSCode extension | `ide/vscode/` | `AstrolexisAI/kcode-vscode` (separate repo, marketplace) |
+| JetBrains plugin | `ide/jetbrains/` | `AstrolexisAI/kcode-jetbrains` (separate repo, marketplace) |
+| Neovim plugin | `ide/neovim/` | `AstrolexisAI/kcode-neovim` (separate repo, LuaRocks) |
+
+## Disabling auxiliary modules
+
+Each auxiliary module declares its status in a comment block at
+the top of its main file. Users who want to turn one off have
+two options:
+
+1. **Env flag** (when available — `KCODE_EXPERIMENTAL_*`,
+   `KCODE_ENABLE_*`): checked at module load / first-use. No code
+   changes needed in the core.
+2. **Build profile**: `bun run build --profile=core-only`
+   (not yet implemented — tracked in the future enterprise
+   minimal build).
+
+## Why this document exists
+
+During the enterprise-maturity refactor (PRs #86 / #90 / #91 / #92)
+the codebase went from "ambitious monorepo" to "audit engine +
+ecosystem". This doc is the anchor that keeps future PRs from
+quietly promoting an auxiliary feature into the critical path
+without a conscious decision.
+
+**Rule of thumb**: if a PR touches a Core module, the CHANGELOG
+entry should be visible from the top; if it touches Auxiliary, it
+goes under a separate sub-section so enterprise consumers
+reviewing changes can skim for what matters to them.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.124",
+  "version": "2.10.125",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/compaction.ts
+++ b/src/core/compaction.ts
@@ -1,4 +1,10 @@
 // KCode - Conversation Compaction
+//
+// STATUS: Auxiliary (see docs/architecture/modules.md).
+// Context-window management — the audit engine runs shorter
+// turns and doesn't depend on this path. Removable without
+// breaking core audit flow.
+//
 // Summarizes pruned messages via LLM instead of discarding them
 
 import { log } from "./logger.js";

--- a/src/core/distillation.ts
+++ b/src/core/distillation.ts
@@ -1,6 +1,13 @@
 // KCode - Knowledge Distillation (RAG-based)
-// Captures successful interaction patterns and replays them as few-shot context.
-// No fine-tuning required — the model "learns" from better examples in its prompt.
+//
+// STATUS: Auxiliary (see docs/architecture/modules.md).
+// Specialized agentic-dev workflow. Not required by the audit
+// engine. Safe to remove — distilled examples just won't be
+// injected into the system prompt.
+//
+// Captures successful interaction patterns and replays them as
+// few-shot context. No fine-tuning required — the model "learns"
+// from better examples in its prompt.
 
 import { getDb } from "./db";
 import { log } from "./logger";

--- a/src/core/rag/engine.ts
+++ b/src/core/rag/engine.ts
@@ -1,6 +1,12 @@
 // KCode - Local RAG Engine
-// Orchestrates embedding, chunking, vector storage, and semantic search.
-// Runs entirely locally — no external APIs required (TF-IDF fallback).
+//
+// STATUS: Auxiliary (see docs/architecture/modules.md).
+// Useful for agentic dev workflows; NOT required by the audit
+// engine. Safe to disable / remove without breaking core audit.
+//
+// Orchestrates embedding, chunking, vector storage, and semantic
+// search. Runs entirely locally — no external APIs required
+// (TF-IDF fallback).
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";

--- a/src/core/voice.ts
+++ b/src/core/voice.ts
@@ -1,4 +1,9 @@
 // KCode - Voice Input (STT)
+//
+// STATUS: Auxiliary (see docs/architecture/modules.md).
+// Skeletal — speech-to-text workflow for accessibility / hands-
+// free use. Not required by the audit engine. Safe to disable.
+//
 // Provides speech-to-text input for KCode using:
 // 1. Kulvex voice pipeline (localhost:9100) if available
 // 2. Local faster-whisper / whisper.cpp if installed

--- a/src/core/world-model.ts
+++ b/src/core/world-model.ts
@@ -1,6 +1,13 @@
 // KCode - Layer 6: World Model
-// Heuristic prediction engine — predicts outcomes before actions and compares after
-// Discrepancies become learnings that improve future predictions
+//
+// STATUS: Auxiliary (see docs/architecture/modules.md).
+// Experimental predictive layer — not on the audit critical
+// path. Failures are silently try/catch'd elsewhere. Can be
+// removed without breaking core.
+//
+// Heuristic prediction engine — predicts outcomes before actions
+// and compares after. Discrepancies become learnings that improve
+// future predictions.
 
 import { getDb } from "./db";
 import { log } from "./logger";


### PR DESCRIPTION
Honest core-vs-auxiliary split for the codebase. docs/architecture/modules.md + STATUS headers on 5 auxiliary modules (RAG, voice, compaction, distillation, world-model). CLAUDE.md references the doc. No code changes — just labeling.