### PR TITLE
feat(fixtures): pattern coverage 28 → 38, 11 langs, + py-004 fix + v2.10.126

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.125",
+  "version": "2.10.126",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/audit-engine/patterns.ts
+++ b/src/core/audit-engine/patterns.ts
@@ -328,7 +328,14 @@ export const PYTHON_PATTERNS: BugPattern[] = [
     title: "SQL query with string formatting (injection risk)",
     severity: "high",
     languages: ["python"],
-    regex: /\b(?:execute|executemany|raw)\s*\(\s*(?:f["']|["'].*%|["'].*\.format\()/g,
+    // `%\s` (not bare `%`) so `"... %s"` / `"... %d"` / `"... %i"`
+    // parameterized-query placeholders don't accidentally match as
+    // if they were `%`-format operators. The Python `%`-format
+    // operator is always written with a space (`"x" % var`) or
+    // with a paren (`"x" %(dict)s`); never adjacent to the format
+    // specifier letter. Found by the Phase 3 fixture harness
+    // (tests/patterns/py-004-sql-injection/negative-pct-placeholder.py).
+    regex: /\b(?:execute|executemany|raw)\s*\(\s*(?:f["']|["'].*%[\s(]|["'].*\.format\()/g,
     explanation:
       "SQL queries built with f-strings, % formatting, or .format() are vulnerable to SQL injection. Use parameterized queries instead.",
     verify_prompt:

--- a/src/core/audit-engine/scanner.ts
+++ b/src/core/audit-engine/scanner.ts
@@ -514,20 +514,28 @@ export function isInsideComment(
  * Apply a single pattern to a file, producing a list of candidate findings.
  */
 /**
- * Test-friendly wrapper: run a single pattern against in-memory content
- * as if it lived at `path`. Identical semantics to the per-file loop in
- * scanProject(), but exposed so the pattern-fixtures harness in
- * tests/patterns/ can assert "this fixture must / must not match".
+ * Test-friendly wrapper: run a single pattern against in-memory
+ * content as if it lived at `path`. The `bypassPathFilters` flag
+ * lets the pattern-fixtures harness in tests/patterns/ assert the
+ * regex invariant directly, without applyPattern's
+ * test-file / config-file / low-severity suppressions (those are
+ * valid in production — and would hide fixture breakage in tests).
  */
 export function scanPatternAgainstContent(
   pattern: BugPattern,
   path: string,
   content: string,
+  opts: { bypassPathFilters?: boolean } = {},
 ): Candidate[] {
-  return applyPattern(pattern, path, content);
+  return applyPattern(pattern, path, content, opts.bypassPathFilters ?? false);
 }
 
-function applyPattern(pattern: BugPattern, path: string, content: string): Candidate[] {
+function applyPattern(
+  pattern: BugPattern,
+  path: string,
+  content: string,
+  bypassPathFilters = false,
+): Candidate[] {
   const lang = getLanguageForFile(path);
   if (!lang || !pattern.languages.includes(lang)) return [];
 
@@ -562,14 +570,20 @@ function applyPattern(pattern: BugPattern, path: string, content: string): Candi
       .slice(startCtx, endCtx)
       .map((l, i) => `${startCtx + i + 1}: ${l}`)
       .join("\n");
-    // Pre-filter: skip obvious false positives in web framework code
-    const isTestFile = path.includes("test") || path.includes("spec") || path.includes("__tests__");
-    const isConfig = path.includes("config") || path.includes(".config.");
-    const isGenerated = path.includes(".next/") || path.includes("dist/") || path.includes("build/");
-    // Skip low-severity findings in test/config/generated files
-    if ((isTestFile || isConfig || isGenerated) && pattern.severity === "low") continue;
-    // Skip hardcoded-secret patterns if the value looks like a placeholder
-    if (pattern.id.includes("hardcoded") && /changeme|placeholder|example|xxx|YOUR_|TODO/i.test(matched_text)) continue;
+    // Pre-filter: skip obvious false positives in web framework code.
+    // bypassPathFilters=true is set only by the pattern-fixtures
+    // harness — fixtures intentionally live under tests/ and fire
+    // low-severity patterns, so the test-file suppression would
+    // hide regressions we want to catch.
+    if (!bypassPathFilters) {
+      const isTestFile = path.includes("test") || path.includes("spec") || path.includes("__tests__");
+      const isConfig = path.includes("config") || path.includes(".config.");
+      const isGenerated = path.includes(".next/") || path.includes("dist/") || path.includes("build/");
+      // Skip low-severity findings in test/config/generated files
+      if ((isTestFile || isConfig || isGenerated) && pattern.severity === "low") continue;
+      // Skip hardcoded-secret patterns if the value looks like a placeholder
+      if (pattern.id.includes("hardcoded") && /changeme|placeholder|example|xxx|YOUR_|TODO/i.test(matched_text)) continue;
+    }
 
     // Skip matches inside JSX className attributes (Tailwind utility strings
     // like "bg-red-500 p-4 text-white" trigger several patterns as false

--- a/tests/pattern-fixtures.test.ts
+++ b/tests/pattern-fixtures.test.ts
@@ -85,6 +85,7 @@ describe("pattern fixture harness — regex-stage invariants", () => {
           pattern,
           join(FIXTURES_ROOT, patternId, fixture),
           content,
+          { bypassPathFilters: true },
         );
         if (candidates.length === 0) {
           throw new Error(
@@ -110,6 +111,7 @@ describe("pattern fixture harness — regex-stage invariants", () => {
           pattern,
           join(FIXTURES_ROOT, patternId, fixture),
           content,
+          { bypassPathFilters: true },
         );
         if (candidates.length > 0) {
           const snippets = candidates

--- a/tests/patterns/cpp-011-signed-unsigned-cmp/negative.cpp
+++ b/tests/patterns/cpp-011-signed-unsigned-cmp/negative.cpp
@@ -1,0 +1,12 @@
+// Negative fixture for cpp-011-signed-unsigned-cmp.
+// Using size_t (or the container's size_type) as the loop index
+// avoids the signed/unsigned compare.
+#include <vector>
+
+int sum_all(const std::vector<int> &data) {
+    int total = 0;
+    for (std::size_t i = 0; i < data.size(); ++i) {
+        total += data[i];
+    }
+    return total;
+}

--- a/tests/patterns/cpp-011-signed-unsigned-cmp/positive.cpp
+++ b/tests/patterns/cpp-011-signed-unsigned-cmp/positive.cpp
@@ -1,0 +1,14 @@
+// Positive fixture for cpp-011-signed-unsigned-cmp.
+// Comparing a signed int loop counter with container.size()
+// (which is size_t / unsigned) compiles with a sign-compare
+// warning at best and overflows silently at worst.
+#include <vector>
+
+int sum_all(const std::vector<int> &data) {
+    int total = 0;
+    // CONFIRMED: int i vs data.size() (unsigned).
+    for (int i = 0; i < data.size(); ++i) {
+        total += data[i];
+    }
+    return total;
+}

--- a/tests/patterns/cs-001-sql-injection/negative.cs
+++ b/tests/patterns/cs-001-sql-injection/negative.cs
@@ -1,0 +1,11 @@
+// Negative fixture for cs-001-sql-injection.
+// Parameterized query with SqlCommand.Parameters is safe.
+using System.Data.SqlClient;
+
+public class UserDao {
+    public SqlDataReader FindByUsername(SqlConnection conn, string username) {
+        var cmd = new SqlCommand("SELECT * FROM users WHERE name = @name", conn);
+        cmd.Parameters.AddWithValue("@name", username);
+        return cmd.ExecuteReader();
+    }
+}

--- a/tests/patterns/cs-001-sql-injection/positive.cs
+++ b/tests/patterns/cs-001-sql-injection/positive.cs
@@ -1,0 +1,12 @@
+// Positive fixture for cs-001-sql-injection.
+// SqlCommand / ExecuteReader with $"..." interpolation or + concat
+// inside the SQL string is injection.
+using System.Data.SqlClient;
+
+public class UserDao {
+    public SqlDataReader FindByUsername(SqlConnection conn, string username) {
+        // CONFIRMED: username interpolated into SQL via $"" string.
+        var cmd = new SqlCommand($"SELECT * FROM users WHERE name = '{username}'", conn);
+        return cmd.ExecuteReader();
+    }
+}

--- a/tests/patterns/js-006-hardcoded-secret/negative.js
+++ b/tests/patterns/js-006-hardcoded-secret/negative.js
@@ -1,0 +1,9 @@
+// Negative fixture for js-006-hardcoded-secret.
+// Secrets fetched from env / vault at runtime don't match a
+// literal-string-assignment pattern.
+
+const API_KEY = process.env.API_KEY;
+const PRIVATE_KEY = await vault.read("private-key");
+const PASSWORD = null; // set by login flow, not hard-coded
+
+module.exports = { API_KEY, PRIVATE_KEY, PASSWORD };

--- a/tests/patterns/js-006-hardcoded-secret/positive.js
+++ b/tests/patterns/js-006-hardcoded-secret/positive.js
@@ -1,0 +1,7 @@
+// Positive fixture for js-006-hardcoded-secret.
+// Uppercase-named credentials assigned string literals are the
+// classic "committed to git by accident" pattern.
+
+const API_KEY = "sk-live-abcdef0123456789abcdefghij";
+const PRIVATE_KEY = "MIIEowIBAAKCAQEAx7JQ8xYlmqU9ZrLxM8yF7KZ";
+const PASSWORD = "prod_admin_pw_2026_v1_secure";

--- a/tests/patterns/kt-001-force-unwrap/negative.kt
+++ b/tests/patterns/kt-001-force-unwrap/negative.kt
@@ -1,0 +1,7 @@
+// Negative fixture for kt-001-force-unwrap.
+// Safe call `?.` with `?: default` returns a fallback instead of
+// crashing.
+
+fun userNameLength(map: Map<String, String>): Int {
+    return map["name"]?.length ?: 0
+}

--- a/tests/patterns/kt-001-force-unwrap/positive.kt
+++ b/tests/patterns/kt-001-force-unwrap/positive.kt
@@ -1,0 +1,7 @@
+// Positive fixture for kt-001-force-unwrap.
+// `x!!.method()` crashes with NullPointerException if x is null.
+
+fun userNameLength(map: Map<String, String>): Int {
+    // CONFIRMED: map["name"] could be null; !! throws NPE.
+    return map["name"]!!.length
+}

--- a/tests/patterns/php-001-sql-injection/negative.php
+++ b/tests/patterns/php-001-sql-injection/negative.php
@@ -1,0 +1,11 @@
+<?php
+// Negative fixture for php-001-sql-injection.
+// Prepared statements with placeholders bind values separately
+// from the SQL — no interpolation.
+
+function getUser($conn, $username) {
+    $stmt = $conn->prepare("SELECT * FROM users WHERE name = ?");
+    $stmt->bind_param("s", $username);
+    $stmt->execute();
+    return $stmt->get_result();
+}

--- a/tests/patterns/php-001-sql-injection/positive.php
+++ b/tests/patterns/php-001-sql-injection/positive.php
@@ -1,0 +1,16 @@
+<?php
+// Positive fixture for php-001-sql-injection.
+// mysql_query() takes the SQL string as its first argument — any
+// variable interpolation inside that string is injection. The
+// regex specifically catches "mysql_query(" / "mysqli_query(" /
+// "->query(" followed by a quoted string containing "$".
+
+function getUserLegacy($username) {
+    // CONFIRMED: $username interpolated into SQL via mysql_query.
+    return mysql_query("SELECT * FROM users WHERE name = '$username'");
+}
+
+function getUserOO($conn, $username) {
+    // CONFIRMED: ->query with interpolated $username.
+    return $conn->query("SELECT * FROM users WHERE name = '$username'");
+}

--- a/tests/patterns/py-004-sql-injection/negative-pct-placeholder.py
+++ b/tests/patterns/py-004-sql-injection/negative-pct-placeholder.py
@@ -1,0 +1,21 @@
+"""Negative fixture for py-004-sql-injection — %s placeholder regression.
+
+Before the Phase 3 fix, the regex branch `["'].*%` matched `%s`
+placeholder strings because any `%` after a quote triggered it.
+The fix requires `%[\s(]` — Python %-format operator is always
+`%` + whitespace (e.g. `"x" % var`) or `%(` for named dicts.
+SQL placeholders `%s` / `%d` / `%i` are `%` + letter and no
+longer match.
+"""
+
+def get_user(cursor, username: str):
+    # Parameterized query using %s placeholder (psycopg2 / MySQLdb).
+    cursor.execute("SELECT * FROM users WHERE name = %s", (username,))
+    return cursor.fetchone()
+
+def multi_insert(cursor, rows):
+    # %s with multiple placeholders, still parameterized.
+    cursor.executemany(
+        "INSERT INTO logs (level, message, created) VALUES (%s, %s, %s)",
+        rows,
+    )

--- a/tests/patterns/py-016-tempfile-mktemp/negative.py
+++ b/tests/patterns/py-016-tempfile-mktemp/negative.py
@@ -1,0 +1,10 @@
+"""Negative fixture for py-016-tempfile-mktemp.
+
+tempfile.mkstemp() returns a fd+path atomically — no race.
+The regex targets mktemp specifically.
+"""
+import tempfile, os
+
+def make_temp_file() -> int:
+    fd, _path = tempfile.mkstemp(suffix=".tmp")
+    return fd

--- a/tests/patterns/py-016-tempfile-mktemp/positive.py
+++ b/tests/patterns/py-016-tempfile-mktemp/positive.py
@@ -1,0 +1,11 @@
+"""Positive fixture for py-016-tempfile-mktemp.
+
+tempfile.mktemp() has a TOCTOU race — the path is returned but
+not created, so an attacker can create a symlink before open().
+Use tempfile.mkstemp() which returns an open fd atomically.
+"""
+import tempfile
+
+def make_temp_path() -> str:
+    # CONFIRMED: race-prone, returns just a name.
+    return tempfile.mktemp(suffix=".tmp")

--- a/tests/patterns/py-017-hardcoded-secret-assign/negative.py
+++ b/tests/patterns/py-017-hardcoded-secret-assign/negative.py
@@ -1,0 +1,12 @@
+"""Negative fixture for py-017-hardcoded-secret-assign.
+
+Credentials read from environment or a secrets manager at
+runtime don't match the literal-assignment pattern.
+"""
+import os
+
+def get_aws_secret() -> str:
+    return os.environ["AWS_SECRET_ACCESS_KEY"]
+
+def get_db_password() -> str:
+    return os.environ.get("DATABASE_PASSWORD", "")

--- a/tests/patterns/py-017-hardcoded-secret-assign/positive.py
+++ b/tests/patterns/py-017-hardcoded-secret-assign/positive.py
@@ -1,0 +1,14 @@
+"""Positive fixture for py-017-hardcoded-secret-assign.
+
+Long-lived credentials as source-code string literals leak
+eventually (git history, docker images, pastebins, backups).
+"""
+
+# CONFIRMED: 32-char AWS-style secret key committed to source.
+aws_secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+# CONFIRMED: RSA private key excerpt committed to source.
+private_key = "MIIEowIBAAKCAQEAx7JQ8xYlmqU9ZrLxM8yF7KZ"
+
+# CONFIRMED: database password in plaintext.
+database_password = "prod_admin_pw_2026_01_01"

--- a/tests/patterns/rb-001-eval/negative.rb
+++ b/tests/patterns/rb-001-eval/negative.rb
@@ -1,0 +1,10 @@
+# Negative fixture for rb-001-eval.
+# eval / send with a hardcoded allow-list or a constant expression
+# has no injection surface.
+
+ALLOWED = %w[add remove list].freeze
+
+def dispatch(obj, action)
+  return unless ALLOWED.include?(action)
+  obj.public_send(action.to_sym)
+end

--- a/tests/patterns/rb-001-eval/positive.rb
+++ b/tests/patterns/rb-001-eval/positive.rb
@@ -1,0 +1,14 @@
+# Positive fixture for rb-001-eval.
+# eval / send / instance_eval with params/request/input is RCE.
+# The regex specifically matches when the first arg is one of
+# those untrusted-source identifiers.
+
+def run_formula(params)
+  # CONFIRMED: params[:formula] is attacker-controlled.
+  eval(params[:formula])
+end
+
+def dispatch(request, obj)
+  # CONFIRMED: method name from request is RCE via send.
+  obj.send(request[:method])
+end

--- a/tests/patterns/rs-001-unsafe-block/negative.rs
+++ b/tests/patterns/rs-001-unsafe-block/negative.rs
@@ -1,0 +1,7 @@
+// Negative fixture for rs-001-unsafe-block.
+// Safe Rust with no `unsafe` keyword. The regex requires
+// `unsafe {` specifically — function signatures don't trigger.
+
+fn read_slice(buf: &[u8], idx: usize) -> Option<u8> {
+    buf.get(idx).copied()
+}

--- a/tests/patterns/rs-001-unsafe-block/positive.rs
+++ b/tests/patterns/rs-001-unsafe-block/positive.rs
@@ -1,0 +1,10 @@
+// Positive fixture for rs-001-unsafe-block.
+// `unsafe { ... }` blocks bypass Rust's safety guarantees and
+// every use needs manual review.
+
+fn read_raw(ptr: *const u8, len: usize) -> u8 {
+    // CONFIRMED: dereferencing raw pointer requires unsafe.
+    unsafe {
+        *ptr.add(len - 1)
+    }
+}

--- a/tests/patterns/swift-001-force-unwrap/negative.swift
+++ b/tests/patterns/swift-001-force-unwrap/negative.swift
@@ -1,0 +1,6 @@
+// Negative fixture for swift-001-force-unwrap.
+// Optional chaining `?.` returns nil instead of crashing.
+
+func userNameLength(from map: [String: String]) -> Int {
+    return map["name"]?.count ?? 0
+}

--- a/tests/patterns/swift-001-force-unwrap/positive.swift
+++ b/tests/patterns/swift-001-force-unwrap/positive.swift
@@ -1,0 +1,8 @@
+// Positive fixture for swift-001-force-unwrap.
+// `identifier!.method()` force-unwraps Optional then calls a
+// method. If the identifier holds nil, this crashes at runtime.
+
+func countFromUser(user: String?) -> Int {
+    // CONFIRMED: user is Optional; ! crashes if nil.
+    return user!.count
+}


### PR DESCRIPTION
38/257 patterns with fixtures covering 11 languages. First coverage for Rust, Swift, PHP, Ruby, Kotlin, C#. Also fixes py-004 percent-placeholder FP documented in the previous batch. Adds bypassPathFilters option so the harness can assert fixture invariants without production test-file suppressions.