### PR TITLE
feat(licensing): dual-license framework (AGPL + commercial) + DCO + v2.10.129

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,38 @@ where regressions hide.
 
 (Nothing pending.)
 
+## [2.10.129] — 2026-04-17
+
+### Added (licensing framework — dual license)
+- `LICENSE-COMMERCIAL.md` — framework for the commercial
+  license path. Explains when you need it vs. when AGPL-3.0
+  covers you, the scope of what's included (indemnification,
+  support SLA, air-gapped deployment, custom patterns), and
+  the inquiry process at `contact@astrolexis.space`. Not a
+  legally binding contract — that's negotiated per customer
+  — but the public framing enterprise evaluators expect. [#99]
+- `CLA.md` — Developer Certificate of Origin (DCO) v1.1 for
+  contributions. Every commit needs `-s`/`--signoff` so the
+  dual-license structure stays enforceable as new code
+  lands. Same mechanism the Linux kernel, Docker, GitLab use. [#99]
+- README: new "License — dual licensed" section replacing the
+  flat "AGPL-3.0-only" one-liner. Clear guidance on which
+  license applies per use case. [#99]
+- CONTRIBUTING: new "Dual license + DCO sign-off" section
+  ahead of the existing versioning contract. [#99]
+
+### Notes
+- `LICENSE` (AGPL-3.0 text) is **unchanged**. Community users
+  see no change — they still use the same free, open-source
+  license they always did.
+- No code changes in this PR — documentation + legal framework
+  only. Binary installs of v2.10.129 behave identically to
+  v2.10.128.
+- Commercial license terms above are the INTENDED scope,
+  subject to legal review before going live. Astrolexis should
+  have a lawyer review LICENSE-COMMERCIAL.md + CLA.md before
+  using them in a signed contract.
+
 ## [2.10.128] — 2026-04-17
 
 ### Security / docs

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,123 @@
+# Contributor License Agreement — KCode
+
+KCode is dual-licensed (see `LICENSE` for AGPL-3.0 and
+`LICENSE-COMMERCIAL.md` for the commercial terms). To keep
+the dual-license structure enforceable, every contribution to
+this repository must be accompanied by a **Developer Certificate
+of Origin (DCO) sign-off**.
+
+## The DCO
+
+The DCO is a lightweight, one-line-per-commit certification
+that you have the right to submit your contribution under the
+project's license terms. It is the same mechanism used by the
+Linux kernel, Docker, GitLab, and many other open-source
+projects.
+
+You sign off a commit by adding a `Signed-off-by:` line at
+the bottom of the commit message:
+
+```
+feat(audit): new pattern for X
+
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Git does this automatically when you pass `--signoff` (or
+`-s`):
+
+```bash
+git commit -s -m "feat(audit): new pattern for X"
+```
+
+By signing off, you certify the following (the full DCO text
+appears below):
+
+## Developer Certificate of Origin 1.1
+
+> By making a contribution to this project, I certify that:
+>
+> (a) The contribution was created in whole or in part by me
+> and I have the right to submit it under the open source
+> license indicated in the file; or
+>
+> (b) The contribution is based upon previous work that, to
+> the best of my knowledge, is covered under an appropriate
+> open source license and I have the right under that license
+> to submit that work with modifications, whether created in
+> whole or in part by me, under the same open source license
+> (unless I am permitted to submit under a different license),
+> as indicated in the file; or
+>
+> (c) The contribution was provided directly to me by some
+> other person who certified (a), (b) or (c) and I have not
+> modified it.
+>
+> (d) I understand and agree that this project and the
+> contribution are public and that a record of the
+> contribution (including all personal information I submit
+> with it, including my sign-off) is maintained indefinitely
+> and may be redistributed consistent with this project or
+> the open source license(s) involved.
+
+— https://developercertificate.org
+
+## What the sign-off grants
+
+When you sign off a commit, you are confirming that:
+
+1. You wrote the code yourself, OR have permission to submit
+   code written by others (under a compatible license).
+2. The contribution may be distributed under **both** the
+   AGPL-3.0 (this repository's public license) and the
+   commercial license terms (see `LICENSE-COMMERCIAL.md`).
+
+That second point matters. Without dual-license rights
+attached to contributions, Astrolexis cannot relicense the
+codebase for commercial customers who need non-AGPL terms.
+The DCO is how contributors grant those rights in a clean,
+widely-understood form.
+
+## Why this matters for the project
+
+KCode is open source, but the pattern catalog, SARIF
+exporter, and audit pipeline also power commercial offerings
+(see `LICENSE-COMMERCIAL.md`). If an AGPL-only contribution
+landed in the codebase without any path to the commercial
+license, Astrolexis would face a choice:
+
+- Remove the contribution to preserve commercial viability.
+- Accept AGPL-only scope for that part, fragmenting the
+  codebase into "commercial OK" and "AGPL only" regions.
+- Pay the contributor for an individual relicense grant,
+  which doesn't scale.
+
+Requiring DCO sign-off at contribution time avoids all three.
+
+## Enforcement
+
+- PR authors whose commits are **not** signed off will be
+  asked to amend their commits with `git commit --amend -s`
+  (or `git rebase -i HEAD~N` with `--signoff`) before the PR
+  can be merged.
+- Automated CI may reject unsigned commits in the future.
+  Currently it's a reviewer check.
+- Existing commits (pre-DCO adoption) are grandfathered;
+  the project treats them as contributed under AGPL-3.0
+  alone. Future relicensing work can address those on a
+  case-by-case basis.
+
+## Questions
+
+Open a GitHub issue with the `licensing` label, or email
+`contact@astrolexis.space`.
+
+## This document is the framework
+
+As with `LICENSE-COMMERCIAL.md`, this document is the
+**framework** under which contributions are accepted. The
+actual legal text that matters is the DCO itself (quoted
+above in full, linked to its canonical source) and your
+`Signed-off-by:` line in every commit.
+
+© 2026 Astrolexis.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,23 @@ bun run dev
 bun run src/index.ts
 ```
 
+## Dual license + DCO sign-off
+
+KCode is dual-licensed (AGPL-3.0 + commercial — see
+[README](./README.md#license--dual-licensed)).
+
+**Every commit must be signed off** under the Developer
+Certificate of Origin so contributions can land under both
+licenses. Sign-off is automatic when you pass `-s` to
+`git commit`:
+
+```bash
+git commit -s -m "your commit message"
+```
+
+Unsigned commits will be asked to amend before merge. Full
+DCO text and rationale in [CLA.md](./CLA.md).
+
 ## Versioning + Changelog contract
 
 KCode follows [Semantic Versioning 2.0.0](https://semver.org/):

--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -1,0 +1,115 @@
+# KCode — Commercial License
+
+**KCode is available under a dual license:**
+
+1. **AGPL-3.0-only** — the license in `LICENSE`. Free to use,
+   modify, and redistribute under the terms of the GNU Affero
+   General Public License version 3.
+
+2. **Commercial License** (this document) — for organizations
+   that cannot comply with AGPL obligations (for example,
+   embedding KCode into a proprietary SaaS offering without
+   publishing the modified source, or distributing KCode as
+   part of a closed-source product).
+
+## When you need the commercial license
+
+You need a commercial license if you want to do any of the
+following **without** complying with AGPL-3.0:
+
+- Run KCode as a service accessed over a network (the AGPL's
+  §13 "network use is distribution" clause triggers) where
+  your modifications stay proprietary.
+- Embed KCode's audit engine into a proprietary product
+  distributed to end users.
+- Incorporate KCode source into a codebase whose license
+  terms are incompatible with AGPL-3.0 (most commercial
+  licenses are).
+- Receive an indemnification guarantee, support SLA, or
+  contractual response times that the AGPL-3.0 disclaims.
+
+You do **NOT** need a commercial license if:
+
+- You use KCode as a CLI tool internally in your company, even
+  at scale, as long as you don't extend it in a way AGPL's
+  network clauses would affect. Running `kcode audit` on your
+  own CI pipeline is perfectly fine under AGPL.
+- You contribute patches back under AGPL.
+- You fork the project, modify it, and release your fork also
+  under AGPL.
+- You use the `AstrolexisAI/KCode` GitHub Action in your own
+  workflows — GitHub Actions consume the AGPL tool without
+  distributing derivative works.
+
+## What the commercial license includes
+
+(These are the **intended** terms — the actual contract is
+negotiated per customer. This section is for transparency about
+the scope, not a legally binding offer.)
+
+- **Unrestricted embedding**: use KCode's audit engine, SARIF
+  exporter, pattern catalog, and SDK inside proprietary
+  products, SaaS, or internal tools without AGPL obligations.
+- **Indemnification** against IP claims related to KCode's
+  use within your product.
+- **Priority support** with response-time SLA appropriate to
+  your tier (standard / premium / enterprise).
+- **Custom pattern development**: security researchers at
+  Astrolexis will curate additional patterns for languages or
+  frameworks specific to your codebase, added to the catalog
+  under your exclusive use for a defined period, or merged to
+  the public catalog if you prefer.
+- **Roadmap input**: commercial customers can propose and
+  prioritize features via a dedicated channel.
+- **Air-gapped deployment** support — running KCode and its
+  dedicated LLM entirely on-prem without network dependencies.
+
+## What the commercial license does NOT include
+
+- Waiver of the "**no warranty**" clause from the AGPL. KCode
+  is provided AS IS under both licenses; commercial support
+  is a separate SLA, not a warranty on correctness of findings.
+- Automatic license grant for derivative works distributed to
+  YOUR customers unless specifically negotiated (the commercial
+  license is typically per-organization; sublicensing requires
+  a separate tier).
+
+## How to obtain the commercial license
+
+Contact Astrolexis with a brief description of your use case:
+
+- **Email**: `contact@astrolexis.space`
+- **Subject line**: `KCode Commercial License — <your company>`
+
+Include:
+
+1. What you want to do that AGPL prevents.
+2. Rough scale (number of repos / developers / scans per month).
+3. Deployment environment (cloud / on-prem / air-gapped).
+4. Existing tooling this would replace or complement.
+
+We'll respond with a proposal including pricing tier and terms
+within 5 business days. A draft contract follows once you accept
+the proposal.
+
+## Note for contributors
+
+If you want to contribute to KCode, please read `CLA.md` — every
+contribution must be signed off under the Developer Certificate
+of Origin so the dual-license structure remains enforceable.
+Contributions made without sign-off can only be incorporated
+under AGPL-3.0, which limits their utility in the commercial
+license path.
+
+## Disclaimer
+
+This document is the **framework** under which the commercial
+license operates. It is not itself a legal contract. A specific
+commercial license agreement is drafted and executed between
+Astrolexis and the licensee once terms are negotiated.
+
+The terms above represent Astrolexis's standard offering as of
+the repository's current date. They may evolve; the binding
+document is whatever is signed between the parties.
+
+© 2026 Astrolexis. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -436,8 +436,32 @@ Features: sidebar chat panel, context menu (Explain/Fix/Test selection), `Ctrl+S
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines. Report security issues to contact@astrolexis.space (see [SECURITY.md](./SECURITY.md)).
 
-## License
+## License — dual licensed
 
-**AGPL-3.0-only** -- Copyright (c) 2026 Astrolexis. See [LICENSE](./LICENSE) for details.
+KCode is available under **two licenses**. Pick the one that
+fits how you use it:
 
-Core functionality is fully open source. Some features require [KCode Pro](https://kulvex.ai/pro) ($19/mo).
+### Open source: AGPL-3.0-only
+
+Run KCode as a CLI, in CI pipelines, in GitHub Actions, in
+your own fork — free of charge, no strings attached, under
+the terms of the GNU Affero General Public License v3.
+See [LICENSE](./LICENSE).
+
+Most users are covered by this.
+
+### Commercial: for proprietary SaaS / embedding / indemnification
+
+If your use case triggers AGPL's network-use clause (§13) or
+if you need to embed KCode into a proprietary product, you
+need a commercial license. Contact `contact@astrolexis.space`.
+See [LICENSE-COMMERCIAL.md](./LICENSE-COMMERCIAL.md) for the
+framework, scope, and inquiry process.
+
+Copyright © 2026 Astrolexis.
+
+### Contributing
+
+Every commit needs a DCO sign-off (`git commit -s -m "..."`)
+so the dual-license structure stays clean. Details in
+[CLA.md](./CLA.md).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kcode",
-  "version": "2.10.128",
+  "version": "2.10.129",
   "description": "AI-powered coding assistant for the terminal - by Astrolexis",
   "author": "Astrolexis",
   "module": "src/index.ts",


### PR DESCRIPTION
Enterprise-sales unblock. AGPL-3.0 stays for community; adds commercial license path for proprietary embedding + indemnification. Ships LICENSE-COMMERCIAL.md (framework), CLA.md (DCO v1.1), README dual-license section, CONTRIBUTING sign-off requirement. NOT legal advice — framework needs lawyer review before used in signed contracts. GitLab CE/EE / MongoDB / Sentry pattern — well-trodden territory.