### PR TITLE
docs: mark license public key explicitly as non-secret + v2.10.128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ where regressions hide.
 
 (Nothing pending.)
 
+## [2.10.128] — 2026-04-17
+
+### Security / docs
+- GitGuardian-false-positive prevention on the embedded license
+  public key (`src/core/license.ts:52`). The PEM block is RSA
+  **PUBLIC** key material — used to VERIFY signed JWTs offline —
+  and is intentionally committed so every install can verify
+  licenses without a network call. Replaced the brief comment
+  with a prominent `!!! PUBLIC KEY — NOT A SECRET !!!` docblock
+  explicitly telling scanners / reviewers this is asymmetric-
+  crypto verification material, not a credential. [#98]
+- Audit confirmed no PRIVATE key or JWT token is embedded
+  anywhere in the repo. `license-signer.ts` reads the private
+  key from an external path (`$KCODE_LICENSE_PRIVATE_KEY` env
+  or `~/.kcode/license-signing.pem`), never embeds it.
+
 ## [2.10.127] — 2026-04-17
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.127",
+  "version": "2.10.128",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",

--- a/src/core/license.ts
+++ b/src/core/license.ts
@@ -45,9 +45,22 @@ export interface LicenseValidationResult {
 }
 
 // ─── Embedded Public Key ────────────────────────────────────────
-// This is the Kulvex license-signing public key (RS256).
-// The corresponding private key is held by the Kulvex licensing server.
-// Customers receive signed JWTs; KCode verifies them locally with this key.
+//
+// !!! PUBLIC KEY — NOT A SECRET !!!
+//
+// This is RSA PUBLIC KEY material used to VERIFY JWTs signed by
+// the Kulvex licensing server. It is intentionally embedded in
+// source so every KCode install can verify licenses offline.
+//
+// The corresponding PRIVATE key lives on the licensing server
+// and never touches this repo. Anyone can read this public key;
+// that's the whole point of asymmetric crypto.
+//
+// If a secret-scanner (GitGuardian, gitleaks, TruffleHog, etc.)
+// flags this block, it's a false positive — the scanner is
+// reading "BEGIN … KEY" without distinguishing PUBLIC from
+// PRIVATE. Mark as "false positive — public key" in your
+// scanner's UI and move on.
 
 const KULVEX_LICENSE_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Z1qR3kJxRKMsz8LWaF1


### PR DESCRIPTION
GitGuardian alerted on the embedded Kulvex license-signing PUBLIC key. It's asymmetric-crypto verification material, not a credential. Added prominent docblock labeling it as non-secret. User should dismiss the GG alert as FP.